### PR TITLE
NETOBSERV-307: eBPF agent running with capabilities instead of full privileges

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -154,6 +154,12 @@ type FlowCollectorEBPF struct {
 	// in edge debug/support scenarios.
 	//+optional
 	Env map[string]string `json:"env,omitempty"`
+
+	// Privileged mode for the eBPF Agent container. If false, the operator will add the following
+	// capabilities to the container, to enable its correct operation:
+	// BPF, PERFMON, NET_ADMIN, SYS_RESOURCE.
+	// +optional
+	Privileged bool `json:"privileged,omitempty"`
 }
 
 // FlowCollectorFLP defines the desired flowlogs-pipeline state of FlowCollector

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -755,6 +755,12 @@ spec:
                     - fatal
                     - panic
                     type: string
+                  privileged:
+                    description: 'Privileged mode for the eBPF Agent container. If
+                      false, the operator will add the following capabilities to the
+                      container, to enable its correct operation: BPF, PERFMON, NET_ADMIN,
+                      SYS_RESOURCE.'
+                    type: boolean
                   resources:
                     description: 'Compute Resources required by this container. Cannot
                       be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -18,6 +18,7 @@ spec:
     interfaces: []
     excludeInterfaces: ["lo"]
     logLevel: info
+    privileged: false
   flowlogsPipeline:
     kind: DaemonSet
 #    kind: Deployment

--- a/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
@@ -18,6 +18,7 @@ spec:
     interfaces: []
     excludeInterfaces: ["lo"]
     logLevel: info
+    privileged: false
   flowlogsPipeline:
     kind: DaemonSet
 #    kind: Deployment

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -1355,6 +1355,13 @@ EBPF contains the settings of an eBPF-based flow reporter  when the "agent" prop
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>privileged</b></td>
+        <td>boolean</td>
+        <td>
+          Privileged mode for the eBPF Agent container. If false, the operator will add the following capabilities to the container, to enable its correct operation: BPF, PERFMON, NET_ADMIN, SYS_RESOURCE.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#flowcollectorspecebpfresources">resources</a></b></td>
         <td>object</td>
         <td>


### PR DESCRIPTION
It also allows configuring the agent to run with full capabilities as a fallback option for some Kubernetes distributions that do not recognize the `BPF` and `PERFMON` capabilities (documented here https://github.com/netobserv/netobserv-ebpf-agent/pull/23)