### PR TITLE
NETOBSERV-505 NOO fails to build with go1.18 and above

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,30 +176,33 @@ run: generate fmt lint ## Run a controller from your host.
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.8)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.7)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
 CRDOC = $(shell pwd)/bin/crdoc
 crdoc: ## Download crdoc locally if necessary.
-	$(call go-get-tool,$(CRDOC),fybrik.io/crdoc@v0.5.2)
+	$(call go-install-tool,$(CRDOC),fybrik.io/crdoc@v0.5.2)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# go-install-tool will update dependencies, download any package $2 and
+# install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(firstword $(MAKEFILE_LIST))))
-define go-get-tool
+define go-install-tool
 @[ -f $(1) ] || { \
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+export GOBIN=$(PROJECT_DIR)/bin; \
+go get $(2); \
+go install $(2); \
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -190,8 +190,7 @@ CRDOC = $(shell pwd)/bin/crdoc
 crdoc: ## Download crdoc locally if necessary.
 	$(call go-install-tool,$(CRDOC),fybrik.io/crdoc@v0.5.2)
 
-# go-install-tool will update dependencies, download any package $2 and
-# install it to $1.
+# go-install-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(firstword $(MAKEFILE_LIST))))
 define go-install-tool
 @[ -f $(1) ] || { \
@@ -200,9 +199,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-export GOBIN=$(PROJECT_DIR)/bin; \
-go get $(2); \
-go install $(2); \
+GOBIN=$(PROJECT_DIR)/bin GOFLAGS="-mod=mod" go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
Use 'go install' to install the executable. This stopped working in  
go1.18 because of https://go.dev/doc/go-get-install-deprecation.

In making this change, kustomize broke and no longer installed. The problem  
is documented in kubernetes-sigs/kustomize#3618.  
The solution is to use at least v4.5.2. kustomize was upgraded to 4.5.7  
from 3.8.8 and everything still worked.