### PR TITLE
NETOBSERV-435 - Set default req/limits resources for eBPF agent

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -136,6 +136,7 @@ type FlowCollectorEBPF struct {
 	// ImagePullPolicy is the Kubernetes pull policy for the image defined above
 	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
 
+	//+kubebuilder:default:={requests:{memory:"50Mi",cpu:"100m"},limits:{memory:"100Mi"}}
 	// Compute Resources required by this container.
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -136,6 +136,12 @@ spec:
                           PERFMON, NET_ADMIN, SYS_RESOURCE.'
                         type: boolean
                       resources:
+                        default:
+                          limits:
+                            memory: 100Mi
+                          requests:
+                            cpu: 100m
+                            memory: 50Mi
                         description: 'Compute Resources required by this container.
                           Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         properties:

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -289,6 +289,8 @@ Settings related to eBPF-based flow reporter when the "agent.type" property is s
         <td>object</td>
         <td>
           Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+          <br/>
+            <i>Default</i>: map[limits:map[memory:100Mi] requests:map[cpu:100m memory:50Mi]]<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
I set some minimalist resources spec for eBPF agent as already defined for others components.
This works fine on my dev cluster generating some spam on a httpd deployment:
- memory is around 30MiB
- max cpu at 84m 

Another discussion around what limits should be set for downstream is available in [NETOBSERV-380](https://issues.redhat.com/browse/NETOBSERV-380)
Requests / limits per cluster size should be documented for upstream in [NETOBSERV-493](https://issues.redhat.com/browse/NETOBSERV-493)