### PR TITLE
updated labels used by prometheus for metrics produced by flp

### DIFF
--- a/controllers/flowlogspipeline/metrics_definitions/bandwidth_per_network_service_per_namespace.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/bandwidth_per_network_service_per_namespace.yaml
@@ -28,5 +28,5 @@ encode:
         filter: {key: name, value: bandwidth_network_service_namespace}
         valuekey: recent_op_value
         labels:
-          - by
-          - aggregate
+          - Service
+          - SrcK8S_Namespace

--- a/controllers/flowlogspipeline/metrics_definitions/bandwidth_per_src_subnet.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/bandwidth_per_src_subnet.yaml
@@ -26,5 +26,4 @@ encode:
         filter: {key: name, value: bandwidth_source_subnet}
         valueKey: recent_op_value
         labels:
-          - by
-          - aggregate
+          - SrcSubnet

--- a/controllers/flowlogspipeline/metrics_definitions/network_services_count.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/network_services_count.yaml
@@ -26,5 +26,4 @@ encode:
         filter: { key: name, value: dest_service_count }
         valuekey: recent_count
         labels:
-          - by
-          - aggregate
+          - Service


### PR DESCRIPTION
Instead of the labels `aggregate` and `by` we now use `Service` and `SrcK8S_Namespace`.