### PR TITLE
NETOBSERV-174 Make loki TimestampLabel configurable

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -174,6 +174,10 @@ type FlowCollectorLoki struct {
 	//+kubebuilder:default:={"app":"netobserv-flowcollector"}
 	// StaticLabels is a map of common labels to set on each flow
 	StaticLabels map[string]string `json:"staticLabels,omitempty"`
+
+	//+kubebuilder:default:="TimeFlowEnd"
+	// TimestampLabel is the label to use for time indexing in Loki. E.g. "TimeReceived", "TimeFlowStart", "TimeFlowEnd".
+	TimestampLabel string `json:"timestampLabel,omitempty"`
 }
 
 // FlowCollectorConsolePlugin defines the desired ConsolePlugin state of FlowCollector

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -290,6 +290,11 @@ spec:
                     description: Timeout is the maximum time connection / request
                       limit A Timeout of zero means no timeout.
                     type: string
+                  timestampLabel:
+                    default: TimeFlowEnd
+                    description: TimestampLabel is the label to use for time indexing
+                      in Loki. E.g. "TimeReceived", "TimeFlowStart", "TimeFlowEnd".
+                    type: string
                   url:
                     default: http://loki:3100/
                     description: URL is the address of an existing Loki service to

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -23,6 +23,7 @@ spec:
     minBackoff: 1s
     maxBackoff: 300s
     maxRetries: 10
+    timestampLabel: TimeFlowEnd
     staticLabels:
       app: netobserv-flowcollector
   consolePlugin:

--- a/controllers/goflowkube/goflowkube_objects.go
+++ b/controllers/goflowkube/goflowkube_objects.go
@@ -33,15 +33,16 @@ type ConfigMap struct {
 }
 
 type LokiConfigMap struct {
-	URL          string            `json:"url,omitempty"`
-	BatchWait    metav1.Duration   `json:"batchWait,omitempty"`
-	BatchSize    int64             `json:"batchSize,omitempty"`
-	Timeout      metav1.Duration   `json:"timeout,omitempty"`
-	MinBackoff   metav1.Duration   `json:"minBackoff,omitempty"`
-	MaxBackoff   metav1.Duration   `json:"maxBackoff,omitempty"`
-	MaxRetries   int32             `json:"maxRetries,omitempty"`
-	Labels       []string          `json:"labels,omitempty"`
-	StaticLabels map[string]string `json:"staticLabels,omitempty"`
+	URL            string            `json:"url,omitempty"`
+	BatchWait      metav1.Duration   `json:"batchWait,omitempty"`
+	BatchSize      int64             `json:"batchSize,omitempty"`
+	Timeout        metav1.Duration   `json:"timeout,omitempty"`
+	MinBackoff     metav1.Duration   `json:"minBackoff,omitempty"`
+	MaxBackoff     metav1.Duration   `json:"maxBackoff,omitempty"`
+	MaxRetries     int32             `json:"maxRetries,omitempty"`
+	Labels         []string          `json:"labels,omitempty"`
+	StaticLabels   map[string]string `json:"staticLabels,omitempty"`
+	TimestampLabel string            `json:"timestampLabel,omitempty"`
 }
 
 func buildLabels() map[string]string {
@@ -158,6 +159,7 @@ func buildConfigMap(desiredGoflowKube *flowsv1alpha1.FlowCollectorGoflowKube,
 		config.Loki.StaticLabels = desiredLoki.StaticLabels
 		config.Loki.Timeout = desiredLoki.Timeout
 		config.Loki.URL = desiredLoki.URL
+		config.Loki.TimestampLabel = desiredLoki.TimestampLabel
 	}
 	config.Loki.Labels = []string{"SrcNamespace", "SrcWorkload", "DstNamespace", "DstWorkload"}
 

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -591,6 +591,15 @@ Loki contains settings related to the loki client
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>timestampLabel</b></td>
+        <td>string</td>
+        <td>
+          TimestampLabel is the label to use for time-series indexing in Loki. E.g. "TimeReceived", "TimeFlowStart", "TimeFlowEnd".<br/>
+          <br/>
+            <i>Default</i>: TimeFlowEnd<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>url</b></td>
         <td>string</td>
         <td>


### PR DESCRIPTION
... and default to "TimeFlowEnd"

JIRA: https://issues.redhat.com/browse/NETOBSERV-174

Note: by making it configurable rather than forced to TimeFlowEnd, we allow having a workaround when Loki generates a lot of out-of-order inserts. This can happen in previous versions of Loki.