### PR TITLE
NETOBSERV-169 send labels to console plugin

### DIFF
--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -1,12 +1,15 @@
 package consoleplugin
 
 import (
+	"strings"
+
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	flowsv1alpha1 "github.com/netobserv/network-observability-operator/api/v1alpha1"
+	"github.com/netobserv/network-observability-operator/controllers/constants"
 	"github.com/netobserv/network-observability-operator/pkg/helper"
 )
 
@@ -103,6 +106,7 @@ func (b *builder) podTemplate() *corev1.PodTemplateSpec {
 					"-cert", "/var/serving-cert/tls.crt",
 					"-key", "/var/serving-cert/tls.key",
 					"-loki", querierURL(b.desiredLoki),
+					"-loki-labels", strings.Join(constants.Labels, ","),
 				},
 			}},
 			Volumes: []corev1.Volume{{

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -6,3 +6,5 @@ const (
 	DeploymentKind = "Deployment"
 	DaemonSetKind  = "DaemonSet"
 )
+
+var Labels = []string{"SrcNamespace", "SrcWorkload", "DstNamespace", "DstWorkload", "FlowDirection"}

--- a/controllers/goflowkube/goflowkube_objects.go
+++ b/controllers/goflowkube/goflowkube_objects.go
@@ -209,7 +209,7 @@ func (b *builder) configMap() (*corev1.ConfigMap, string) {
 		config.Loki.URL = b.desiredLoki.URL
 		config.Loki.TimestampLabel = b.desiredLoki.TimestampLabel
 	}
-	config.Loki.Labels = []string{"SrcNamespace", "SrcWorkload", "DstNamespace", "DstWorkload"}
+	config.Loki.Labels = constants.Labels
 
 	bs, err := json.Marshal(config)
 	if err == nil {

--- a/controllers/goflowkube/goflowkube_test.go
+++ b/controllers/goflowkube/goflowkube_test.go
@@ -219,7 +219,7 @@ func TestConfigMapShouldDeserializeAsYAML(t *testing.T) {
 	assert.Equal(loki.MaxBackoff.Duration.String(), lokiCfg["maxBackoff"])
 	assert.EqualValues(loki.MaxRetries, lokiCfg["maxRetries"])
 	assert.EqualValues(loki.BatchSize, lokiCfg["batchSize"])
-	assert.EqualValues([]interface{}{"SrcNamespace", "SrcWorkload", "DstNamespace", "DstWorkload"}, lokiCfg["labels"])
+	assert.EqualValues([]interface{}{"SrcNamespace", "SrcWorkload", "DstNamespace", "DstWorkload", "FlowDirection"}, lokiCfg["labels"])
 	assert.Equal(fmt.Sprintf("%v", loki.StaticLabels), fmt.Sprintf("%v", lokiCfg["staticLabels"]))
 }
 


### PR DESCRIPTION
This PR is part of [NETOBSERV-169](https://issues.redhat.com/browse/NETOBSERV-169) - Create index on FlowDirection
Changes:
- Send Loki labels to console `plugin backend`
- Added `FlowDirection`

Check https://github.com/netobserv/network-observability-console-plugin/pull/70