### PR TITLE
NETOBSERV-304: fix update reconciliation of eBPF agent

### DIFF
--- a/config/samples/flows_v1alpha1_flowcollector_ebpf.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector_ebpf.yaml
@@ -16,7 +16,7 @@ spec:
     buffersLength: 50
     logLevel: info
   flowlogsPipeline:
-    kind: Deployment
+    kind: DaemonSet
     replicas: 1
     port: 2055
     image: 'quay.io/netobserv/flowlogs-pipeline:latest'

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -19,6 +19,7 @@ import (
 	"github.com/netobserv/network-observability-operator/controllers/constants"
 	"github.com/netobserv/network-observability-operator/controllers/reconcilers"
 	"github.com/netobserv/network-observability-operator/pkg/helper"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 const (
@@ -230,13 +231,7 @@ func (c *AgentController) requiredAction(current, desired *v1.DaemonSet) reconci
 	if current == nil && desired != nil {
 		return actionCreate
 	}
-	dspec, cspec := &desired.Spec.Template.Spec, &current.Spec.Template.Spec
-	equal := helper.IsSubSet(current.ObjectMeta.Labels, desired.ObjectMeta.Labels) &&
-		dspec.ServiceAccountName == cspec.ServiceAccountName &&
-		dspec.HostNetwork == cspec.HostNetwork &&
-		dspec.DNSPolicy == cspec.DNSPolicy &&
-		len(dspec.Containers) == len(cspec.Containers)
-	if equal {
+	if equality.Semantic.DeepDerivative(&desired.Spec, current.Spec) {
 		return actionNone
 	}
 	return actionUpdate


### PR DESCRIPTION
replaces manual comparison of fields by `equality.Semantic.DeepDerivative`, which skips fields of the "actual" state that are not in the "desired" state (e.g. these fields that are added by Kubernetes as metadata)