### PR TITLE
NETOBSERV-82: Enforcing crd validation to only have one instance per cluster

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -16,6 +16,14 @@ patchesStrategicMerge:
 #- patches/cainjection_in_flowcollectors.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
+
+patches:
+- target:
+    kind: CustomResourceDefinition
+    name: flowcollectors.flows.netobserv.io
+  path: patches/singleton_in_flowcollectors.yaml
+
+
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml

--- a/config/crd/patches/singleton_in_flowcollectors.yaml
+++ b/config/crd/patches/singleton_in_flowcollectors.yaml
@@ -1,0 +1,6 @@
+# The following patch make a CRD be a "singleton".
+# Only one CR can be created because validation restricts the value of
+# name and namespace.
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata/properties
+  value: {"name" : {"type": "string", "pattern": "^cluster$"}}

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -1,7 +1,7 @@
 apiVersion: flows.netobserv.io/v1alpha1
 kind: FlowCollector
 metadata:
-  name: flowcollector-sample
+  name: cluster
 spec:
   ipfix:
     cacheActiveTimeout: 60s


### PR DESCRIPTION
Using the validation scheme to only accept default as the CRD name, only one instance of the CRD can be created per cluster.

Jira link : https://issues.redhat.com/browse/NETOBSERV-82