### PR TITLE
Removed goflow references

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ If you use OpenShift 4.10, you don't have anything to do: the operator will conf
 ### With upstream ovn-kubernetes (e.g. using KIND)
 
 ```bash
-GF_IP=`kubectl get svc flowlogs-pipeline -n network-observability -ojsonpath='{.spec.clusterIP}'` && echo $GF_IP
-kubectl set env daemonset/ovnkube-node -c ovnkube-node -n ovn-kubernetes OVN_IPFIX_TARGETS="$GF_IP:2055"
+FLP_IP=`kubectl get svc flowlogs-pipeline -n network-observability -ojsonpath='{.spec.clusterIP}'` && echo $FLP_IP
+kubectl set env daemonset/ovnkube-node -c ovnkube-node -n ovn-kubernetes OVN_IPFIX_TARGETS="$FLP_IP:2055"
 ```
 
 ### On older OpenShift with OVN-Kubernetes CNI
@@ -126,8 +126,8 @@ kubectl set env daemonset/ovnkube-node -c ovnkube-node -n ovn-kubernetes OVN_IPF
 In OpenShift, a difference with the upstream `ovn-kubernetes` is that the flows export config is managed by the `ClusterNetworkOperator`.
 
 ```bash
-GF_IP=`oc get svc flowlogs-pipeline -n network-observability -ojsonpath='{.spec.clusterIP}'` && echo $GF_IP
-oc patch networks.operator.openshift.io cluster --type='json' -p "[{'op': 'add', 'path': '/spec', 'value': {'exportNetworkFlows': {'ipfix': { 'collectors': ['$GF_IP:2055']}}}}]"
+FLP_IP=`oc get svc flowlogs-pipeline -n network-observability -ojsonpath='{.spec.clusterIP}'` && echo $FLP_IP
+oc patch networks.operator.openshift.io cluster --type='json' -p "[{'op': 'add', 'path': '/spec', 'value': {'exportNetworkFlows': {'ipfix': { 'collectors': ['$FLP_IP:2055']}}}}]"
 ```
 
 ## Installing Loki
@@ -158,7 +158,7 @@ oc patch console.operator.openshift.io cluster --type='json' -p '[{"op": "add", 
 The plugin provides new views in the OpenShift Console: a new submenu _Network Traffic_ in _Observe_, and new tabs in several details views (Pods, Deployments, Services...).
 
 ![Main view](./docs/assets/network-traffic-main.png)
-_Main view_ 
+_Main view_
 
 ![Pod traffic](./docs/assets/network-traffic-pod.png)
 _Pod traffic_

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -121,8 +121,8 @@ spec:
     You need to explicitly turn on IPFIX export for the `ClusterNetworkOperator`:
 
     ```
-    GF_IP=`oc get svc flowlogs-pipeline -n network-observability -ojsonpath='{.spec.clusterIP}'` && echo $GF_IP
-    oc patch networks.operator.openshift.io cluster --type='json' -p "[{'op': 'add', 'path': '/spec', 'value': {'exportNetworkFlows': {'ipfix': { 'collectors': ['$GF_IP:2055']}}}}]"
+    FLP_IP=`oc get svc flowlogs-pipeline -n network-observability -ojsonpath='{.spec.clusterIP}'` && echo $FLP_IP
+    oc patch networks.operator.openshift.io cluster --type='json' -p "[{'op': 'add', 'path': '/spec', 'value': {'exportNetworkFlows': {'ipfix': { 'collectors': ['$FLP_IP:2055']}}}}]"
     ```
     To turn it off, remove the `exportNetworkFlows` from `networks.operator.openshift.io/cluster`.
 
@@ -130,8 +130,8 @@ spec:
     You need to explicitly turn on IPFIX export in ovn-kubernetes:
 
     ```
-    GF_IP=`kubectl get svc flowlogs-pipeline -n network-observability -ojsonpath='{.spec.clusterIP}'` && echo $GF_IP
-    kubectl set env daemonset/ovnkube-node -c ovnkube-node -n ovn-kubernetes OVN_IPFIX_TARGETS="$GF_IP:2055"
+    FLP_IP=`kubectl get svc flowlogs-pipeline -n network-observability -ojsonpath='{.spec.clusterIP}'` && echo $FLP_IP
+    kubectl set env daemonset/ovnkube-node -c ovnkube-node -n ovn-kubernetes OVN_IPFIX_TARGETS="$FLP_IP:2055"
     ```
 
     To turn it off, remove the `OVN_IPFIX_TARGETS` env from `daemonset/ovnkube-node`.

