### PR TITLE
NETOBSERV-107 Add version information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build the manager binary
 FROM registry.access.redhat.com/ubi8/go-toolset:1.16.7-5 as builder
+ARG OPVERSION="unknown"
 
 WORKDIR /opt/app-root
 
@@ -19,7 +20,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod vendor -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags "-X main.version=$OPVERSION" -mod vendor -a -o manager main.go
 
 # Create final image from minimal + built binary
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-204

--- a/Makefile
+++ b/Makefile
@@ -121,13 +121,13 @@ coverage-report-html:
 ##@ Build
 
 build: generate fmt lint ## Build manager binary.
-	go build -mod vendor -o bin/manager main.go
+	go build -ldflags "-X main.version=${VERSION}" -mod vendor -o bin/manager main.go
 
 run: manifests generate fmt lint ## Run a controller from your host.
 	go run ./main.go
 
 image-build: test ## Build OCI image with the manager.
-	$(OCI_BIN) build -t ${IMG} .
+	$(OCI_BIN) build --build-arg OPVERSION="$(VERSION)" -t ${IMG} .
 
 image-push: ## Push OCI image with the manager.
 	$(OCI_BIN) push ${IMG}
@@ -142,11 +142,11 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set label version:$(VERSION)
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
-
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
@@ -154,7 +154,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.8)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
@@ -178,6 +178,7 @@ endef
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	cd config/manager && $(KUSTOMIZE) edit set label version:$(VERSION)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
 
@@ -233,4 +234,4 @@ catalog-push: ## Push a catalog image.
 # Deploy the sample FlowCollector CR
 .PHONY: create-sample
 create-sample:
-	kubectl apply -f ./config/samples/flows_v1alpha1_flowcollector.yaml
+	sed -e 's~:main~:$(VERSION)~' ./config/samples/flows_v1alpha1_flowcollector.yaml | echo | kubectl apply -f -

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,3 +14,6 @@ images:
 - name: controller
   newName: quay.io/netobserv/network-observability-operator
   newTag: main
+commonLabels:
+  app: network-observability-operator
+  version: main

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -7,13 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	flowsv1alpha1 "github.com/netobserv/network-observability-operator/api/v1alpha1"
+	"github.com/netobserv/network-observability-operator/pkg/helper"
 )
-
-func buildLabels() map[string]string {
-	return map[string]string{
-		"app": pluginName,
-	}
-}
 
 const secretName = "console-serving-cert"
 const displayName = "Network Observability plugin"
@@ -22,7 +17,27 @@ const proxyAlias = "backend"
 // lokiURLAnnotation contains the used Loki querier URL, facilitating the change management
 const lokiURLAnnotation = "flows.netobserv.io/loki-url"
 
-func buildConsolePlugin(desired *flowsv1alpha1.FlowCollectorConsolePlugin, ns string) *osv1alpha1.ConsolePlugin {
+type builder struct {
+	namespace   string
+	labels      map[string]string
+	desired     *flowsv1alpha1.FlowCollectorConsolePlugin
+	desiredLoki *flowsv1alpha1.FlowCollectorLoki
+}
+
+func newBuilder(ns string, desired *flowsv1alpha1.FlowCollectorConsolePlugin, desiredLoki *flowsv1alpha1.FlowCollectorLoki) builder {
+	version := helper.ExtractVersion(desired.Image)
+	return builder{
+		namespace: ns,
+		labels: map[string]string{
+			"app":     pluginName,
+			"version": version,
+		},
+		desired:     desired,
+		desiredLoki: desiredLoki,
+	}
+}
+
+func (b *builder) consolePlugin() *osv1alpha1.ConsolePlugin {
 	return &osv1alpha1.ConsolePlugin{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: pluginName,
@@ -31,8 +46,8 @@ func buildConsolePlugin(desired *flowsv1alpha1.FlowCollectorConsolePlugin, ns st
 			DisplayName: displayName,
 			Service: osv1alpha1.ConsolePluginService{
 				Name:      pluginName,
-				Namespace: ns,
-				Port:      desired.Port,
+				Namespace: b.namespace,
+				Port:      b.desired.Port,
 				BasePath:  "/",
 			},
 			Proxy: []osv1alpha1.ConsolePluginProxy{{
@@ -40,44 +55,45 @@ func buildConsolePlugin(desired *flowsv1alpha1.FlowCollectorConsolePlugin, ns st
 				Alias: proxyAlias,
 				Service: osv1alpha1.ConsolePluginProxyServiceConfig{
 					Name:      pluginName,
-					Namespace: ns,
-					Port:      desired.Port,
+					Namespace: b.namespace,
+					Port:      b.desired.Port,
 				},
 			}},
 		},
 	}
 }
 
-func buildDeployment(desired *flowsv1alpha1.FlowCollectorSpec, ns string) *appsv1.Deployment {
+func (b *builder) deployment() *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pluginName,
-			Namespace: ns,
+			Namespace: b.namespace,
+			Labels:    b.labels,
 			Annotations: map[string]string{
-				lokiURLAnnotation: querierURL(&desired.Loki),
+				lokiURLAnnotation: querierURL(b.desiredLoki),
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &desired.ConsolePlugin.Replicas,
+			Replicas: &b.desired.Replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: buildLabels(),
+				MatchLabels: b.labels,
 			},
-			Template: *buildPodTemplate(desired),
+			Template: *b.podTemplate(),
 		},
 	}
 }
 
