### PR TITLE
Use consistent default prom port

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -239,7 +239,7 @@ type FlowCollectorFLP struct {
 
 	//+kubebuilder:validation:Minimum=1
 	//+kubebuilder:validation:Maximum=65535
-	//+kubebuilder:default:=9090
+	//+kubebuilder:default:=9102
 	// PrometheusPort is the prometheus HTTP port: this port exposes prometheus metrics
 	PrometheusPort int32 `json:"prometheusPort,omitempty"`
 

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -1405,7 +1405,7 @@ spec:
                     minimum: 1025
                     type: integer
                   prometheusPort:
-                    default: 9090
+                    default: 9102
                     description: 'PrometheusPort is the prometheus HTTP port: this
                       port exposes prometheus metrics'
                     format: int32

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -1549,7 +1549,7 @@ Settings related to the flowlogs-pipeline component, which collects and enriches
           PrometheusPort is the prometheus HTTP port: this port exposes prometheus metrics<br/>
           <br/>
             <i>Format</i>: int32<br/>
-            <i>Default</i>: 9090<br/>
+            <i>Default</i>: 9102<br/>
             <i>Minimum</i>: 1<br/>
             <i>Maximum</i>: 65535<br/>
         </td>


### PR DESCRIPTION
Align sample file / CSV with kubebuilder / CRD, using 9102