### PR TITLE
Remove netflow v5 load generator

### DIFF
--- a/.mk/local.mk
+++ b/.mk/local.mk
@@ -24,6 +24,7 @@ local-redeploy: clean-leftovers undeploy-all deploy-all  ## Local re-deploy (lok
 local-undeploy: clean-leftovers undeploy-all delete-kind-cluster  ## Local cleanup
 
 local-run: create-kind-cluster local-redeploy ## local-redeploy + run the operator locally
+# TODO: restore traffic generator, but using IPFIX instead of NFv5 (could be inspired from https://github.com/netobserv/flowlogs-pipeline/blob/main/pkg/test/ipfix.go)
 	@echo "====> Running the operator locally (in background process)"
 	go run ./main.go &
 	@echo "====> Waiting for flowlogs-pipeline pod to be ready"
@@ -31,10 +32,6 @@ local-run: create-kind-cluster local-redeploy ## local-redeploy + run the operat
 	kubectl wait --timeout=180s --for=condition=ready pod -l app=flowlogs-pipeline
 	@echo "====> Getting first pod in the demon-set"
 	first_pod=$$(kubectl get pods --selector=app=flowlogs-pipeline -o jsonpath='{.items[0].metadata.name}'); \
-	kubectl expose pod $$first_pod --name=flowlogs-pipeline-netflows --protocol=UDP --port=2056 --target-port=2056; \
-	echo "====> Sending simulated logs to pod $$first_pod exposed as service flowlogs-pipeline-netflows"
-	kubectl create deployment netflow-simulator --image=networkstatic/nflow-generator:latest -- /etc/nflow/nflow-generator --target=flowlogs-pipeline-netflows.network-observability.svc.cluster.local --port=2056 --spike=http
-	kubectl wait --timeout=180s --for=condition=ready pod -l app=netflow-simulator
 	@echo "====> Operator process info"
 	@PID=$$(pgrep --oldest --full "main.go"); echo -e "\n===> The operator is running in process $$PID\nTo stop the operator process use: pkill -p $$PID"
 	@echo "====> Done"


### PR DESCRIPTION
It was not officially supported by the operator, and now has been
removed from its config to avoid keeping unnecessary opened port