### PR TITLE
Give a name to console plugin service port

### DIFF
--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -200,6 +200,7 @@ func (b *builder) service(old *corev1.Service) *corev1.Service {
 				Ports: []corev1.ServicePort{{
 					Port:     b.desired.Port,
 					Protocol: "TCP",
+					Name:     "main",
 				}},
 			},
 		}


### PR DESCRIPTION
This is necessary to add a ServiceMonitor for cluster monitoring