### PR TITLE
NETOBSERV-90: enable deployment as Daemonset

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -116,3 +116,11 @@ rules:
   - create
   - delete
   - get
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - hostnetwork
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -59,6 +59,7 @@ func NewFlowCollectorReconciler(client client.Client, scheme *runtime.Scheme) *F
 //+kubebuilder:rbac:groups=flows.netobserv.io,resources=flowcollectors,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=flows.netobserv.io,resources=flowcollectors/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=flows.netobserv.io,resources=flowcollectors/finalizers,verbs=update
+//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=hostnetwork,verbs=use
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -172,7 +173,6 @@ func (r *FlowCollectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.DaemonSet{}).
-		Owns(&corev1.Service{}).
 		Owns(&ascv1.HorizontalPodAutoscaler{}).
 		Owns(&corev1.Service{})
 


### PR DESCRIPTION
- Adding a HostPort to the container specification in the DaemonSet
- Setting the proper RBAC permissions
- Enable the deployment in the master node