### PR TITLE
adding workflow to build catalog bundle on push to main

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -46,3 +46,24 @@ jobs:
           registry: ${{ env.REGISTRY }}
       - name: print image url
         run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+      - name: build bundle
+        run: VERSION=${{ env.TAGS }} IMAGE_TAG_BASE=${{ env.REGISTRY }}/${{ env.IMAGE }} make bundle-build
+      - name: push bundle to quay.io
+        id: push-bundle
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ env.IMAGE }}-bundle
+          tags: v${{ env.TAGS }}
+          registry: ${{ env.REGISTRY }}
+      - name: build catalog
+        run: VERSION=${{ env.TAGS }} IMAGE_TAG_BASE=${{ env.REGISTRY }}/${{ env.IMAGE }} make catalog-build
+      - name: push catalog to quay.io
+        id: push-catalog
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ env.IMAGE }}-catalog
+          tags: v${{ env.TAGS }}
+          registry: ${{ env.REGISTRY }}
+      - name: print images reference
+        run: |
+          echo "Images: ${{ steps.push-to-quay.outputs.registry-paths }}, ${{ steps.push-bundle.outputs.registry-paths }}, ${{ steps.push-catalog.outputs.registry-paths }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ on:
     tags: ['*']
 
 env:
-  REGISTRY_USER: rhn_support_memodi
+  REGISTRY_USER: netobserv+github_ci
   REGISTRY_PASSWORD: ${{ secrets.QUAY_SECRET }}
-  REGISTRY: quay.io/rhn_support_memodi
+  REGISTRY: quay.io/netobserv
   IMAGE: network-observability-operator
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ on:
     tags: ['*']
 
 env:
-  REGISTRY_USER: netobserv+github_ci
+  REGISTRY_USER: rhn_support_memodi
   REGISTRY_PASSWORD: ${{ secrets.QUAY_SECRET }}
-  REGISTRY: quay.io/netobserv
+  REGISTRY: quay.io/rhn_support_memodi
   IMAGE: network-observability-operator
 
 jobs:


### PR DESCRIPTION
This should help by creating subscription of NOO catalog image developed from `main` branch as an alternative to `make deploy` target