-func buildPodTemplate(desired *flowsv1alpha1.FlowCollectorSpec) *corev1.PodTemplateSpec {
+func (b *builder) podTemplate() *corev1.PodTemplateSpec {
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: buildLabels(),
+			Labels: b.labels,
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{
 				Name:            pluginName,
-				Image:           desired.ConsolePlugin.Image,
-				ImagePullPolicy: corev1.PullPolicy(desired.ConsolePlugin.ImagePullPolicy),
-				Resources:       *desired.ConsolePlugin.Resources.DeepCopy(),
+				Image:           b.desired.Image,
+				ImagePullPolicy: corev1.PullPolicy(b.desired.ImagePullPolicy),
+				Resources:       *b.desired.Resources.DeepCopy(),
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      secretName,
 					MountPath: "/var/serving-cert",
@@ -86,7 +102,7 @@ func buildPodTemplate(desired *flowsv1alpha1.FlowCollectorSpec) *corev1.PodTempl
 				Args: []string{
 					"-cert", "/var/serving-cert/tls.crt",
 					"-key", "/var/serving-cert/tls.key",
-					"-loki", querierURL(&desired.Loki),
+					"-loki", querierURL(b.desiredLoki),
 				},
 			}},
 			Volumes: []corev1.Volume{{
@@ -102,21 +118,21 @@ func buildPodTemplate(desired *flowsv1alpha1.FlowCollectorSpec) *corev1.PodTempl
 	}
 }
 
-func buildService(old *corev1.Service, desired *flowsv1alpha1.FlowCollectorConsolePlugin, ns string) *corev1.Service {
+func (b *builder) service(old *corev1.Service) *corev1.Service {
 	if old == nil {
 		return &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pluginName,
-				Namespace: ns,
-				Labels:    buildLabels(),
+				Namespace: b.namespace,
+				Labels:    b.labels,
 				Annotations: map[string]string{
 					"service.alpha.openshift.io/serving-cert-secret-name": "console-serving-cert",
 				},
 			},
 			Spec: corev1.ServiceSpec{
-				Selector: buildLabels(),
+				Selector: b.labels,
 				Ports: []corev1.ServicePort{{
-					Port:     desired.Port,
+					Port:     b.desired.Port,
 					Protocol: "TCP",
 				}},
 			},
@@ -125,7 +141,7 @@ func buildService(old *corev1.Service, desired *flowsv1alpha1.FlowCollectorConso
 	// In case we're updating an existing service, we need to build from the old one to keep immutable fields such as clusterIP
 	newService := old.DeepCopy()
 	newService.Spec.Ports = []corev1.ServicePort{{
-		Port:     desired.Port,
+		Port:     b.desired.Port,
 		Protocol: corev1.ProtocolUDP,
 	}}
 	return newService
@@ -136,7 +152,9 @@ func buildServiceAccount(ns string) *corev1.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pluginName,
 			Namespace: ns,
-			Labels:    buildLabels(),
+			Labels: map[string]string{
+				"app": pluginName,
+			},
 		},
 	}
 }

--- a/controllers/goflowkube/goflowkube_test.go
+++ b/controllers/goflowkube/goflowkube_test.go
@@ -193,10 +193,14 @@ func TestServiceUpdateCheck(t *testing.T) {
 func TestConfigMapShouldDeserializeAsYAML(t *testing.T) {
 	assert := assert.New(t)
 
+	ns := "namespace"
 	goflowKube := getGoflowKubeConfig()
 	loki := getLokiConfig()
-	cm, digest := buildConfigMap(&goflowKube, &loki, "namespace")
+	b := newBuilder(ns, &goflowKube, &loki)
+	cm, digest := b.configMap()
 	assert.NotEmpty(t, digest)
+
+	assert.Equal("dev", cm.Labels["version"])
 
 	data, ok := cm.Data[configFile]
 	assert.True(ok)
@@ -245,4 +249,32 @@ func TestAutoScalerUpdateCheck(t *testing.T) {
 	autoScalerSpec, goflowKube = getAutoScalerSpecs()
 	autoScalerSpec.Namespace = "NewNamespace"
 	assert.Equal(autoScalerNeedsUpdate(&autoScalerSpec, &goflowKube, testNamespace), true)
+}
+
+func TestLabels(t *testing.T) {
+	assert := assert.New(t)
+
+	gfk := getGoflowKubeConfig()
+	builder := newBuilder("ns", &gfk, nil)
+
+	// Deployment
+	depl := builder.deployment("digest")
+	assert.Equal("goflow-kube", depl.Labels["app"])
+	assert.Equal("goflow-kube", depl.Spec.Template.Labels["app"])
+	assert.Equal("dev", depl.Labels["version"])
+	assert.Equal("dev", depl.Spec.Template.Labels["version"])
+
+	// DaemonSet
+	ds := builder.daemonSet("digest")
+	assert.Equal("goflow-kube", ds.Labels["app"])
+	assert.Equal("goflow-kube", ds.Spec.Template.Labels["app"])
+	assert.Equal("dev", ds.Labels["version"])
+	assert.Equal("dev", ds.Spec.Template.Labels["version"])
+
+	// Service
+	svc := builder.service(nil)
+	assert.Equal("goflow-kube", svc.Labels["app"])
+	assert.Equal("goflow-kube", svc.Spec.Selector["app"])
+	assert.Equal("dev", svc.Labels["version"])
+	assert.Equal("dev", svc.Spec.Selector["version"])
 }

--- a/main.go
+++ b/main.go
@@ -18,27 +18,30 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
+	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	flowsv1alpha1 "github.com/netobserv/network-observability-operator/api/v1alpha1"
 	"github.com/netobserv/network-observability-operator/controllers"
-	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 
+const app = "network-observability-operator"
+
 var (
+	version  = "unknown"
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
@@ -55,11 +58,13 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var versionFlag bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&versionFlag, "v", false, "print version")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -67,6 +72,13 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	appVersion := fmt.Sprintf("%s %s", app, version)
+	if versionFlag {
+		fmt.Println(appVersion)
+		os.Exit(0)
+	}
+	setupLog.Info("Starting " + appVersion)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -2,6 +2,8 @@
 // to perform some basic computational operations
 package helper
 
+import "strings"
+
 func ContainsString(slice []string, s string) bool {
 	for _, item := range slice {
 		if item == s {
@@ -9,4 +11,13 @@ func ContainsString(slice []string, s string) bool {
 		}
 	}
 	return false
+}
+
+func ExtractVersion(image string) string {
+	parts := strings.Split(image, ":")
+	nparts := len(parts)
+	if nparts > 1 {
+		return parts[nparts-1]
+	}
+	return "unknown"
 }

--- a/pkg/helper/helpers_test.go
+++ b/pkg/helper/helpers_test.go
@@ -1,0 +1,21 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	v := ExtractVersion("quay.io/netobserv/goflow-kube:v0.1.0")
+	assert.Equal("v0.1.0", v)
+}
+
+func TestExtractUnknownVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	v := ExtractVersion("goflow-kube")
+	assert.Equal("unknown", v)
+}


### PR DESCRIPTION
JIRA https://issues.redhat.com/browse/NETOBSERV-107

version information is added in several places:
- via kustomize, as label on the operator (manager) itself
- through build ldflags, to the main package, logged for information
  (both in "make build" and "make image-build")
- in deployed components (goflow-kube and console plugin) as k8s label
  (note that the version here is taken from the images defined in CR, which can
be different from the operator version)
- lastly, I updated the helper target `make create-sample` so that it can use a custom version from env

Use the VERSION env in make targets to set a specific version
(e.g. `VERSION="0.1.0-test" IMAGE_TAG_BASE="quay.io/jotak/network-observability-operator" make image-build image-push deploy`)