### PR TITLE
Move FLP log level in the example CR to error

### DIFF
--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -26,7 +26,7 @@ spec:
     port: 2055
     image: 'quay.io/netobserv/flowlogs-pipeline:main'
     imagePullPolicy: IfNotPresent
-    logLevel: info
+    logLevel: error
     enableKubeProbes: true
     healthPort: 8080
     prometheusPort: 9090

--- a/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
@@ -26,7 +26,7 @@ spec:
     port: 2055
     image: 'quay.io/netobserv/flowlogs-pipeline:v0.1.1'
     imagePullPolicy: IfNotPresent
-    logLevel: info
+    logLevel: error
     enableKubeProbes: true
     healthPort: 8080
     prometheusPort: 9090


### PR DESCRIPTION
No reason for the example CR's to be in info level for FLP. If needed this can be changed dynamically. To be able to use NOO similar to customers best is to use error level.