### PR TITLE
NETOBSERV-308: fix vanilla kubernetes deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,12 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # Image building tool (docker / podman)
+ifndef OCI_BIN
 ifeq (,$(shell which podman 2>/dev/null))
 OCI_BIN=docker
 else
 OCI_BIN=podman
+endif
 endif
 
 DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -137,6 +137,8 @@ rules:
   - create
   - delete
   - get
+  - list
+  - watch
 - apiGroups:
   - security.openshift.io
   resources:

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	flowsv1alpha1 "github.com/netobserv/network-observability-operator/api/v1alpha1"
@@ -129,7 +130,6 @@ func (c *AgentController) desired(coll *flowsv1alpha1.FlowCollector) *v1.DaemonS
 	if coll == nil || coll.Spec.Agent != flowsv1alpha1.AgentEBPF {
 		return nil
 	}
-	trueVal := true
 	version := helper.ExtractVersion(coll.Spec.EBPF.Image)
 	return &v1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -159,7 +159,8 @@ func (c *AgentController) desired(coll *flowsv1alpha1.FlowCollector) *v1.DaemonS
 						Resources:       coll.Spec.EBPF.Resources,
 						// TODO: other parameters when NETOBSERV-201 is implemented
 						SecurityContext: &corev1.SecurityContext{
-							Privileged: &trueVal,
+							Privileged: pointer.Bool(true),
+							RunAsUser:  pointer.Int64(0),
 						},
 						Env: c.envConfig(coll),
 					}},

--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -52,7 +52,7 @@ func NewFlowCollectorReconciler(client client.Client, scheme *runtime.Scheme) *F
 
 //+kubebuilder:rbac:groups=apps,resources=deployments;daemonsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=namespaces;services;serviceaccounts;configmaps,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;create;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;create;delete;watch;list
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;create;delete;update;watch
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;create;delete;update;patch;list
 //+kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;update;list;update;watch

--- a/controllers/flowcollector_controller_console_test.go
+++ b/controllers/flowcollector_controller_console_test.go
@@ -11,10 +11,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 
 	flowsv1alpha1 "github.com/netobserv/network-observability-operator/api/v1alpha1"
 	. "github.com/netobserv/network-observability-operator/controllers/controllerstest"
-	"github.com/netobserv/network-observability-operator/pkg/helper"
 )
 
 // Because the simulated Kube server doesn't manage automatic resource cleanup like an actual Kube would do,