--- a/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
@@ -52,8 +52,8 @@ spec:
     You need to explicitly turn on IPFIX export for the `ClusterNetworkOperator`:
 
     ```
-    GF_IP=`oc get svc flowlogs-pipeline -n network-observability -ojsonpath='{.spec.clusterIP}'` && echo $GF_IP
-    oc patch networks.operator.openshift.io cluster --type='json' -p "[{'op': 'add', 'path': '/spec', 'value': {'exportNetworkFlows': {'ipfix': { 'collectors': ['$GF_IP:2055']}}}}]"
+    FLP_IP=`oc get svc flowlogs-pipeline -n network-observability -ojsonpath='{.spec.clusterIP}'` && echo $FLP_IP
+    oc patch networks.operator.openshift.io cluster --type='json' -p "[{'op': 'add', 'path': '/spec', 'value': {'exportNetworkFlows': {'ipfix': { 'collectors': ['$FLP_IP:2055']}}}}]"
     ```
     To turn it off, remove the `exportNetworkFlows` from `networks.operator.openshift.io/cluster`.
 
@@ -61,8 +61,8 @@ spec:
     You need to explicitly turn on IPFIX export in ovn-kubernetes:
 
     ```
-    GF_IP=`kubectl get svc flowlogs-pipeline -n network-observability -ojsonpath='{.spec.clusterIP}'` && echo $GF_IP
-    kubectl set env daemonset/ovnkube-node -c ovnkube-node -n ovn-kubernetes OVN_IPFIX_TARGETS="$GF_IP:2055"
+    FLP_IP=`kubectl get svc flowlogs-pipeline -n network-observability -ojsonpath='{.spec.clusterIP}'` && echo $FLP_IP
+    kubectl set env daemonset/ovnkube-node -c ovnkube-node -n ovn-kubernetes OVN_IPFIX_TARGETS="$FLP_IP:2055"
     ```
 
     To turn it off, remove the `OVN_IPFIX_TARGETS` env from `daemonset/ovnkube-node`.

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -39,19 +39,19 @@ func flowCollectorControllerSpecs() {
 		Name:      "ovs-flows-config",
 		Namespace: "openshift-network-operator",
 	}
