### PR TITLE
NETOBSERV-265 and NETOBSERV-348 timestamp indexing

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -283,10 +283,6 @@ type FlowCollectorLoki struct {
 	//+kubebuilder:default:={"app":"netobserv-flowcollector"}
 	// StaticLabels is a map of common labels to set on each flow
 	StaticLabels map[string]string `json:"staticLabels,omitempty"`
-
-	//+kubebuilder:default:="TimeFlowEnd"
-	// TimestampLabel is the label to use for time indexing in Loki. E.g. "TimeReceived", "TimeFlowStart", "TimeFlowEnd".
-	TimestampLabel string `json:"timestampLabel,omitempty"`
 }
 
 // FlowCollectorConsolePlugin defines the desired ConsolePlugin state of FlowCollector

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -1501,11 +1501,6 @@ spec:
                     description: Timeout is the maximum time connection / request
                       limit A Timeout of zero means no timeout.
                     type: string
-                  timestampLabel:
-                    default: TimeFlowEnd
-                    description: TimestampLabel is the label to use for time indexing
-                      in Loki. E.g. "TimeReceived", "TimeFlowStart", "TimeFlowEnd".
-                    type: string
                   url:
                     default: http://loki:3100/
                     description: URL is the address of an existing Loki service to

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -37,7 +37,6 @@ spec:
     minBackoff: 1s
     maxBackoff: 300s
     maxRetries: 10
-    timestampLabel: TimeFlowEnd
     staticLabels:
       app: netobserv-flowcollector
   consolePlugin:

--- a/controllers/flowlogspipeline/flp_objects.go
+++ b/controllers/flowlogspipeline/flp_objects.go
@@ -201,7 +201,8 @@ func (b *builder) configMap() (*corev1.ConfigMap, string) {
 		lokiWrite["staticLabels"] = b.desiredLoki.StaticLabels
 		lokiWrite["timeout"] = b.desiredLoki.Timeout.ToUnstructured()
 		lokiWrite["url"] = b.desiredLoki.URL
-		lokiWrite["timestampLabel"] = b.desiredLoki.TimestampLabel
+		lokiWrite["timestampLabel"] = "TimeFlowEndMs"
+		lokiWrite["timestampScale"] = "1ms"
 	}
 
 	loki = map[string]interface{}{"name": "loki",

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -2631,15 +2631,6 @@ Loki contains settings related to the loki client
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>timestampLabel</b></td>
-        <td>string</td>
-        <td>
-          TimestampLabel is the label to use for time indexing in Loki. E.g. "TimeReceived", "TimeFlowStart", "TimeFlowEnd".<br/>
-          <br/>
-            <i>Default</i>: TimeFlowEnd<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b>url</b></td>
         <td>string</td>
         <td>


### PR DESCRIPTION
As a result to using millisecond-based time fields (TimeFlowEndMs,
TimeFlowStartMs), we also need to change the time indexed field to keep
consistent queries (TimeFlowEnd => TimeFlowEndMs)

Take that opportunity to stop exposing this as a config, as it could
create troubles