### PR TITLE
Console plugin annotation

### DIFF
--- a/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
@@ -9,6 +9,7 @@ metadata:
     createdAt: ':created-at:'
     description: A network observability operator based on netflows (IPFIX) for OVN
     repository: https://github.com/netobserv/network-observability-operator
+    console.openshift.io/plugins: '["network-observability-plugin"]'
   name: netobserv-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
Missing `console.openshift.io/plugins` annotation

> An operator can also give console a hint that it has a plugin available through the console.openshift.io/plugins annotations. The annotation tells the console to show a checkbox to enable plugins during operator install. Only users who can edit the console operator config will see the checkbox. The annotation value is a serialized JSON array of strings, where each item is the name of a ConsolePlugin resource the operator will create.
https://github.com/openshift/enhancements/blob/master/enhancements/console/dynamic-plugins.md#delivering-plugins