### PR TITLE
Workaround for sampling=1 bugs

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -98,18 +98,19 @@ type FlowCollectorIPFIX struct {
 	// CacheMaxFlows is the max number of flows in an aggregate; when reached, the reporter sends the flows
 	CacheMaxFlows int32 `json:"cacheMaxFlows,omitempty" mapstructure:"cacheMaxFlows,omitempty"`
 
-	//+kubebuilder:validation:Minimum=0
+	//+kubebuilder:validation:Minimum=2
 	//+kubebuilder:default:=400
 	// Sampling is the sampling rate on the reporter. 100 means one flow on 100 is sent.
-	// To ensure cluster stability, it is not possible to sample every packets by setting 0 or 1: in that case,
-	// the value will be raised to 2. If you really want to sample every packet, which may put cluster stability at risk,
-	// set "forceAllowSamplingAll" to "true". Alternatively, you can use the eBPF Agent instead of IPFIX.
+	// To ensure cluster stability, it is not possible to set a value below 2.
+	// If you really want to sample every packet, which may impact the cluster stability,
+	// refer to "forceSampleAll". Alternatively, you can use the eBPF Agent instead of IPFIX.
 	Sampling int32 `json:"sampling,omitempty" mapstructure:"sampling,omitempty"`
 
 	//+kubebuilder:default:=false
 	// It is not recommended to sample all the traffic with IPFIX, as it may generate cluster instability.
 	// If you REALLY want to do that, set this flag to true. Use at your own risks.
-	ForceAllowSamplingAll bool `json:"forceAllowSamplingAll,omitempty" mapstructure:"-"`
+	// When it is set to true, the value of "sampling" is ignored.
+	ForceSampleAll bool `json:"forceSampleAll,omitempty" mapstructure:"-"`
 }
 
 // FlowCollectorEBPF defines a FlowCollector that uses eBPF to collect the flows information

--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -89,19 +89,27 @@ type FlowCollectorIPFIX struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
 
 	//+kubebuilder:validation:Pattern:=^\d+(ns|ms|s|m)?$
-	//+kubebuilder:default:="60s"
+	//+kubebuilder:default:="20s"
 	// CacheActiveTimeout is the max period during which the reporter will aggregate flows before sending
 	CacheActiveTimeout string `json:"cacheActiveTimeout,omitempty" mapstructure:"cacheActiveTimeout,omitempty"`
 
 	//+kubebuilder:validation:Minimum=0
-	//+kubebuilder:default:=100
+	//+kubebuilder:default:=400
 	// CacheMaxFlows is the max number of flows in an aggregate; when reached, the reporter sends the flows
 	CacheMaxFlows int32 `json:"cacheMaxFlows,omitempty" mapstructure:"cacheMaxFlows,omitempty"`
 
 	//+kubebuilder:validation:Minimum=0
 	//+kubebuilder:default:=400
-	// Sampling is the sampling rate on the reporter. 100 means one flow on 100 is sent. 0 means disabled.
+	// Sampling is the sampling rate on the reporter. 100 means one flow on 100 is sent.
+	// To ensure cluster stability, it is not possible to sample every packets by setting 0 or 1: in that case,
+	// the value will be raised to 2. If you really want to sample every packet, which may put cluster stability at risk,
+	// set "forceAllowSamplingAll" to "true". Alternatively, you can use the eBPF Agent instead of IPFIX.
 	Sampling int32 `json:"sampling,omitempty" mapstructure:"sampling,omitempty"`
+
+	//+kubebuilder:default:=false
+	// It is not recommended to sample all the traffic with IPFIX, as it may generate cluster instability.
+	// If you REALLY want to do that, set this flag to true. Use at your own risks.
+	ForceAllowSamplingAll bool `json:"forceAllowSamplingAll,omitempty" mapstructure:"-"`
 }
 
 // FlowCollectorEBPF defines a FlowCollector that uses eBPF to collect the flows information

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -1444,23 +1444,23 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
-                  forceAllowSamplingAll:
+                  forceSampleAll:
                     default: false
                     description: It is not recommended to sample all the traffic with
                       IPFIX, as it may generate cluster instability. If you REALLY
                       want to do that, set this flag to true. Use at your own risks.
