### PR TITLE
NETOBSERV-80: Increased testing of goflowkube reconciler (& bugfix)

### DIFF
--- a/controllers/goflowkube/goflowkube_objects.go
+++ b/controllers/goflowkube/goflowkube_objects.go
@@ -164,7 +164,7 @@ func buildService(desired *flowsv1alpha1.FlowCollectorGoflowKube, ns string) *co
 			Selector: buildLabels(),
 			Ports: []corev1.ServicePort{{
 				Port:     desired.Port,
-				Protocol: "UDP",
+				Protocol: corev1.ProtocolUDP,
 			}},
 		},
 	}

--- a/controllers/goflowkube/goflowkube_reconciler.go
+++ b/controllers/goflowkube/goflowkube_reconciler.go
@@ -177,7 +177,7 @@ func deploymentNeedsUpdate(depl *appsv1.Deployment, desired *flowsv1alpha1.FlowC
 
 func serviceNeedsUpdate(svc *corev1.Service, desired *flowsv1alpha1.FlowCollectorGoflowKube) bool {
 	for _, port := range svc.Spec.Ports {
-		if port.Port == desired.Port && port.Protocol == "UDP" {
+		if port.Port == desired.Port && port.Protocol == corev1.ProtocolUDP {
 			return false
 		}
 	}
@@ -202,9 +202,12 @@ func containerNeedsUpdate(podSpec *corev1.PodSpec, desired *flowsv1alpha1.FlowCo
 }
 
 func autoScalerNeedsUpdate(asc *ascv1.HorizontalPodAutoscaler, desired *flowsv1alpha1.FlowCollectorGoflowKube) bool {
+	differentPointerValues := func(a, b *int32) bool {
+		return (a == nil && b != nil) || (a != nil && b == nil) || (a != nil && *a != *b)
+	}
 	if asc.Spec.MaxReplicas != desired.HPA.MaxReplicas ||
-		asc.Spec.MinReplicas != desired.HPA.MinReplicas ||
-		asc.Spec.TargetCPUUtilizationPercentage != desired.HPA.TargetCPUUtilizationPercentage {
+		differentPointerValues(asc.Spec.MinReplicas, desired.HPA.MinReplicas) ||
+		differentPointerValues(asc.Spec.TargetCPUUtilizationPercentage, desired.HPA.TargetCPUUtilizationPercentage) {
 		return true
 	}
 	return false

--- a/pkg/helper/testhelpers.go
+++ b/pkg/helper/testhelpers.go
@@ -1,0 +1,23 @@
+package helper
+
+import (
+	"encoding/json"
+)
+
+// AsyncJSON allows converting values to JSON strings at the moment they are printed.
+// This type is helpful for printing messages in asynchronous Ginkgo clauses
+type AsyncJSON struct {
+	Ptr interface{}
+}
+
+func (am AsyncJSON) String() string {
+	bytes, err := json.Marshal(am.Ptr)
+	if err != nil {
+		panic(err)
+	}
+	return string(bytes)
+}
+
+func Int32Ptr(v int32) *int32 {
+	return &v
+}


### PR DESCRIPTION
* Tested HPA autoscaler
* Corrected bug in "autoScalerNeedsUpdate" function

Testing coverage is now 80%. See description of task https://issues.redhat.com/browse/NETOBSERV-92 for more information.

Read more at: https://issues.redhat.com/browse/NETOBSERV-80?focusedCommentId=19364614 and https://issues.redhat.com/browse/NETOBSERV-92