### PR TITLE
NETOBSERV-101 - loki statusURL

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -300,8 +300,14 @@ type FlowCollectorLoki struct {
 	//+kubebuilder:validation:optional
 	// QuerierURL specifies the address of the Loki querier service, in case it is different from the
 	// Loki ingester URL. If empty, the URL value will be used (assuming that the Loki ingester
-	// and querier are int he same host).
+	// and querier are in the same host).
 	QuerierURL string `json:"querierUrl,omitempty"`
+
+	//+kubebuilder:validation:optional
+	// StatusURL specifies the address of the Loki /ready /metrics /config endpoints, in case it is different from the
+	// Loki querier URL. If empty, the QuerierURL value will be used.
+	// This is usefull to show error messages and some context in the frontend
+	StatusURL string `json:"statusUrl,omitempty"`
 
 	//+kubebuilder:default:="netobserv"
 	// TenantID is the Loki X-Scope-OrgID that identifies the tenant for each request.

--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -300,13 +300,13 @@ type FlowCollectorLoki struct {
 	//+kubebuilder:validation:optional
 	// QuerierURL specifies the address of the Loki querier service, in case it is different from the
 	// Loki ingester URL. If empty, the URL value will be used (assuming that the Loki ingester
-	// and querier are in the same host).
+	// and querier are in the same server).
 	QuerierURL string `json:"querierUrl,omitempty"`
 
 	//+kubebuilder:validation:optional
 	// StatusURL specifies the address of the Loki /ready /metrics /config endpoints, in case it is different from the
 	// Loki querier URL. If empty, the QuerierURL value will be used.
-	// This is usefull to show error messages and some context in the frontend
+	// This is useful to show error messages and some context in the frontend
 	StatusURL string `json:"statusUrl,omitempty"`
 
 	//+kubebuilder:default:="netobserv"

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -1607,7 +1607,7 @@ spec:
                     description: QuerierURL specifies the address of the Loki querier
                       service, in case it is different from the Loki ingester URL.
                       If empty, the URL value will be used (assuming that the Loki
-                      ingester and querier are in the same host).
+                      ingester and querier are in the same server).
                     type: string
                   sendAuthToken:
                     default: false
@@ -1627,7 +1627,7 @@ spec:
                     description: StatusURL specifies the address of the Loki /ready
                       /metrics /config endpoints, in case it is different from the
                       Loki querier URL. If empty, the QuerierURL value will be used.
-                      This is usefull to show error messages and some context in the
+                      This is useful to show error messages and some context in the
                       frontend
                     type: string
                   tenantID:

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -1607,7 +1607,7 @@ spec:
                     description: QuerierURL specifies the address of the Loki querier
                       service, in case it is different from the Loki ingester URL.
                       If empty, the URL value will be used (assuming that the Loki
-                      ingester and querier are int he same host).
+                      ingester and querier are in the same host).
                     type: string
                   sendAuthToken:
                     default: false
@@ -1623,6 +1623,13 @@ spec:
                     description: StaticLabels is a map of common labels to set on
                       each flow
                     type: object