+                      When it is set to true, the value of "sampling" is ignored.
                     type: boolean
                   sampling:
                     default: 400
-                    description: 'Sampling is the sampling rate on the reporter. 100
+                    description: Sampling is the sampling rate on the reporter. 100
                       means one flow on 100 is sent. To ensure cluster stability,
-                      it is not possible to sample every packets by setting 0 or 1:
-                      in that case, the value will be raised to 2. If you really want
-                      to sample every packet, which may put cluster stability at risk,
-                      set "forceAllowSamplingAll" to "true". Alternatively, you can
-                      use the eBPF Agent instead of IPFIX.'
+                      it is not possible to set a value below 2. If you really want
+                      to sample every packet, which may impact the cluster stability,
+                      refer to "forceSampleAll". Alternatively, you can use the eBPF
+                      Agent instead of IPFIX.
                     format: int32
-                    minimum: 0
+                    minimum: 2
                     type: integer
                 type: object
               kafka:

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -1432,22 +1432,33 @@ spec:
                   "agent" property is set to "ipfix".
                 properties:
                   cacheActiveTimeout:
-                    default: 60s
+                    default: 20s
                     description: CacheActiveTimeout is the max period during which
                       the reporter will aggregate flows before sending
                     pattern: ^\d+(ns|ms|s|m)?$
                     type: string
                   cacheMaxFlows:
-                    default: 100
+                    default: 400
                     description: CacheMaxFlows is the max number of flows in an aggregate;
                       when reached, the reporter sends the flows
                     format: int32
                     minimum: 0
                     type: integer
+                  forceAllowSamplingAll:
+                    default: false
+                    description: It is not recommended to sample all the traffic with
+                      IPFIX, as it may generate cluster instability. If you REALLY
+                      want to do that, set this flag to true. Use at your own risks.
+                    type: boolean
                   sampling:
                     default: 400
-                    description: Sampling is the sampling rate on the reporter. 100
-                      means one flow on 100 is sent. 0 means disabled.
+                    description: 'Sampling is the sampling rate on the reporter. 100
+                      means one flow on 100 is sent. To ensure cluster stability,
+                      it is not possible to sample every packets by setting 0 or 1:
+                      in that case, the value will be raised to 2. If you really want
+                      to sample every packet, which may put cluster stability at risk,
+                      set "forceAllowSamplingAll" to "true". Alternatively, you can
+                      use the eBPF Agent instead of IPFIX.'
                     format: int32
                     minimum: 0
                     type: integer

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -6,8 +6,8 @@ spec:
   namespace: "network-observability"
   agent: ipfix
   ipfix:
-    cacheActiveTimeout: 60s
-    cacheMaxFlows: 100
+    cacheActiveTimeout: 20s
+    cacheMaxFlows: 400
     sampling: 400
   ebpf:
     image: 'quay.io/netobserv/netobserv-ebpf-agent:main'

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -192,8 +192,8 @@ func flowCollectorControllerSpecs() {
 			}, timeout, interval).Should(Equal(map[string]string{
 				"sampling":           "200",
 				"sharedTarget":       "11.22.33.44:9999",
-				"cacheMaxFlows":      "100",
-				"cacheActiveTimeout": "60s",
+				"cacheMaxFlows":      "400",
+				"cacheActiveTimeout": "20s",
 			}))
 		})
 
@@ -228,9 +228,48 @@ func flowCollectorControllerSpecs() {
 			}, timeout, interval).Should(Equal(map[string]string{
 				"sampling":           "1234",
 				"sharedTarget":       "11.22.33.44:1999",
-				"cacheMaxFlows":      "100",
+				"cacheMaxFlows":      "400",
 				"cacheActiveTimeout": "30s",
 			}))
