### PR TITLE
NETOBSERV-192 automated release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,13 @@
-name: push to quay.io
+name: release to quay.io
 on:
   push:
-    branches: [ main ]
+    tags: [*]
 
 env:
   REGISTRY_USER: netobserv+github_ci
   REGISTRY_PASSWORD: ${{ secrets.QUAY_SECRET }}
   REGISTRY: quay.io/netobserv
   IMAGE: network-observability-operator
-  TAGS: main
 
 jobs:
   push-image:
@@ -18,31 +17,40 @@ jobs:
       matrix:
         go: ['1.17']
     steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: validate tag
+        id: validate_tag
+        run: |
+          tag=`git describe --exact-match --tags 2> /dev/null`
+          if [[ $tag =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+              echo "$tag is a valid release tag"
+              set -e
+              echo "::set-output name=tag::$tag"
+          else
+              echo "$tag is NOT a valid release tag"
+              exit 1
+          fi
       - name: install make
         run: sudo apt-get install make
       - name: set up go 1.x
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: build images
-        run: make ci-images-build
+      - name: build image
+        run: VERSION=${{ steps.validate_tag.outputs.tag }} IMAGE_TAG_BASE=${{ env.REGISTRY }}/${{ env.IMAGE }} make image-build
       - name: podman login to quay.io
         uses: redhat-actions/podman-login@v1
         with:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
           registry: quay.io
-      - name: get short sha
-        id: shortsha
-        run: echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
-      - name: push to quay.io
+      - name: push operator to quay.io
         id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ env.IMAGE }}
-          tags: ${{ env.TAGS }} ${{ steps.shortsha.outputs.short_sha }}
+          tags: ${{ steps.validate_tag.outputs.tag }}
           registry: ${{ env.REGISTRY }}
       - name: print image url
         run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/Makefile
+++ b/Makefile
@@ -134,10 +134,8 @@ build: generate fmt lint ## Build manager binary.
 image-build:
 	$(OCI_BIN) build --build-arg BUILD_VERSION="${BUILD_VERSION}" -t ${IMG} .
 
-image-sha-build: image-build
-	echo "FROM ${IMG}" > tmp.Dockerfile && \
-		$(OCI_BIN) build --label quay.expires-after=2w -t ${IMG_SHA} -f tmp.Dockerfile . && \
-		rm tmp.Dockerfile
+ci-images-build: image-build
+	$(OCI_BIN) build --build-arg BASE_IMAGE=$(IMG) -t $(IMG_SHA) -f ./shortlived.Dockerfile .
 
 image-push: ## Push OCI image with the manager.
 	$(OCI_BIN) push ${IMG}

--- a/shortlived.Dockerfile
+++ b/shortlived.Dockerfile
@@ -1,0 +1,3 @@
+ARG BASE_IMAGE=quay.io/netobserv/network-observability-operator:main
+FROM $BASE_IMAGE
+LABEL quay.expires-after=2w


### PR DESCRIPTION
https://issues.redhat.com/browse/NETOBSERV-192

Add release github action (similar to the one in console plugin)
Also small changes in the short-lived image implementation, similar to
what was done  in FLP