### PR TITLE
NETOBSERV-334 ebpf: flows are logged properly in FLP

### DIFF
--- a/controllers/flowlogspipeline/flp_objects.go
+++ b/controllers/flowlogspipeline/flp_objects.go
@@ -246,6 +246,11 @@ func (b *builder) addTransformStages(lastStage *config.PipelineBuilderStage) {
 	}
 	enrichedStage.WriteLoki("loki", lokiWrite)
 
+	// write on Stdout if logging trace enabled
+	if b.desired.LogLevel == "trace" {
+		enrichedStage.WriteStdout("stdout", api.WriteStdout{Format: "json"})
+	}
+
 	// prometheus stage (encode) configuration
 	agg := enrichedStage.Aggregate("aggregate", []api.AggregateDefinition{})
 	agg.EncodePrometheus("prometheus", api.PromEncode{


### PR DESCRIPTION
Wait for https://github.com/netobserv/flowlogs-pipeline/pull/226 before merge

This PR adds a `stdout` stage after enrichment when desired `logLevel` is `trace`