+		})
+
+		It("Should prevent undesired sampling-everything", func() {
+			Eventually(func() error {
+				fc := flowsv1alpha1.FlowCollector{}
+				if err := k8sClient.Get(ctx, crKey, &fc); err != nil {
+					return err
+				}
+				fc.Spec.IPFIX.Sampling = 1
+				return k8sClient.Update(ctx, &fc)
+			}).Should(Succeed())
+
+			By("Expecting that ovn-flows-configmap is updated with sampling=2")
+			Eventually(func() interface{} {
+				ofc := v1.ConfigMap{}
+				if err := k8sClient.Get(ctx, ovsConfigMapKey, &ofc); err != nil {
+					return err
+				}
+				return ofc.Data["sampling"]
+			}, timeout, interval).Should(Equal("2"))
+
+			Eventually(func() error {
+				fc := flowsv1alpha1.FlowCollector{}
+				if err := k8sClient.Get(ctx, crKey, &fc); err != nil {
+					return err
+				}
+				fc.Spec.IPFIX.Sampling = 1
+				fc.Spec.IPFIX.ForceAllowSamplingAll = true
+				return k8sClient.Update(ctx, &fc)
+			}).Should(Succeed())
+
+			By("Expecting that ovn-flows-configmap is updated with sampling=1")
+			Eventually(func() interface{} {
+				ofc := v1.ConfigMap{}
+				if err := k8sClient.Get(ctx, ovsConfigMapKey, &ofc); err != nil {
+					return err
+				}
+				return ofc.Data["sampling"]
+			}, timeout, interval).Should(Equal("1"))
 		})
 
 		It("Should redeploy if the spec doesn't change but the external flowlogs-pipeline-config does", func() {
@@ -316,8 +355,8 @@ func flowCollectorControllerSpecs() {
 			}, timeout, interval).Should(Equal(map[string]string{
 				"sampling":           "200",
 				"nodePort":           "7891",
-				"cacheMaxFlows":      "100",
-				"cacheActiveTimeout": "60s",
+				"cacheMaxFlows":      "400",
+				"cacheActiveTimeout": "20s",
 			}))
 
 			ds := appsv1.DaemonSet{}
@@ -515,8 +554,8 @@ func flowCollectorControllerSpecs() {
 			}, timeout, interval).Should(Equal(map[string]string{
 				"sampling":           "200",
 				"sharedTarget":       "111.122.133.144:9999",
-				"cacheMaxFlows":      "100",
-				"cacheActiveTimeout": "60s",
+				"cacheMaxFlows":      "400",
+				"cacheActiveTimeout": "20s",
 			}))
 		})
 

