### PR TITLE
Adding support for FLP operational metrics

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -166,6 +166,12 @@ type FlowCollectorFLP struct {
 	// HealthPort is a collector HTTP port in the Pod that exposes the health check API
 	HealthPort int32 `json:"healthPort,omitempty"`
 
+	//+kubebuilder:validation:Minimum=1
+	//+kubebuilder:validation:Maximum=65535
+	//+kubebuilder:default:=9090
+	// PrometheusPort is the prometheus HTTP port: this port exposes prometheus metrics
+	PrometheusPort int32 `json:"prometheusPort,omitempty"`
+
 	//+kubebuilder:default:="quay.io/netobserv/flowlogs-pipeline:main"
 	// Image is the collector image (including domain and tag)
 	Image string `json:"image,omitempty"`

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -1356,6 +1356,14 @@ spec:
                     maximum: 65535
                     minimum: 1025
                     type: integer
+                  prometheusPort:
+                    default: 9090
+                    description: 'PrometheusPort is the prometheus HTTP port: this
+                      port exposes prometheus metrics'
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
                   replicas:
                     default: 1
                     description: Replicas defines the number of replicas (pods) to

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -18,6 +18,7 @@ spec:
     logLevel: info
     enableKubeProbes: true
     healthPort: 8080
+    prometheusPort: 9090
   loki:
     url: 'http://loki:3100/'
     batchWait: 1s

--- a/config/samples/flows_v1alpha1_flowcollector_ebpf.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector_ebpf.yaml
@@ -24,6 +24,7 @@ spec:
     printOutput: false
     enableKubeProbes: false
     healthPort: 8080
+    prometheusPort: 9090
   loki:
     url: 'http://loki:3100/'
     batchWait: 1s

--- a/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
@@ -18,6 +18,7 @@ spec:
     logLevel: info
     enableKubeProbes: true
     healthPort: 8080
+    prometheusPort: 9090
   loki:
     url: 'http://loki:3100/'
     batchWait: 1s

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -67,7 +67,8 @@ func getFLPConfig() flowsv1alpha1.FlowCollectorFLP {
 				},
 			}},
 		},
-		HealthPort: 8080,
+		HealthPort:     8080,
+		PrometheusPort: 9090,
 	}
 }
 
@@ -366,7 +367,7 @@ func TestConfigMapShouldDeserializeAsYAML(t *testing.T) {
 	collector := ingest["collector"].(map[interface{}]interface{})
 	assert.Equal(flp.Port, int32(collector["port"].(int)))
 
-	lokiCfg := parameters[4].(map[interface{}]interface{})["write"].(map[interface{}]interface{})["loki"].(map[interface{}]interface{})
+	lokiCfg := parameters[3].(map[interface{}]interface{})["write"].(map[interface{}]interface{})["loki"].(map[interface{}]interface{})
 	assert.Equal(loki.URL, lokiCfg["url"])
 	assert.Equal(loki.BatchWait.Duration.String(), lokiCfg["batchWait"])
 	assert.Equal(loki.MinBackoff.Duration.String(), lokiCfg["minBackoff"])
@@ -375,6 +376,11 @@ func TestConfigMapShouldDeserializeAsYAML(t *testing.T) {
 	assert.EqualValues(loki.BatchSize, lokiCfg["batchSize"])
 	assert.EqualValues([]interface{}{"SrcK8S_Namespace", "SrcK8S_OwnerName", "DstK8S_Namespace", "DstK8S_OwnerName", "FlowDirection"}, lokiCfg["labels"])
 	assert.Equal(fmt.Sprintf("%v", loki.StaticLabels), fmt.Sprintf("%v", lokiCfg["staticLabels"]))
+
+	encode := parameters[5].(map[interface{}]interface{})["encode"].(map[interface{}]interface{})
+	prom := encode["prom"].(map[interface{}]interface{})
+	assert.Equal(flp.PrometheusPort, int32(prom["port"].(int)))
+
 }
 
 func TestAutoScalerUpdateCheck(t *testing.T) {

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -1292,7 +1292,7 @@ EBPF contains the settings of an eBPF-based flow reporter. This section should n
         <td><b>env</b></td>
         <td>map[string]string</td>
         <td>
-          Env allows passing custom environment variables to the NetObserv Agent. Useful for passing some very concrete performance-tuning options (e.g. GOGC, GOMAXPROX) that shouldn't be publicly exposed as part of the FlowCollector descriptor, as they are only useful in very concrete debug/support scenarios.<br/>
+          Env allows passing custom environment variables to the NetObserv Agent. Useful for passing some very concrete performance-tuning options (e.g. GOGC, GOMAXPROCS) that shouldn't be publicly exposed as part of the FlowCollector descriptor, as they are only useful in edge debug/support scenarios.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1486,6 +1486,18 @@ FlowlogsPipeline contains settings related to the flowlogs-pipeline component
             <i>Format</i>: int32<br/>
             <i>Default</i>: 2055<br/>
             <i>Minimum</i>: 1025<br/>
+            <i>Maximum</i>: 65535<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>prometheusPort</b></td>
+        <td>integer</td>
+        <td>
+          PrometheusPort is the prometheus HTTP port: this port exposes prometheus metrics<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+            <i>Default</i>: 9090<br/>
+            <i>Minimum</i>: 1<br/>
             <i>Maximum</i>: 65535<br/>
         </td>
         <td>false</td>


### PR DESCRIPTION
Use on each of the FLP instances: http://localhost:90990/metrics
For example::
```
1000650000@flowlogs-pipeline-hpjn4:/$ curl localhost:9090/metrics | grep "ingest_collector_flow_logs_processed"
# HELP ingest_collector_flow_logs_processed Number of log lines (flow logs) processed
# TYPE ingest_collector_flow_logs_processed counter
ingest_collector_flow_logs_processed 2899
```

We see that we processed 2899 from the point in time we started the pod