-	gfKey1 := types.NamespacedName{
+	flpKey1 := types.NamespacedName{
 		Name:      constants.FLPName,
 		Namespace: operatorNamespace,
 	}
-	gfKey2 := types.NamespacedName{
+	flpKey2 := types.NamespacedName{
 		Name:      constants.FLPName,
 		Namespace: otherNamespace,
 	}
-	gfKeyKafkaIngester := types.NamespacedName{
+	flpKeyKafkaIngester := types.NamespacedName{
 		Name:      constants.FLPName + flowlogspipeline.FlpConfSuffix[flowlogspipeline.ConfKafkaIngester],
 		Namespace: operatorNamespace,
 	}
-	gfKeyKafkaTransformer := types.NamespacedName{
+	flpKeyKafkaTransformer := types.NamespacedName{
 		Name:      constants.FLPName + flowlogspipeline.FlpConfSuffix[flowlogspipeline.ConfKafkaTransformer],
 		Namespace: operatorNamespace,
 	}
@@ -145,7 +145,7 @@ func flowCollectorControllerSpecs() {
 			By("Expecting to create the flowlogs-pipeline Deployment")
 			Eventually(func() interface{} {
 				dp := appsv1.Deployment{}
-				if err := k8sClient.Get(ctx, gfKey1, &dp); err != nil {
+				if err := k8sClient.Get(ctx, flpKey1, &dp); err != nil {
 					return err
 				}
 				oldDigest = dp.Spec.Template.Annotations[flowlogspipeline.PodConfigurationDigest]
@@ -159,7 +159,7 @@ func flowCollectorControllerSpecs() {
 			svc := v1.Service{}
 			By("Expecting to create the flowlogs-pipeline Service")
 			Eventually(func() interface{} {
-				if err := k8sClient.Get(ctx, gfKey1, &svc); err != nil {
+				if err := k8sClient.Get(ctx, flpKey1, &svc); err != nil {
 					return err
 				}
 				return svc
@@ -174,7 +174,7 @@ func flowCollectorControllerSpecs() {
 			By("Expecting to create the flowlogs-pipeline ServiceAccount")
 			Eventually(func() interface{} {
 				svcAcc := v1.ServiceAccount{}
-				if err := k8sClient.Get(ctx, gfKey1, &svcAcc); err != nil {
+				if err := k8sClient.Get(ctx, flpKey1, &svcAcc); err != nil {
 					return err
 				}
 				return svcAcc
@@ -212,7 +212,7 @@ func flowCollectorControllerSpecs() {
 			By("Expecting updated flowlogs-pipeline Service port")
 			Eventually(func() interface{} {
 				svc := v1.Service{}
-				if err := k8sClient.Get(ctx, gfKey1, &svc); err != nil {
+				if err := k8sClient.Get(ctx, flpKey1, &svc); err != nil {
 					return err
 				}
 				return svc.Spec.Ports[0].Port
@@ -246,7 +246,7 @@ func flowCollectorControllerSpecs() {
 			By("Expecting that the flowlogsPipeline.PodConfigurationDigest attribute has changed")
 			Eventually(func() error {
 				dp := appsv1.Deployment{}
-				if err := k8sClient.Get(ctx, gfKey1, &dp); err != nil {
+				if err := k8sClient.Get(ctx, flpKey1, &dp); err != nil {
 					return err
 				}
 				currentConfigDigest := dp.Spec.Template.Annotations[flowlogspipeline.PodConfigurationDigest]
@@ -260,7 +260,7 @@ func flowCollectorControllerSpecs() {
 
 		It("Should autoscale when the HPA options change", func() {
 			hpa := ascv2.HorizontalPodAutoscaler{}
-			Expect(k8sClient.Get(ctx, gfKey1, &hpa)).To(Succeed())
+			Expect(k8sClient.Get(ctx, flpKey1, &hpa)).To(Succeed())
 			Expect(*hpa.Spec.MinReplicas).To(Equal(int32(1)))
 			Expect(hpa.Spec.MaxReplicas).To(Equal(int32(1)))
 			Expect(*hpa.Spec.Metrics[0].Resource.Target.AverageUtilization).To(Equal(int32(90)))
@@ -273,7 +273,7 @@ func flowCollectorControllerSpecs() {
 
 			By("Changing the Horizontal Pod Autoscaler instance")
 			Eventually(func() error {
-				if err := k8sClient.Get(ctx, gfKey1, &hpa); err != nil {
+				if err := k8sClient.Get(ctx, flpKey1, &hpa); err != nil {
 					return err
 				}
 				if *hpa.Spec.MinReplicas != int32(2) || hpa.Spec.MaxReplicas != int32(2) ||
@@ -321,7 +321,7 @@ func flowCollectorControllerSpecs() {
 			}))
 
 			ds := appsv1.DaemonSet{}
-			Expect(k8sClient.Get(ctx, gfKey1, &ds)).To(Succeed())
+			Expect(k8sClient.Get(ctx, flpKey1, &ds)).To(Succeed())
 
 			oldConfigDigest = ds.Spec.Template.Annotations[flowlogspipeline.PodConfigurationDigest]
 			Expect(oldConfigDigest).ToNot(BeEmpty())
@@ -370,7 +370,7 @@ func flowCollectorControllerSpecs() {
 			By("Expecting that the flowlogsPipeline.PodConfigurationDigest attribute has changed")
 			Eventually(func() error {
 				dp := appsv1.DaemonSet{}
-				if err := k8sClient.Get(ctx, gfKey1, &dp); err != nil {
+				if err := k8sClient.Get(ctx, flpKey1, &dp); err != nil {
 					return err
 				}
 				currentConfigDigest := dp.Spec.Template.Annotations[flowlogspipeline.PodConfigurationDigest]
@@ -398,24 +398,24 @@ func flowCollectorControllerSpecs() {
 		It("Should deploy kafka ingester and transformer", func() {
 			By("Expecting ingester daemonset to be created")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKeyKafkaIngester, &appsv1.DaemonSet{})
+				return k8sClient.Get(ctx, flpKeyKafkaIngester, &appsv1.DaemonSet{})
 			}, timeout, interval).Should(Succeed())
 
 			By("Expecting transformer deployment to be created")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKeyKafkaTransformer, &appsv1.Deployment{})
+				return k8sClient.Get(ctx, flpKeyKafkaTransformer, &appsv1.Deployment{})
 			}, timeout, interval).Should(Succeed())
 
 			By("Not Expecting transformer service to be created")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKeyKafkaTransformer, &v1.Service{})
+				return k8sClient.Get(ctx, flpKeyKafkaTransformer, &v1.Service{})
 			}, timeout, interval).Should(MatchError(`services "flowlogs-pipeline-transformer" not found`))
 		})
 
 		It("Should delete previous flp deployment", func() {
 			By("Expecting deployment to be deleted")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKey1, &appsv1.DaemonSet{})
+				return k8sClient.Get(ctx, flpKey1, &appsv1.DaemonSet{})
 			}, timeout, interval).Should(MatchError(`daemonsets.apps "flowlogs-pipeline" not found`))
 		})
 
@@ -433,19 +433,19 @@ func flowCollectorControllerSpecs() {
 		It("Should deploy single flp again", func() {
 			By("Expecting daemonset to be created")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKey1, &appsv1.DaemonSet{})
+				return k8sClient.Get(ctx, flpKey1, &appsv1.DaemonSet{})
 			}, timeout, interval).Should(Succeed())
 		})
 
 		It("Should delete kafka ingester and transformer", func() {
 			By("Expecting ingester daemonset to be deleted")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKeyKafkaIngester, &appsv1.DaemonSet{})
+				return k8sClient.Get(ctx, flpKeyKafkaIngester, &appsv1.DaemonSet{})
 			}, timeout, interval).Should(MatchError(`daemonsets.apps "flowlogs-pipeline-ingester" not found`))
 
 			By("Expecting transformer deployment to be deleted")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKeyKafkaTransformer, &appsv1.Deployment{})
+				return k8sClient.Get(ctx, flpKeyKafkaTransformer, &appsv1.Deployment{})
 			}, timeout, interval).Should(MatchError(`deployments.apps "flowlogs-pipeline-transformer" not found`))
 		})
 
@@ -471,37 +471,37 @@ func flowCollectorControllerSpecs() {
 		It("Should redeploy goglow-kube in new namespace", func() {
 			By("Expecting daemonset in previous namespace to be deleted")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKey1, &appsv1.DaemonSet{})
+				return k8sClient.Get(ctx, flpKey1, &appsv1.DaemonSet{})
 			}, timeout, interval).Should(MatchError(`daemonsets.apps "flowlogs-pipeline" not found`))
 
 			By("Expecting deployment in previous namespace to be deleted")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKey1, &appsv1.Deployment{})
+				return k8sClient.Get(ctx, flpKey1, &appsv1.Deployment{})
 			}, timeout, interval).Should(MatchError(`deployments.apps "flowlogs-pipeline" not found`))
 
 			By("Expecting service in previous namespace to be deleted")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKey1, &v1.Service{})
+				return k8sClient.Get(ctx, flpKey1, &v1.Service{})
 			}, timeout, interval).Should(MatchError(`services "flowlogs-pipeline" not found`))
 
 			By("Expecting service account in previous namespace to be deleted")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKey1, &v1.ServiceAccount{})
+				return k8sClient.Get(ctx, flpKey1, &v1.ServiceAccount{})
 			}, timeout, interval).Should(MatchError(`serviceaccounts "flowlogs-pipeline" not found`))
 
 			By("Expecting deployment to be created in new namespace")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKey2, &appsv1.Deployment{})
+				return k8sClient.Get(ctx, flpKey2, &appsv1.Deployment{})
 			}, timeout, interval).Should(Succeed())
 
 			By("Expecting service to be created in new namespace")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKey2, &v1.Service{})
+				return k8sClient.Get(ctx, flpKey2, &v1.Service{})
 			}, timeout, interval).Should(Succeed())
 
 			By("Expecting service account to be created in new namespace")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, gfKey2, &v1.ServiceAccount{})
