### PR TITLE
NETOBSERV-101 R&D: Kube enricher write path for downstream operator

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -308,6 +308,11 @@ type FlowCollectorLoki struct {
 	// it will be ignored if instanceSpec is specified
 	TenantID string `json:"tenantID,omitempty"`
 
+	//+kubebuilder:default:=false
+	// SendAuthToken is a flag to enable or disable Authorization header from service account secret
+	// It allows authentication to loki operator gateway
+	SendAuthToken bool `json:"sendAuthToken,omitempty"`
+
 	//+kubebuilder:default:="1s"
 	// BatchWait is max time to wait before sending a batch
 	BatchWait metav1.Duration `json:"batchWait,omitempty"`

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -1609,6 +1609,12 @@ spec:
                       If empty, the URL value will be used (assuming that the Loki
                       ingester and querier are int he same host).
                     type: string
+                  sendAuthToken:
+                    default: false
+                    description: SendAuthToken is a flag to enable or disable Authorization
+                      header from service account secret It allows authentication
+                      to loki operator gateway
+                    type: boolean
                   staticLabels:
                     additionalProperties:
                       type: string

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -2858,6 +2858,15 @@ Settings related to the Loki client, used as a flow store.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>sendAuthToken</b></td>
+        <td>boolean</td>
+        <td>
+          SendAuthToken is a flag to enable or disable Authorization header from service account secret It allows authentication to loki operator gateway<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>staticLabels</b></td>
         <td>map[string]string</td>
         <td>

--- a/pkg/helper/tokens.go
+++ b/pkg/helper/tokens.go
@@ -1,0 +1,33 @@
+package helper
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const TokensPath = "/var/run/secrets/tokens/"
+
+// AppendTokenVolume will add a volume + volume mount for a service account token if defined
+func AppendTokenVolume(volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, name string, fileName string) ([]corev1.Volume, []corev1.VolumeMount) {
+	volOut := append(volumes,
+		corev1.Volume{
+			Name: name,
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
+						{
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Path: fileName,
+							},
+						},
+					},
+				},
+			},
+		})
+	vmOut := append(volumeMounts,
+		corev1.VolumeMount{
+			MountPath: TokensPath,
+			Name:      name,
+		},
+	)
+	return volOut, vmOut
+}


### PR DESCRIPTION
This PR adds `sendAuthToken` option to configure the following components to send their service account token as Authorization header:
- [flowlogs-pipeline](https://github.com/netobserv/flowlogs-pipeline/pull/260)
- [console-plugin](https://github.com/netobserv/network-observability-console-plugin/pull/183)

It will need [skip TLS checks & add TenantID](https://github.com/netobserv/network-observability-operator/pull/120) ~~and [flowlogs-pipeline](https://github.com/netobserv/flowlogs-pipeline/pull/260)~~ to be merged first

Edit, following @OlivierCazade feedback we can directly set `flowlogs-pipeline` `clientConfig.authorization` and keep `loki-client-go` as is.