### PR TITLE
Doc: remove ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NetObserv Operator
 
-NetObserv Operator is a Kubernetes / OpenShift operator for network observability. It deploys a monitoring pipeline to collect and enrich network flows. These flows can be produced by a provided eBPF agent, or by any device or CNI able to export flows in IPFIX format, such as OVN-Kubernetes.
+NetObserv Operator is a Kubernetes / OpenShift operator for network observability. It deploys a monitoring pipeline to collect and enrich network flows. These flows can be produced by the NetObserv eBPF agent, or by any device or CNI able to export flows in IPFIX format, such as OVN-Kubernetes.
 
 The operator provides dashboards, metrics, and keeps flows accessible in a queryable log store, Grafana Loki. When used in OpenShift, new dashboards are available in the Console.
 

--- a/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ spec:
       name: flowcollectors.flows.netobserv.io
       version: v1alpha1
   description: |-
-    NetObserv Operator is an OpenShift / Kubernetes operator for network observability. It deploys a monitoring pipeline to collect and enrich network flows. These flows can be produced by a provided eBPF agent, or by any device or CNI able to export flows in IPFIX format, such as OVN-Kubernetes.
+    NetObserv Operator is an OpenShift / Kubernetes operator for network observability. It deploys a monitoring pipeline to collect and enrich network flows. These flows can be produced by the NetObserv eBPF agent, or by any device or CNI able to export flows in IPFIX format, such as OVN-Kubernetes.
 
     The operator provides dashboards, metrics, and keeps flows accessible in a queryable log store, Grafana Loki. When used in OpenShift, new dashboards are available in the Console.
 


### PR DESCRIPTION
"The provided eBPF Agent" was ambiguous, it is not clear if it's provided
by NetObserv or by the user.