### PR TITLE
NETOBSERV-158: Added sticky session to goflow kube to fix template defs miss

### DIFF
--- a/controllers/goflowkube/goflowkube_objects.go
+++ b/controllers/goflowkube/goflowkube_objects.go
@@ -191,7 +191,8 @@ func buildService(old *corev1.Service, desired *flowsv1alpha1.FlowCollectorGoflo
 				Labels:    buildLabels(),
 			},
 			Spec: corev1.ServiceSpec{
-				Selector: buildLabels(),
+				Selector:        buildLabels(),
+				SessionAffinity: corev1.ServiceAffinityClientIP,
 				Ports: []corev1.ServicePort{{
 					Port:     desired.Port,
 					Protocol: corev1.ProtocolUDP,


### PR DESCRIPTION
This change add sticky session to goflowkube based on the client IP.

Related Jira issue:
https://issues.redhat.com/browse/NETOBSERV-158