### PR TITLE
NETOBSERV-83 : Namespace configuration

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -27,6 +27,11 @@ import (
 type FlowCollectorSpec struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
 
+	//+kubebuilder:default:=""
+	// Namespace  where console plugin and goflowkube pods are going to be deployed.
+	// If empty, the namespace of the operator is going to be used
+	Namespace string `json:"namespace,omitempty"`
+
 	// IPFIX contains IPFIX-related settings for the flow reporter
 	IPFIX FlowCollectorIPFIX `json:"ipfix,omitempty"`
 
@@ -38,6 +43,9 @@ type FlowCollectorSpec struct {
 
 	// ConsolePlugin contains settings related to the console dynamic plugin
 	ConsolePlugin FlowCollectorConsolePlugin `json:"consolePlugin,omitempty"`
+
+	// CNO contains settings related to the cluster network operator
+	Cno ClusterNetworkOperator `json:"cno,omitempty"`
 }
 
 // FlowCollectorIPFIX defines the desired IPFIX state of FlowCollector
@@ -192,6 +200,15 @@ type FlowCollectorConsolePlugin struct {
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,8,opt,name=resources"`
+}
+
+// CNO defines the desired configuration related to the Cluster Network Configuration
+type ClusterNetworkOperator struct {
+	// Important: Run "make generate" to regenerate code after modifying this file
+
+	//+kubebuilder:default:=openshift-network-operator
+	// Namespace  where the configmap is going to be deployed.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // FlowCollectorStatus defines the observed state of FlowCollector

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -36,6 +36,15 @@ spec:
           spec:
             description: FlowCollectorSpec defines the desired state of FlowCollector
             properties:
+              cno:
+                description: CNO contains settings related to the cluster network
+                  operator
+                properties:
+                  namespace:
+                    default: openshift-network-operator
+                    description: Namespace  where the configmap is going to be deployed.
+                    type: string
+                type: object
               consolePlugin:
                 description: ConsolePlugin contains settings related to the console
                   dynamic plugin
@@ -281,6 +290,12 @@ spec:
                       push the flows to.
                     type: string
                 type: object
+              namespace:
+                default: ""
+                description: Namespace  where console plugin and goflowkube pods are
+                  going to be deployed. If empty, the namespace of the operator is
+                  going to be used
+                type: string
             type: object
           status:
             description: FlowCollectorStatus defines the observed state of FlowCollector

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -55,6 +55,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - namespaces
   - services
   verbs:
   - create

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -8,4 +8,5 @@ const (
 	DaemonSetKind  = "DaemonSet"
 	ServiceKind    = "Service"
 	AutoscalerKind = "HorizontalPodAutoscaler"
+	NamespaceKind  = "Namespace"
 )

--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,7 +30,7 @@ import (
 // Make sure it always matches config/default/kustomization.yaml:namespace
 // See also https://github.com/operator-framework/operator-lib/issues/74
 const operatorNamespace = "network-observability"
-const cnoNamespace = "openshift-network-operator"
+
 const ovsFlowsConfigMapName = "ovs-flows-config"
 const finalizerName = "flows.netobserv.io/finalizer"
 
@@ -37,22 +38,21 @@ const finalizerName = "flows.netobserv.io/finalizer"
 type FlowCollectorReconciler struct {
 	client.Client
 	Scheme              *runtime.Scheme
-	ovsConfigController ovs.FlowsConfigController
+	ovsConfigController *ovs.FlowsConfigController
 	consoleEnabled      bool
 }
 
 func NewFlowCollectorReconciler(client client.Client, scheme *runtime.Scheme) *FlowCollectorReconciler {
 	return &FlowCollectorReconciler{
-		Client: client,
-		Scheme: scheme,
-		ovsConfigController: ovs.NewFlowsConfigController(client,
-			operatorNamespace, cnoNamespace, ovsFlowsConfigMapName),
-		consoleEnabled: false,
+		Client:              client,
+		Scheme:              scheme,
+		ovsConfigController: nil,
+		consoleEnabled:      false,
 	}
 }
 
 //+kubebuilder:rbac:groups=apps,resources=deployments;daemonsets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=services;configmaps,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=namespaces;services;configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;create;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;create;delete
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins;clusterrolebindings,verbs=get;create;delete;update;patch;list
@@ -89,18 +89,42 @@ func (r *FlowCollectorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
+	ns := getNamespaceName(desired)
+	// If namespace does not exist, we create it
+	nsExist, err := r.namespaceExist(ctx, ns)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !nsExist {
+		err = r.Create(ctx, buildNamespace(ns))
+		if err != nil {
+			log.Error(err, "Failed to create Namespace")
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Goflow
 	gfReconciler := goflowkube.Reconciler{
 		Client: r.Client,
 		SetControllerReference: func(obj client.Object) error {
 			return ctrl.SetControllerReference(desired, obj, r.Scheme)
 		},
-		OperatorNamespace: operatorNamespace,
+		Namespace: ns,
 	}
 	if err := gfReconciler.Reconcile(ctx, &desired.Spec.GoflowKube, &desired.Spec.Loki); err != nil {
 		log.Error(err, "Failed to get FlowCollector")
 		return ctrl.Result{}, err
 	}
+
+	//ovsConfig is not initialized yet
+	if r.ovsConfigController == nil {
+		newFlowConfigController := ovs.NewFlowsConfigController(r.Client,
+			ns,
+			desired.Spec.Cno.Namespace,
+			ovsFlowsConfigMapName)
+		r.ovsConfigController = newFlowConfigController
+	}
+
 	// ovs-flows-config map for CNO
 	if err := r.ovsConfigController.Reconcile(ctx, desired); err != nil {
 		log.Error(err, "Failed to reconcile ovs-flows-config ConfigMap")
@@ -113,7 +137,7 @@ func (r *FlowCollectorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			SetControllerReference: func(obj client.Object) error {
 				return ctrl.SetControllerReference(desired, obj, r.Scheme)
 			},
-			OperatorNamespace: operatorNamespace,
+			Namespace: ns,
 		}
 		err := cpReconciler.Reconcile(ctx, &desired.Spec.ConsolePlugin)
 		if err != nil {
@@ -189,4 +213,25 @@ func (r *FlowCollectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *FlowCollectorReconciler) deleteExternalResources(ctx context.Context) error {
 	return r.ovsConfigController.Finalize(ctx)
+}
+
+func getNamespaceName(desired *flowsv1alpha1.FlowCollector) string {
+	if desired.Spec.Namespace != "" {
+		return desired.Spec.Namespace
+	} else {
+		return operatorNamespace
+	}
+}
+
+func (r *FlowCollectorReconciler) namespaceExist(ctx context.Context, nsName string) (bool, error) {
+	err := r.Get(ctx, types.NamespacedName{Name: nsName}, &corev1.Namespace{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		} else {
+			log.FromContext(ctx).Error(err, "Failed to get namespace")
+			return false, err
+		}
+	}
+	return true, nil
 }

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -31,7 +31,7 @@ var _ = Describe("FlowCollector Controller", func() {
 	expectedSharedTarget := "11.22.33.44:999"
 	configMapKey := types.NamespacedName{
 		Name:      "ovs-flows-config",
-		Namespace: cnoNamespace,
+		Namespace: "openshift-network-operator",
 	}
 	gfKey := types.NamespacedName{
 		Name:      constants.GoflowKubeName,

--- a/controllers/flowcollector_objects.go
+++ b/controllers/flowcollector_objects.go
@@ -1,0 +1,14 @@
+package controllers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func buildNamespace(ns string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ns,
+		},
+	}
+}

--- a/controllers/ovs/flowsconfig.go
+++ b/controllers/ovs/flowsconfig.go
@@ -18,31 +18,31 @@ import (
 )
 
 type FlowsConfigController struct {
-	ovsConfigMapName  string
-	operatorNamespace string
-	cnoNamespace      string
-	client            client.Client
-	lookupIP          func(string) ([]net.IP, error)
+	ovsConfigMapName    string
+	goflowkubeNamespace string
+	cnoNamespace        string
+	client              client.Client
+	lookupIP            func(string) ([]net.IP, error)
 }
 
 func NewFlowsConfigController(client client.Client,
-	operatorNamespace, cnoNamespace, ovsConfigMapName string) FlowsConfigController {
-	return FlowsConfigController{
-		client:            client,
-		operatorNamespace: operatorNamespace,
-		cnoNamespace:      cnoNamespace,
-		ovsConfigMapName:  ovsConfigMapName,
-		lookupIP:          net.LookupIP,
+	goflowkubeNamespace, cnoNamespace, ovsConfigMapName string) *FlowsConfigController {
+	return &FlowsConfigController{
+		client:              client,
+		goflowkubeNamespace: goflowkubeNamespace,
+		cnoNamespace:        cnoNamespace,
+		ovsConfigMapName:    ovsConfigMapName,
+		lookupIP:            net.LookupIP,
 	}
 }
 
 // NewTestFlowsConfigController allows creating a FlowsConfigController instance that with an
 // injected IP resolver for testing.
 func NewTestFlowsConfigController(client client.Client,
-	operatorNamespace, cnoNamespace, ovsConfigMapName string,
+	goflowkubeNamespace, cnoNamespace, ovsConfigMapName string,
 	lookupIP func(string) ([]net.IP, error),
-) FlowsConfigController {
-	fc := NewFlowsConfigController(client, operatorNamespace, cnoNamespace, ovsConfigMapName)
+) *FlowsConfigController {
+	fc := NewFlowsConfigController(client, goflowkubeNamespace, cnoNamespace, ovsConfigMapName)
 	fc.lookupIP = lookupIP
 	return fc
 }
@@ -135,7 +135,7 @@ func (c *FlowsConfigController) desired(
 	case constants.DeploymentKind:
 		svc := corev1.Service{}
 		if err := c.client.Get(ctx, types.NamespacedName{
-			Namespace: c.operatorNamespace,
+			Namespace: c.goflowkubeNamespace,
 			Name:      constants.GoflowKubeName,
 		}, &svc); err != nil {
 			return nil, err


### PR DESCRIPTION
Added several fields in the CRD :
- namespace to deploy goflow-kube and console-plugin pods
- name and namespace of the CNO configmap