+				return k8sClient.Get(ctx, flpKey2, &v1.ServiceAccount{})
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -572,21 +572,21 @@ func flowCollectorControllerSpecs() {
 			By("Expecting flowlogs-pipeline deployment to be garbage collected")
 			Eventually(func() interface{} {
 				d := appsv1.Deployment{}
-				_ = k8sClient.Get(ctx, gfKey2, &d)
+				_ = k8sClient.Get(ctx, flpKey2, &d)
 				return &d
 			}, timeout, interval).Should(BeGarbageCollectedBy(&flowCR))
 
 			By("Expecting flowlogs-pipeline service to be garbage collected")
 			Eventually(func() interface{} {
 				svc := v1.Service{}
-				_ = k8sClient.Get(ctx, gfKey2, &svc)
+				_ = k8sClient.Get(ctx, flpKey2, &svc)
 				return &svc
 			}, timeout, interval).Should(BeGarbageCollectedBy(&flowCR))
 
 			By("Expecting flowlogs-pipeline service account to be garbage collected")
 			Eventually(func() interface{} {
 				svcAcc := v1.ServiceAccount{}
-				_ = k8sClient.Get(ctx, gfKey2, &svcAcc)
+				_ = k8sClient.Get(ctx, flpKey2, &svcAcc)
 				return &svcAcc
 			}, timeout, interval).Should(BeGarbageCollectedBy(&flowCR))
 

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -413,8 +413,8 @@ func TestAutoScalerUpdateCheck(t *testing.T) {
 func TestLabels(t *testing.T) {
 	assert := assert.New(t)
 
-	gfk := getFLPConfig()
-	builder := newBuilder("ns", corev1.ProtocolUDP, &gfk, nil, ConfSingle)
+	flpk := getFLPConfig()
+	builder := newBuilder("ns", corev1.ProtocolUDP, &flpk, nil, ConfSingle)
 
 	// Deployment
 	depl := builder.deployment("digest")


### PR DESCRIPTION
I noticed this while working on kafka but did not want to overload the kafka PR.

We still have naming reference to goflow instead of flp, this PR change them.