+                  statusUrl:
+                    description: StatusURL specifies the address of the Loki /ready
+                      /metrics /config endpoints, in case it is different from the
+                      Loki querier URL. If empty, the QuerierURL value will be used.
+                      This is usefull to show error messages and some context in the
+                      frontend
+                    type: string
                   tenantID:
                     default: netobserv
                     description: TenantID is the Loki X-Scope-OrgID that identifies

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -108,15 +108,23 @@ func tokenPath(desiredLoki *flowsv1alpha1.FlowCollectorLoki) string {
 }
 
 func buildArgs(desired *flowsv1alpha1.FlowCollectorConsolePlugin, desiredLoki *flowsv1alpha1.FlowCollectorLoki) []string {
+	querierURL := querierURL(desiredLoki)
+	statusURL := statusURL(desiredLoki)
+
 	args := []string{
 		"-cert", "/var/serving-cert/tls.crt",
 		"-key", "/var/serving-cert/tls.key",
-		"-loki", querierURL(desiredLoki),
+		"-loki", querierURL,
 		"-loki-labels", strings.Join(constants.LokiIndexFields, ","),
 		"-loki-tenant-id", desiredLoki.TenantID,
 		"-loglevel", desired.LogLevel,
 		"-frontend-config", filepath.Join(configPath, configFile),
 	}
+
+	if querierURL != statusURL {
+		args = append(args, "-loki-status", statusURL)
+	}
+
 	if desiredLoki.TLS.Enable {
 		if desiredLoki.TLS.InsecureSkipVerify {
 			args = append(args, "-loki-skip-tls")

--- a/controllers/consoleplugin/consoleplugin_reconciler.go
+++ b/controllers/consoleplugin/consoleplugin_reconciler.go
@@ -243,6 +243,13 @@ func querierURL(loki *flowsv1alpha1.FlowCollectorLoki) string {
 	return loki.URL
 }
 
+func statusURL(loki *flowsv1alpha1.FlowCollectorLoki) string {
+	if loki.StatusURL != "" {
+		return loki.StatusURL
+	}
+	return querierURL(loki)
+}
+
 func serviceNeedsUpdate(svc *corev1.Service, desired *pluginSpec, ns string) bool {
 	if svc.Namespace != ns {
 		return true

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -2854,7 +2854,7 @@ Settings related to the Loki client, used as a flow store.
         <td><b>querierUrl</b></td>
         <td>string</td>
         <td>
-          QuerierURL specifies the address of the Loki querier service, in case it is different from the Loki ingester URL. If empty, the URL value will be used (assuming that the Loki ingester and querier are int he same host).<br/>
+          QuerierURL specifies the address of the Loki querier service, in case it is different from the Loki ingester URL. If empty, the URL value will be used (assuming that the Loki ingester and querier are in the same host).<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2873,6 +2873,13 @@ Settings related to the Loki client, used as a flow store.
           StaticLabels is a map of common labels to set on each flow<br/>
           <br/>
             <i>Default</i>: map[app:netobserv-flowcollector]<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>statusUrl</b></td>
+        <td>string</td>
+        <td>
+          StatusURL specifies the address of the Loki /ready /metrics /config endpoints, in case it is different from the Loki querier URL. If empty, the QuerierURL value will be used. This is usefull to show error messages and some context in the frontend<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -2854,7 +2854,7 @@ Settings related to the Loki client, used as a flow store.
         <td><b>querierUrl</b></td>
         <td>string</td>
         <td>
-          QuerierURL specifies the address of the Loki querier service, in case it is different from the Loki ingester URL. If empty, the URL value will be used (assuming that the Loki ingester and querier are in the same host).<br/>
+          QuerierURL specifies the address of the Loki querier service, in case it is different from the Loki ingester URL. If empty, the URL value will be used (assuming that the Loki ingester and querier are in the same server).<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2879,7 +2879,7 @@ Settings related to the Loki client, used as a flow store.
         <td><b>statusUrl</b></td>
         <td>string</td>
         <td>
-          StatusURL specifies the address of the Loki /ready /metrics /config endpoints, in case it is different from the Loki querier URL. If empty, the QuerierURL value will be used. This is usefull to show error messages and some context in the frontend<br/>
+          StatusURL specifies the address of the Loki /ready /metrics /config endpoints, in case it is different from the Loki querier URL. If empty, the QuerierURL value will be used. This is useful to show error messages and some context in the frontend<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
Following https://github.com/observatorium/api/pull/350 we will not have access to loki ready, config, metrics and build infos endpoints using the gateway.

This PR allow to configure a `statusURL` in the CRD and send it to the console plugin

Related PR: https://github.com/netobserv/network-observability-console-plugin/pull/186