### PR TITLE
Try fix flaky tests, + use filepath.Join

### DIFF
--- a/controllers/flowcollector_controller_console_test.go
+++ b/controllers/flowcollector_controller_console_test.go
@@ -179,26 +179,16 @@ func flowCollectorConsolePluginSpecs() {
 				timeout, interval).Should(Equal("http://loki:3100/"))
 		})
 		It("Should update the Loki URL in the Console Plugin if it changes in the Spec", func() {
-			Expect(func() error {
-				upd := flowsv1alpha1.FlowCollector{}
-				if err := k8sClient.Get(ctx, crKey, &upd); err != nil {
-					return err
-				}
-				upd.Spec.Loki.URL = "http://loki.namespace:8888"
-				return k8sClient.Update(ctx, &upd)
-			}()).Should(Succeed())
+			UpdateCR(crKey, func(fc *flowsv1alpha1.FlowCollector) {
+				fc.Spec.Loki.URL = "http://loki.namespace:8888"
+			})
 			Eventually(getContainerArgumentAfter("network-observability-plugin", "-loki", cpKey),
 				timeout, interval).Should(Equal("http://loki.namespace:8888"))
 		})
 		It("Should use the Loki Querier URL instead of the Loki URL, if the first is defined", func() {
-			Expect(func() error {
-				upd := flowsv1alpha1.FlowCollector{}
-				if err := k8sClient.Get(ctx, crKey, &upd); err != nil {
-					return err
-				}
-				upd.Spec.Loki.QuerierURL = "http://loki-querier:6789"
-				return k8sClient.Update(ctx, &upd)
-			}()).Should(Succeed())
+			UpdateCR(crKey, func(fc *flowsv1alpha1.FlowCollector) {
+				fc.Spec.Loki.QuerierURL = "http://loki-querier:6789"
+			})
 			Eventually(getContainerArgumentAfter("network-observability-plugin", "-loki", cpKey),
 				timeout, interval).Should(Equal("http://loki-querier:6789"))
 		})
@@ -217,10 +207,9 @@ func flowCollectorConsolePluginSpecs() {
 
 		It("Should be unregistered", func() {
 			By("Update CR to unregister")
-			fc := flowsv1alpha1.FlowCollector{}
-			Expect(k8sClient.Get(ctx, crKey, &fc)).Should(Succeed())
-			fc.Spec.ConsolePlugin.Register = false
-			Expect(k8sClient.Update(ctx, &fc)).Should(Succeed())
+			UpdateCR(crKey, func(fc *flowsv1alpha1.FlowCollector) {
+				fc.Spec.ConsolePlugin.Register = false
+			})
 
 			By("Expecting the Console CR to not have plugin registered")
 			Eventually(func() interface{} {

--- a/controllers/flowcollector_controller_ebpf_test.go
+++ b/controllers/flowcollector_controller_ebpf_test.go
@@ -129,12 +129,11 @@ func flowCollectorEBPFSpecs() {
 		})
 
 		It("Should update fields that have changed", func() {
-			updated := flowsv1alpha1.FlowCollector{}
-			Expect(k8sClient.Get(ctx, crKey, &updated)).Should(Succeed())
-			Expect(updated.Spec.EBPF.Sampling).To(Equal(int32(123)))
-			updated.Spec.EBPF.Sampling = 4
-			updated.Spec.EBPF.Privileged = true
-			Expect(k8sClient.Update(ctx, &updated)).Should(Succeed())
+			UpdateCR(crKey, func(fc *flowsv1alpha1.FlowCollector) {
+				Expect(fc.Spec.EBPF.Sampling).To(Equal(int32(123)))
+				fc.Spec.EBPF.Sampling = 4
+				fc.Spec.EBPF.Privileged = true
+			})
 
 			ds := appsv1.DaemonSet{}
 			By("expecting that the daemonset spec has eventually changed")

--- a/controllers/flowlogspipeline/flp_objects.go
+++ b/controllers/flowlogspipeline/flp_objects.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"path/filepath"
 	"strconv"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
@@ -253,7 +254,7 @@ func (b *builder) obtainMetricsConfiguration() ([]api.AggregateDefinition, api.P
 
 	for _, entry := range entries {
 		fileName := entry.Name()
-		srcPath := metricsConfigDir + "/" + fileName
+		srcPath := filepath.Join(metricsConfigDir, fileName)
 
 		input, err := metricsConfigEmbed.ReadFile(srcPath)
 		if err != nil {


### PR DESCRIPTION
Flaky tests are due to the new status conditions recently added to the CRD: the CR kinda auto-updates its status and could cause a race when tests also update the CR in the meantime, resulting in this error message: "the object has been modified; please apply your changes to the latest version and try again"

To fix that, this patch provide a new idiomatic way to update CR in
tests, where it will first fetch the current CR until it is ready
(assuming than its status won't change "by itself" once it's ready)