### PR TITLE
NETOBSERV-88: restart pods on configmap change (bugfix)

### DIFF
--- a/controllers/goflowkube/goflowkube_test.go
+++ b/controllers/goflowkube/goflowkube_test.go
@@ -194,7 +194,9 @@ func TestConfigMapShouldDeserializeAsYAML(t *testing.T) {
 
 	goflowKube := getGoflowKubeConfig()
 	loki := getLokiConfig()
-	cm := buildConfigMap(&goflowKube, &loki, "namespace")
+	cm, digest := buildConfigMap(&goflowKube, &loki, "namespace")
+	assert.NotEmpty(t, digest)
+
 	data, ok := cm.Data[configFile]
 	assert.True(ok)
 


### PR DESCRIPTION
It adds a new annotation to the pods that contains a digest of the
the goflow-kube-config configmap contents. When that configmap changes,
the Pod template inside the Daemonset or Deployment is updated so
Kubernetes will force the update of the goflow-kube pods.

Demo:

https://user-images.githubusercontent.com/939550/143897920-5a794abc-4e2b-48e5-9598-cc27f5d0191f.mp4