--- a/controllers/ovs/flowsconfig_cno_reconciler.go
+++ b/controllers/ovs/flowsconfig_cno_reconciler.go
@@ -113,7 +113,11 @@ func (c *FlowsConfigCNOController) current(ctx context.Context) (*flowsConfig, e
 func (c *FlowsConfigCNOController) desired(
 	ctx context.Context, coll *flowsv1alpha1.FlowCollector) (*flowsConfig, error) {
 
-	conf := flowsConfig{FlowCollectorIPFIX: coll.Spec.IPFIX}
+	// Adapt sampling if necessary. See https://bugzilla.redhat.com/show_bug.cgi?id=2103136 , https://bugzilla.redhat.com/show_bug.cgi?id=2104943
+	corrected := coll.Spec.IPFIX.DeepCopy()
+	corrected.Sampling = correctSampling(ctx, corrected)
+
+	conf := flowsConfig{FlowCollectorIPFIX: *corrected}
 
 	// According to the "OVS flow export configuration" RFE:
 	// nodePort be set by the NOO when the collector is deployed as a DaemonSet

--- a/controllers/ovs/flowsconfig_cno_reconciler.go
+++ b/controllers/ovs/flowsconfig_cno_reconciler.go
@@ -113,9 +113,8 @@ func (c *FlowsConfigCNOController) current(ctx context.Context) (*flowsConfig, e
 func (c *FlowsConfigCNOController) desired(
 	ctx context.Context, coll *flowsv1alpha1.FlowCollector) (*flowsConfig, error) {
 
-	// Adapt sampling if necessary. See https://bugzilla.redhat.com/show_bug.cgi?id=2103136 , https://bugzilla.redhat.com/show_bug.cgi?id=2104943
 	corrected := coll.Spec.IPFIX.DeepCopy()
-	corrected.Sampling = correctSampling(ctx, corrected)
+	corrected.Sampling = getSampling(ctx, corrected)
 
 	conf := flowsConfig{FlowCollectorIPFIX: *corrected}
 

--- a/controllers/ovs/flowsconfig_ovnk_reconciler.go
+++ b/controllers/ovs/flowsconfig_ovnk_reconciler.go
@@ -91,8 +91,7 @@ func (c *FlowsConfigOVNKController) desiredEnv(ctx context.Context, coll *flowsv
 	if err != nil {
 		return nil, err
 	}
-	// Adapt sampling if necessary. See https://bugzilla.redhat.com/show_bug.cgi?id=2103136 , https://bugzilla.redhat.com/show_bug.cgi?id=2104943
-	sampling := correctSampling(ctx, &coll.Spec.IPFIX)
+	sampling := getSampling(ctx, &coll.Spec.IPFIX)
 
 	envs := map[string]string{
 		"OVN_IPFIX_TARGETS":              "",

--- a/controllers/ovs/flowsconfig_ovnk_reconciler.go
+++ b/controllers/ovs/flowsconfig_ovnk_reconciler.go
@@ -91,12 +91,14 @@ func (c *FlowsConfigOVNKController) desiredEnv(ctx context.Context, coll *flowsv
 	if err != nil {
 		return nil, err
 	}
+	// Adapt sampling if necessary. See https://bugzilla.redhat.com/show_bug.cgi?id=2103136 , https://bugzilla.redhat.com/show_bug.cgi?id=2104943
+	sampling := correctSampling(ctx, &coll.Spec.IPFIX)
 
 	envs := map[string]string{
 		"OVN_IPFIX_TARGETS":              "",
 		"OVN_IPFIX_CACHE_ACTIVE_TIMEOUT": strconv.Itoa(int(cacheTimeout.Seconds())),
 		"OVN_IPFIX_CACHE_MAX_FLOWS":      strconv.Itoa(int(coll.Spec.IPFIX.CacheMaxFlows)),
-		"OVN_IPFIX_SAMPLING":             strconv.Itoa(int(coll.Spec.IPFIX.Sampling)),
+		"OVN_IPFIX_SAMPLING":             strconv.Itoa(int(sampling)),
 	}
 
 	if coll.Spec.Agent != flowsv1alpha1.AgentIPFIX {

--- a/controllers/ovs/flowsconfig_types.go
+++ b/controllers/ovs/flowsconfig_types.go
@@ -1,10 +1,12 @@
 package ovs
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
 	"github.com/mitchellh/mapstructure"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/netobserv/network-observability-operator/api/v1alpha1"
 )
@@ -34,4 +36,13 @@ func (fc *flowsConfig) asStringMap() map[string]string {
 		stringVals[k] = fmt.Sprint(v)
 	}
 	return stringVals
+}
+
+func correctSampling(ctx context.Context, cfg *v1alpha1.FlowCollectorIPFIX) int32 {
+	rlog := log.FromContext(ctx)
+	if !cfg.ForceAllowSamplingAll && cfg.Sampling < 2 {
+		rlog.Info("Sampling auto-correction triggered (to avoid this auto-correction, configure flag 'forceAllowSamplingAll' in Spec)", "old value", cfg.Sampling, "new value", 2)
+		return 2
+	}
+	return cfg.Sampling
 }

--- a/controllers/ovs/flowsconfig_types.go
+++ b/controllers/ovs/flowsconfig_types.go
@@ -38,11 +38,14 @@ func (fc *flowsConfig) asStringMap() map[string]string {
 	return stringVals
 }
 
-func correctSampling(ctx context.Context, cfg *v1alpha1.FlowCollectorIPFIX) int32 {
+// getSampling returns the configured sampling, or 1 if ipfix.forceSampleAll is true
+// Note that configured sampling has a minimum value of 2.
+// See also https://bugzilla.redhat.com/show_bug.cgi?id=2103136 , https://bugzilla.redhat.com/show_bug.cgi?id=2104943
+func getSampling(ctx context.Context, cfg *v1alpha1.FlowCollectorIPFIX) int32 {
 	rlog := log.FromContext(ctx)
-	if !cfg.ForceAllowSamplingAll && cfg.Sampling < 2 {
-		rlog.Info("Sampling auto-correction triggered (to avoid this auto-correction, configure flag 'forceAllowSamplingAll' in Spec)", "old value", cfg.Sampling, "new value", 2)
-		return 2
+	if cfg.ForceSampleAll {
+		rlog.Info("Warning, sampling is set to 1. This may put cluster stability at risk.")
+		return 1
 	}
 	return cfg.Sampling
 }

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -2540,10 +2540,10 @@ Settings related to IPFIX-based flow reporter when the "agent" property is set t
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>forceAllowSamplingAll</b></td>
+        <td><b>forceSampleAll</b></td>
         <td>boolean</td>
         <td>
-          It is not recommended to sample all the traffic with IPFIX, as it may generate cluster instability. If you REALLY want to do that, set this flag to true. Use at your own risks.<br/>
+          It is not recommended to sample all the traffic with IPFIX, as it may generate cluster instability. If you REALLY want to do that, set this flag to true. Use at your own risks. When it is set to true, the value of "sampling" is ignored.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -2552,11 +2552,11 @@ Settings related to IPFIX-based flow reporter when the "agent" property is set t
         <td><b>sampling</b></td>
         <td>integer</td>
         <td>
-          Sampling is the sampling rate on the reporter. 100 means one flow on 100 is sent. To ensure cluster stability, it is not possible to sample every packets by setting 0 or 1: in that case, the value will be raised to 2. If you really want to sample every packet, which may put cluster stability at risk, set "forceAllowSamplingAll" to "true". Alternatively, you can use the eBPF Agent instead of IPFIX.<br/>
+          Sampling is the sampling rate on the reporter. 100 means one flow on 100 is sent. To ensure cluster stability, it is not possible to set a value below 2. If you really want to sample every packet, which may impact the cluster stability, refer to "forceSampleAll". Alternatively, you can use the eBPF Agent instead of IPFIX.<br/>
           <br/>
             <i>Format</i>: int32<br/>
             <i>Default</i>: 400<br/>
-            <i>Minimum</i>: 0<br/>
+            <i>Minimum</i>: 2<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -2525,7 +2525,7 @@ Settings related to IPFIX-based flow reporter when the "agent" property is set t
         <td>
           CacheActiveTimeout is the max period during which the reporter will aggregate flows before sending<br/>
           <br/>
-            <i>Default</i>: 60s<br/>
+            <i>Default</i>: 20s<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2535,15 +2535,24 @@ Settings related to IPFIX-based flow reporter when the "agent" property is set t
           CacheMaxFlows is the max number of flows in an aggregate; when reached, the reporter sends the flows<br/>
           <br/>
             <i>Format</i>: int32<br/>
-            <i>Default</i>: 100<br/>
+            <i>Default</i>: 400<br/>
             <i>Minimum</i>: 0<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>forceAllowSamplingAll</b></td>
+        <td>boolean</td>
+        <td>
+          It is not recommended to sample all the traffic with IPFIX, as it may generate cluster instability. If you REALLY want to do that, set this flag to true. Use at your own risks.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>sampling</b></td>
         <td>integer</td>
         <td>
-          Sampling is the sampling rate on the reporter. 100 means one flow on 100 is sent. 0 means disabled.<br/>
+          Sampling is the sampling rate on the reporter. 100 means one flow on 100 is sent. To ensure cluster stability, it is not possible to sample every packets by setting 0 or 1: in that case, the value will be raised to 2. If you really want to sample every packet, which may put cluster stability at risk, set "forceAllowSamplingAll" to "true". Alternatively, you can use the eBPF Agent instead of IPFIX.<br/>
           <br/>
             <i>Format</i>: int32<br/>
             <i>Default</i>: 400<br/>


### PR DESCRIPTION
By default, prevent setting sampling=1 for IPFIX ~~(automatically raised
to 2 in that case)~~
Flag "forceSampleAll" can be use to force sampling=1 (used at their own risks)

See bugs:
- https://bugzilla.redhat.com/show_bug.cgi?id=2103136
- https://bugzilla.redhat.com/show_bug.cgi?id=2104943

Change ipfix cache defaults:

- timeout decreased to 20s
- max-flows increased to 400