@@ -78,7 +78,7 @@ func flowCollectorConsolePluginSpecs() {
 						Image:           "testimg:latest",
 						Register:        true,
 						HPA: &flowsv1alpha1.FlowCollectorHPA{
-							MinReplicas: helper.Int32Ptr(1),
+							MinReplicas: pointer.Int32(1),
 							MaxReplicas: 1,
 							Metrics: []ascv2.MetricSpec{{
 								Type: ascv2.ResourceMetricSourceType,
@@ -86,7 +86,7 @@ func flowCollectorConsolePluginSpecs() {
 									Name: v1.ResourceCPU,
 									Target: ascv2.MetricTarget{
 										Type:               ascv2.UtilizationMetricType,
-										AverageUtilization: helper.Int32Ptr(90),
+										AverageUtilization: pointer.Int32(90),
 									},
 								},
 							}},

--- a/controllers/flowcollector_controller_ebpf_test.go
+++ b/controllers/flowcollector_controller_ebpf_test.go
@@ -81,6 +81,8 @@ func flowCollectorEBPFSpecs() {
 			Expect(len(spec.Containers)).To(Equal(1))
 			Expect(spec.Containers[0].SecurityContext.Privileged).To(Not(BeNil()))
 			Expect(*spec.Containers[0].SecurityContext.Privileged).To(BeTrue())
+			Expect(spec.Containers[0].SecurityContext.RunAsUser).To(Not(BeNil()))
+			Expect(*spec.Containers[0].SecurityContext.RunAsUser).To(Equal(int64(0)))
 			Expect(spec.Containers[0].Env).To(ContainElements(
 				v1.EnvVar{Name: "CACHE_ACTIVE_TIMEOUT", Value: "15s"},
 				v1.EnvVar{Name: "CACHE_MAX_FLOWS", Value: "100"},

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -12,6 +12,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 
 	flowsv1alpha1 "github.com/netobserv/network-observability-operator/api/v1alpha1"
 	"github.com/netobserv/network-observability-operator/controllers/constants"
@@ -84,7 +85,7 @@ func flowCollectorControllerSpecs() {
 						LogLevel:        "error",
 						Image:           "testimg:latest",
 						HPA: &flowsv1alpha1.FlowCollectorHPA{
-							MinReplicas: helper.Int32Ptr(1),
+							MinReplicas: pointer.Int32(1),
 							MaxReplicas: 1,
 							Metrics: []ascv2.MetricSpec{{
 								Type: ascv2.ResourceMetricSourceType,
@@ -92,7 +93,7 @@ func flowCollectorControllerSpecs() {
 									Name: v1.ResourceCPU,
 									Target: ascv2.MetricTarget{
 										Type:               ascv2.UtilizationMetricType,
-										AverageUtilization: helper.Int32Ptr(90),
+										AverageUtilization: pointer.Int32(90),
 									},
 								},
 							}},
@@ -107,7 +108,7 @@ func flowCollectorControllerSpecs() {
 						ImagePullPolicy: "Never",
 						Image:           "testimg:latest",
 						HPA: &flowsv1alpha1.FlowCollectorHPA{
-							MinReplicas: helper.Int32Ptr(1),
+							MinReplicas: pointer.Int32(1),
 							MaxReplicas: 1,
 							Metrics: []ascv2.MetricSpec{{
 								Type: ascv2.ResourceMetricSourceType,
@@ -115,7 +116,7 @@ func flowCollectorControllerSpecs() {
 									Name: v1.ResourceCPU,
 									Target: ascv2.MetricTarget{
 										Type:               ascv2.UtilizationMetricType,
-										AverageUtilization: helper.Int32Ptr(90),
+										AverageUtilization: pointer.Int32(90),
 									},
 								},
 							}},
@@ -258,7 +259,7 @@ func flowCollectorControllerSpecs() {
 			// update FlowCollector and verify that HPA spec also changed
 			fc := flowsv1alpha1.FlowCollector{}
 			Expect(k8sClient.Get(ctx, crKey, &fc)).To(Succeed())
-			fc.Spec.FlowlogsPipeline.HPA.MinReplicas = helper.Int32Ptr(2)
+			fc.Spec.FlowlogsPipeline.HPA.MinReplicas = pointer.Int32(2)
 			fc.Spec.FlowlogsPipeline.HPA.MaxReplicas = 2
 			Expect(k8sClient.Update(ctx, &fc)).To(Succeed())
 

--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
 	k8s.io/kube-aggregator v0.23.5
+	k8s.io/utils v0.0.0-20211116205334-6203023598ed
 	sigs.k8s.io/controller-runtime v0.11.0
 )

--- a/pkg/helper/testhelpers.go
+++ b/pkg/helper/testhelpers.go
@@ -17,7 +17,3 @@ func (am AsyncJSON) String() string {
 	}
 	return string(bytes)
 }
-
-func Int32Ptr(v int32) *int32 {
-	return &v
-}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -488,6 +488,7 @@ k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
 k8s.io/kube-openapi/pkg/schemaconv
 k8s.io/kube-openapi/pkg/util/proto
 # k8s.io/utils v0.0.0-20211116205334-6203023598ed
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/clock
 k8s.io/utils/clock/testing


### PR DESCRIPTION
* Adds list and watch permissions for cluster roles, which seem to be implicit in OpenShift but required in K8s.
* Configure securityContext with `runAsUser: 0` option to force execution as root (might change when we disable privileged container and use only capabilities).
* Extra: remove redundant `Int32Ptr` function (there was already a K8s utility providing it).