### PR TITLE
NETOBSERV-365 Fix errors in operator logs

### DIFF
--- a/controllers/consoleplugin/consoleplugin_reconciler.go
+++ b/controllers/consoleplugin/consoleplugin_reconciler.go
@@ -63,7 +63,7 @@ func (r *CPReconciler) InitStaticResources(ctx context.Context) error {
 // PrepareNamespaceChange cleans up old namespace and restore the relevant "static" resources
 func (r *CPReconciler) PrepareNamespaceChange(ctx context.Context) error {
 	// Switching namespace => delete everything in the previous namespace
-	r.nobjMngr.CleanupNamespace(ctx)
+	r.nobjMngr.CleanupPreviousNamespace(ctx)
 	return r.CreateOwned(ctx, buildServiceAccount(r.nobjMngr.Namespace))
 }
 


### PR DESCRIPTION
The errors we see in the operator logs are due to trying to clean items from the previous namespace (in the case of a changing namespace), despite the context here is not a changing namespace.
So I just duplicated the cleanup function to allow cleaning the current namespace.