### PR TITLE
NETOBSERV-258: configure eBPF agent for Kafka

### DIFF
--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -32,7 +32,7 @@ spec:
     prometheusPort: 9090
   kafka:
     enable: false
-    address: "kafka-cluster-kafka-bootstrap"
+    address: "kafka-cluster-kafka-bootstrap.network-observability"
     topic: "network-flows"
   loki:
     url: 'http://loki:3100/'

--- a/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
@@ -30,6 +30,10 @@ spec:
     enableKubeProbes: true
     healthPort: 8080
     prometheusPort: 9090
+  kafka:
+    enable: false
+    address: "kafka-cluster-kafka-bootstrap.network-observability"
+    topic: "network-flows"
   loki:
     url: 'http://loki:3100/'
     batchWait: 1s
@@ -37,7 +41,6 @@ spec:
     minBackoff: 1s
     maxBackoff: 300s
     maxRetries: 10
-    timestampLabel: TimeFlowEnd
     staticLabels:
       app: netobserv-flowcollector
   consolePlugin:
@@ -52,3 +55,7 @@ spec:
         "3100": loki
   clusterNetworkOperator:
     namespace: "openshift-network-operator"
+  ovnKubernetes:
+    namespace: "ovn-kubernetes"
+    daemonSetName: "ovnkube-node"
+    containerName: "ovnkube-node"

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -460,27 +460,42 @@ func TestLabels(t *testing.T) {
 func TestDeployNeeded(t *testing.T) {
 	assert := assert.New(t)
 
-	kafka := flowsv1alpha1.FlowCollectorKafka{Enable: false, Address: "loaclhost:9092", Topic: "FLP"}
+	spec := flowsv1alpha1.FlowCollectorSpec{
+		Agent: "ipfix",
+		Kafka: flowsv1alpha1.FlowCollectorKafka{Enable: false, Address: "loaclhost:9092", Topic: "FLP"},
+	}
 	// Kafka not configured
-	res, err := checkDeployNeeded(kafka, ConfSingle)
+	res, err := checkDeployNeeded(&spec, ConfSingle)
 	assert.True(res)
 	assert.NoError(err)
-	res, err = checkDeployNeeded(kafka, ConfKafkaIngester)
+	res, err = checkDeployNeeded(&spec, ConfKafkaIngester)
 	assert.False(res)
 	assert.NoError(err)
-	res, err = checkDeployNeeded(kafka, ConfKafkaTransformer)
+	res, err = checkDeployNeeded(&spec, ConfKafkaTransformer)
 	assert.False(res)
 	assert.NoError(err)
 
 	// Kafka configured
-	kafka.Enable = true
-	res, err = checkDeployNeeded(kafka, ConfSingle)
+	spec.Kafka.Enable = true
+	res, err = checkDeployNeeded(&spec, ConfSingle)
 	assert.False(res)
 	assert.NoError(err)
-	res, err = checkDeployNeeded(kafka, ConfKafkaIngester)
+	res, err = checkDeployNeeded(&spec, ConfKafkaIngester)
 	assert.True(res)
 	assert.NoError(err)
-	res, err = checkDeployNeeded(kafka, ConfKafkaTransformer)
+	res, err = checkDeployNeeded(&spec, ConfKafkaTransformer)
+	assert.True(res)
+	assert.NoError(err)
+
+	// Kafka + eBPF agent configured
+	spec.Agent = "ebpf"
+	res, err = checkDeployNeeded(&spec, ConfSingle)
+	assert.False(res)
+	assert.NoError(err)
+	res, err = checkDeployNeeded(&spec, ConfKafkaIngester)
+	assert.False(res)
+	assert.NoError(err)
+	res, err = checkDeployNeeded(&spec, ConfKafkaTransformer)
 	assert.True(res)
 	assert.NoError(err)
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -69,6 +69,7 @@ var _ = Describe("FlowCollector Controller", Ordered, Serial, func() {
 	flowCollectorControllerSpecs()
 	flowCollectorConsolePluginSpecs()
 	flowCollectorEBPFSpecs()
+	flowCollectorEBPFKafkaSpecs()
 })
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
This PR requires that the following PR is first merged: https://github.com/netobserv/netobserv-ebpf-agent/pull/33

When Kafka and the eBPF agent are set:

* It deploys the eBPF agent configured to export directly to kafka
* It does not deploy the flowlogs-processor-ingester daemonset.