### PR TITLE
NETOBSERV-96: passing Loki URL to the plugin backend

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -138,6 +138,12 @@ type FlowCollectorLoki struct {
 	// URL is the address of an existing Loki service to push the flows to.
 	URL string `json:"url,omitempty"`
 
+	//+kubebuilder:validation:optional
+	// QuerierURL specifies the address of the Loki querier service, in case it is different from the
+	// Loki ingester URL. If empty, the URL value will be used (assuming that the Loki ingester
+	// and querier are int he same host).
+	QuerierURL string `json:"querierUrl,omitempty"`
+
 	//+kubebuilder:default:="1s"
 	// BatchWait is max time to wait before sending a batch
 	BatchWait metav1.Duration `json:"batchWait,omitempty"`

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -271,6 +271,12 @@ spec:
                     description: MinBackoff is the initial backoff time for client
                       connection between retries
                     type: string
+                  querierUrl:
+                    description: QuerierURL specifies the address of the Loki querier
+                      service, in case it is different from the Loki ingester URL.
+                      If empty, the URL value will be used (assuming that the Loki
+                      ingester and querier are int he same host).
+                    type: string
                   staticLabels:
                     additionalProperties:
                       type: string

--- a/controllers/consoleplugin/consoleplugin_test.go
+++ b/controllers/consoleplugin/consoleplugin_test.go
@@ -118,9 +118,12 @@ func TestBuiltContainer(t *testing.T) {
 	assert := assert.New(t)
 
 	//newly created containers should not need update
-	containerConfig := getPluginConfig()
-	newContainer := buildPodTemplate(&containerConfig)
-	assert.Equal(containerNeedsUpdate(&newContainer.Spec, &containerConfig), false)
+	config := flowsv1alpha1.FlowCollectorSpec{
+		Loki:          flowsv1alpha1.FlowCollectorLoki{URL: "http://foo:1234"},
+		ConsolePlugin: getPluginConfig(),
+	}
+	newContainer := buildPodTemplate(&config)
+	assert.Equal(containerNeedsUpdate(&newContainer.Spec, &config.ConsolePlugin), false)
 }
 
 func TestBuiltService(t *testing.T) {

--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -137,7 +137,7 @@ func (r *FlowCollectorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			},
 			Namespace: ns,
 		}
-		err := cpReconciler.Reconcile(ctx, &desired.Spec.ConsolePlugin)
+		err := cpReconciler.Reconcile(ctx, &desired.Spec)
 		if err != nil {
 			log.Error(err, "Failed to get ConsolePlugin")
 			return ctrl.Result{}, err

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -324,4 +324,94 @@ var _ = Describe("FlowCollector Controller", func() {
 			}, timeout, interval).Should(Succeed())
 		})
 	})
+	Context("configuring the Console plugin", func() {
+		dKey := types.NamespacedName{
+			Name:      "console-plugin-flowcollector",
+			Namespace: operatorNamespace,
+		}
+		created := &flowsv1alpha1.FlowCollector{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: dKey.Name,
+			},
+			Spec: flowsv1alpha1.FlowCollectorSpec{
+				GoflowKube: flowsv1alpha1.FlowCollectorGoflowKube{
+					Kind:            "Deployment",
+					Port:            7891,
+					ImagePullPolicy: "Never",
+					LogLevel:        "error",
+					Image:           "testimg:latest",
+				},
+				Loki: flowsv1alpha1.FlowCollectorLoki{
+					URL: "http://loki:1234",
+				},
+				ConsolePlugin: flowsv1alpha1.FlowCollectorConsolePlugin{
+					Replicas:        1,
+					Port:            8888,
+					Image:           "console:latest",
+					ImagePullPolicy: "Never",
+				},
+			},
+		}
+		It("Should configure the Loki URL in the Console plugin backend", func() {
+			Expect(k8sClient.Create(ctx, created)).Should(Succeed())
+			Eventually(getContainerArgumentAfter("network-observability-plugin", "-loki"),
+				timeout, interval).Should(Equal("http://loki:1234"))
+		})
+		It("Should update the Loki URL in the Console Plugin if it changes in the Spec", func() {
+			Expect(func() error {
+				upd := flowsv1alpha1.FlowCollector{}
+				if err := k8sClient.Get(ctx, dKey, &upd); err != nil {
+					return err
+				}
+				upd.Spec.Loki.URL = "http://loki.namespace:8888"
+				return k8sClient.Update(ctx, &upd)
+			}()).Should(Succeed())
+			Eventually(getContainerArgumentAfter("network-observability-plugin", "-loki"),
+				timeout, interval).Should(Equal("http://loki.namespace:8888"))
+		})
+		It("Should use the Loki Querier URL instead of the Loki URL, if the first is defined", func() {
+			Expect(func() error {
+				upd := flowsv1alpha1.FlowCollector{}
+				if err := k8sClient.Get(ctx, dKey, &upd); err != nil {
+					return err
+				}
+				upd.Spec.Loki.QuerierURL = "http://loki-querier:6789"
+				return k8sClient.Update(ctx, &upd)
+			}()).Should(Succeed())
+			Eventually(getContainerArgumentAfter("network-observability-plugin", "-loki"),
+				timeout, interval).Should(Equal("http://loki-querier:6789"))
+		})
+	})
 })
+
+func getContainerArgumentAfter(containerName, argName string) func() interface{} {
+	pluginDeploymentKey := types.NamespacedName{
+		Name:      "network-observability-plugin",
+		Namespace: operatorNamespace,
+	}
+	return func() interface{} {
+		deployment := appsv1.Deployment{}
+		if err := k8sClient.Get(ctx, pluginDeploymentKey, &deployment); err != nil {
+			return err
+		}
+		for i := range deployment.Spec.Template.Spec.Containers {
+			cnt := &deployment.Spec.Template.Spec.Containers[i]
+			if cnt.Name == containerName {
+				args := cnt.Args
+				for len(args) > 0 {
+					if args[0] == argName {
+						if len(args) < 2 {
+							return fmt.Errorf("container %q: arg %v has no value. Actual args: %v",
+								containerName, argName, cnt.Args)
+						}
+						return args[1]
+					}
+					args = args[1:]
+				}
+				return fmt.Errorf("container %q: arg %v not found. Actual args: %v",
+					containerName, argName, cnt.Args)
+			}
+		}
+		return fmt.Errorf("container not found: %v", containerName)
+	}
+}

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -566,6 +566,13 @@ Loki contains settings related to the loki client
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>querierUrl</b></td>
+        <td>string</td>
+        <td>
+          QuerierURL specifies the address of the Loki querier service, in case it is different from the Loki ingester URL. If empty, the URL value will be used (assuming that the Loki ingester and querier are int he same host).<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>staticLabels</b></td>
         <td>map[string]string</td>
         <td>


### PR DESCRIPTION
Fetches the Loki URL from the FlowCollector and accordingly configures
the Network Console Plugin to receive such URL.

It also adds the optional `querierUrl` argument, that can be specified
if the Loki querier and ingester are in different hosts. `querierUrl`
has priority over `url`.

Related PR: https://github.com/netobserv/network-observability-console-plugin/pull/11