### PR TITLE
NETOBSERV-433 and NETOBSERV-373 - unify names

### DIFF
--- a/.mk/local.mk
+++ b/.mk/local.mk
@@ -15,7 +15,7 @@ local-deploy: create-kind-cluster deploy-all  ## Local deploy (kind, loki, grafa
 .PHONY: clean-leftovers
 clean-leftovers:
 	-PID=$$(pgrep --oldest --full "main.go"); pkill -P $$PID; pkill $$PID
-	-kubectl delete namespace network-observability
+	-kubectl delete namespace netobserv
 
 .PHONY: local-redeploy
 local-redeploy: clean-leftovers undeploy-all deploy-all  ## Local re-deploy (loki, grafana, example-cr and sample-workload excluding the operator)

--- a/.mk/ocp.mk
+++ b/.mk/ocp.mk
@@ -29,8 +29,8 @@ ocp-run: ocp-undeploy ocp-deploy ocp-deploy-operator  ## OCP-deploy + run the op
 
 .PHONY: ocp-deploy-operator
 ocp-deploy-operator: ## run flp from the operator
-	@echo "====> Enable network-observability-plugin in OCP console"
-	oc patch console.operator.openshift.io cluster --type='json' -p '[{"op": "add", "path": "/spec/plugins", "value": ["network-observability-plugin"]}]'
+	@echo "====> Enable netobserv-plugin in OCP console"
+	oc patch console.operator.openshift.io cluster --type='json' -p '[{"op": "add", "path": "/spec/plugins", "value": ["netobserv-plugin"]}]'
 	@echo "====> Running the operator locally"
 	go run ./main.go
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,7 +28,7 @@ Creating a `FlowCollector` triggers the operator deploying the monitoring pipeli
 
 - Configures IPFIX exports
 - Deploys the flow collector pods, `flowlogs-pipeline`
-- Deploys the `network-observability-plugin` if using OpenShift Console
+- Deploys the `netobserv-plugin` if using OpenShift Console
 
 You should be able to see flows in OpenShift Console and Grafana. If not, wait up to 10 minutes. See the [FAQ on troubleshooting](./README.md#faq--troubleshooting) for more information.
 

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-NAMESPACE ?= network-observability
+NAMESPACE ?= netobserv
 
 all: help
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ OpenShift 4.10 or above is required.
 Make sure all pods are up and running:
 
 ```bash
-# Assuming configured namespace is network-observability (default)
-kubectl get pods -n network-observability
+# Assuming configured namespace is netobserv (default)
+kubectl get pods -n netobserv
 ```
 
 Should provide results similar to this:
@@ -169,7 +169,7 @@ flowlogs-pipeline-wmx4z                         1/1     Running   0          43m
 grafana-6dbddc9869-sxn62                        1/1     Running   0          31m
 loki                                            1/1     Running   0          43m
 netobserv-controller-manager-7487d87dc-2ltq2    2/2     Running   0          43m
-network-observability-plugin-7fb8c5477b-drg2z   1/1     Running   0          43m
+netobserv-plugin-7fb8c5477b-drg2z               1/1     Running   0          43m
 ```
 
 Results may slightly differ depending on the installation method and the `FlowCollector` configuration. At least you should see `flowlogs-pipeline` pods in a `Running` state.
@@ -177,8 +177,8 @@ Results may slightly differ depending on the installation method and the `FlowCo
 If you use the eBPF agent, check also for pods in privileged namespace:
 
 ```bash
-# Assuming configured namespace is network-observability (default)
-kubectl get pods -n network-observability-privileged
+# Assuming configured namespace is netobserv (default)
+kubectl get pods -n netobserv-privileged
 ```
 
 ```
@@ -227,14 +227,14 @@ If it's not already there, add the plugin reference:
 ```yaml
 spec:
   plugins:
-  - network-observability-plugin
+  - netobserv-plugin
 ```
 
 If the new dashboards still don't show up, try clearing your browser cache and refreshing. Check also the `netobserv-console-plugin-...` pod status and logs.
 
 ```bash
-kubectl get pods -n network-observability -l app=network-observability-plugin
-kubectl logs -n network-observability -l app=network-observability-plugin
+kubectl get pods -n netobserv -l app=netobserv-plugin
+kubectl logs -n netobserv -l app=netobserv-plugin
 ```
 
 ## Contributions

--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -414,7 +414,7 @@ type FlowCollectorConsolePlugin struct {
 	//+kubebuilder:default:=true
 	// register allows, when set to true, to automatically register the provided console plugin with the OpenShift Console operator.
 	// When set to false, you can still register it manually by editing console.operator.openshift.io/cluster.
-	// E.g: oc patch console.operator.openshift.io cluster --type='json' -p '[{"op": "add", "path": "/spec/plugins/-", "value": "network-observability-plugin"}]'
+	// E.g: oc patch console.operator.openshift.io cluster --type='json' -p '[{"op": "add", "path": "/spec/plugins/-", "value": "netobserv-plugin"}]'
 	Register bool `json:"register"`
 
 	//+kubebuilder:validation:Minimum=0

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -808,12 +808,11 @@ spec:
                     type: object
                   register:
                     default: true
-                    description: 'register allows, when set to true, to automatically
-                      register the provided console plugin with the OpenShift Console
-                      operator. When set to false, you can still register it manually
-                      by editing console.operator.openshift.io/cluster. E.g: oc patch
-                      console.operator.openshift.io cluster --type=''json'' -p ''[{"op":
-                      "add", "path": "/spec/plugins/-", "value": "network-observability-plugin"}]'''
+                    description: 'register allows, when set to true, to automatically register the provided console plugin
+                      with the OpenShift Console operator. When set to false, you
+                      can still register it manually by editing console.operator.openshift.io/cluster.
+                      E.g: oc patch console.operator.openshift.io cluster --type=''json''
+                      -p ''[{"op": "add", "path": "/spec/plugins/-", "value": "netobserv-plugin"}]'''
                     type: boolean
                   replicas:
                     default: 1

--- a/bundle/manifests/netobserv-manager-config_v1_configmap.yaml
+++ b/bundle/manifests/netobserv-manager-config_v1_configmap.yaml
@@ -15,5 +15,5 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app: network-observability-operator
+    app: netobserv-operator
   name: netobserv-manager-config

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -817,7 +817,7 @@ spec:
                       operator. When set to false, you can still register it manually
                       by editing console.operator.openshift.io/cluster. E.g: oc patch
                       console.operator.openshift.io cluster --type=''json'' -p ''[{"op":
-                      "add", "path": "/spec/plugins/-", "value": "network-observability-plugin"}]'''
+                      "add", "path": "/spec/plugins/-", "value": "netobserv-plugin"}]'''
                     type: boolean
                   replicas:
                     default: 1
@@ -1731,20 +1731,21 @@ spec:
                             description: TLS configuration.
                             properties:
                               certFile:
-                                description: Certificate file name within the ConfigMap
-                                  / Secret
+                                description: certFile defines the path to the certificate
+                                  file name within the ConfigMap / Secret
                                 type: string
                               certKey:
-                                description: Certificate private key file name within
-                                  the ConfigMap / Secret. Omit when the key is not
-                                  necessary.
+                                description: certKey defines the path to the certificate
+                                  private key file name within the ConfigMap / Secret.
+                                  Omit when the key is not necessary.
                                 type: string
                               name:
-                                description: Name of the ConfigMap or Secret containing
+                                description: name of the ConfigMap or Secret containing
                                   certificates
                                 type: string
                               type:
-                                description: 'Reference type: configmap or secret'
+                                description: 'type for the certificate reference:
+                                  configmap or secret'
                                 enum:
                                 - configmap
                                 - secret

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: network-observability
+namespace: netobserv
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -15,4 +15,4 @@ images:
   newName: quay.io/netobserv/network-observability-operator
   newTag: 0.1.4
 commonLabels:
-  app: network-observability-operator
+  app: netobserv-operator

--- a/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Monitoring
-    console.openshift.io/plugins: '["network-observability-plugin"]'
+    console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: ':container-image:'
     createdAt: ':created-at:'
     description: Network flows collector and monitoring solution
@@ -34,9 +34,9 @@ spec:
     For a quick install that is not suitable for production (it deploys a single pod, configures a 1GB storage PVC, with 24 hours of retention), run the following commands:
 
     ```
-    kubectl create namespace network-observability
-    kubectl apply -f <(curl -L https://raw.githubusercontent.com/netobserv/documents/be14cbdca9af223f5472fffef05257089bc73c8a/examples/zero-click-loki/1-storage.yaml) -n network-observability
-    kubectl apply -f <(curl -L https://raw.githubusercontent.com/netobserv/documents/be14cbdca9af223f5472fffef05257089bc73c8a/examples/zero-click-loki/2-loki.yaml) -n network-observability
+    kubectl create namespace netobserv
+    kubectl apply -f <(curl -L https://raw.githubusercontent.com/netobserv/documents/be14cbdca9af223f5472fffef05257089bc73c8a/examples/zero-click-loki/1-storage.yaml) -n netobserv
+    kubectl apply -f <(curl -L https://raw.githubusercontent.com/netobserv/documents/be14cbdca9af223f5472fffef05257089bc73c8a/examples/zero-click-loki/2-loki.yaml) -n netobserv
     ```
 
     - [Grafana](https://grafana.com/oss/grafana/) can optionally be installed for custom dashboards and query capabilities.

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -3,7 +3,7 @@ kind: FlowCollector
 metadata:
   name: cluster
 spec:
-  namespace: "network-observability"
+  namespace: netobserv
   agent:
     type: EBPF
     ipfix:
@@ -48,7 +48,7 @@ spec:
         memory: 300Mi
   kafka:
     enable: false
-    address: "kafka-cluster-kafka-bootstrap.network-observability"
+    address: "kafka-cluster-kafka-bootstrap.netobserv"
     topic: "network-flows"
     tls:
       enable: false
@@ -62,7 +62,7 @@ spec:
         certFile: user.crt
         certKey: user.key
   loki:
-    url: 'http://loki.network-observability.svc:3100/'
+    url: 'http://loki.netobserv.svc:3100/'
     batchWait: 1s
     batchSize: 102400
     minBackoff: 1s

--- a/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
@@ -3,7 +3,7 @@ kind: FlowCollector
 metadata:
   name: cluster
 spec:
-  namespace: "network-observability"
+  namespace: netobserv
   agent:
     type: EBPF
     ipfix:
@@ -35,7 +35,7 @@ spec:
     dropUnusedFields: true
   kafka:
     enable: false
-    address: "kafka-cluster-kafka-bootstrap.network-observability"
+    address: "kafka-cluster-kafka-bootstrap.netobserv"
     topic: "network-flows"
     tls:
       enable: false
@@ -49,7 +49,7 @@ spec:
         certFile: user.crt
         certKey: user.key
   loki:
-    url: 'http://loki.network-observability.svc:3100/'
+    url: 'http://loki.netobserv.svc:3100/'
     batchWait: 1s
     batchSize: 102400
     minBackoff: 1s

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -19,7 +19,7 @@ import (
 )
 
 const secretName = "console-serving-cert"
-const displayName = "Network Observability plugin"
+const displayName = "NetObserv plugin"
 const proxyAlias = "backend"
 
 const configMapName = "console-plugin-config"

--- a/controllers/consoleplugin/consoleplugin_test.go
+++ b/controllers/consoleplugin/consoleplugin_test.go
@@ -210,15 +210,15 @@ func TestLabels(t *testing.T) {
 
 	// Deployment
 	depl := builder.deployment("digest")
-	assert.Equal("network-observability-plugin", depl.Labels["app"])
-	assert.Equal("network-observability-plugin", depl.Spec.Template.Labels["app"])
+	assert.Equal("netobserv-plugin", depl.Labels["app"])
+	assert.Equal("netobserv-plugin", depl.Spec.Template.Labels["app"])
 	assert.Equal("dev", depl.Labels["version"])
 	assert.Equal("dev", depl.Spec.Template.Labels["version"])
 
 	// Service
 	svc := builder.service(nil)
-	assert.Equal("network-observability-plugin", svc.Labels["app"])
-	assert.Equal("network-observability-plugin", svc.Spec.Selector["app"])
+	assert.Equal("netobserv-plugin", svc.Labels["app"])
+	assert.Equal("netobserv-plugin", svc.Spec.Selector["app"])
 	assert.Equal("dev", svc.Labels["version"])
 	assert.Empty(svc.Spec.Selector["version"])
 }

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -2,10 +2,11 @@
 package constants
 
 const (
-	DefaultOperatorNamespace = "network-observability"
+	DefaultOperatorNamespace = "netobserv"
+	OperatorName             = "netobserv-operator"
 	FLPName                  = "flowlogs-pipeline"
 	FLPPortName              = "flp" // must be <15 chars
-	PluginName               = "network-observability-plugin"
+	PluginName               = "netobserv-plugin"
 	DeploymentKind           = "Deployment"
 	DaemonSetKind            = "DaemonSet"
 

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -150,7 +150,7 @@ func (c *AgentController) desired(coll *flowsv1alpha1.FlowCollector) *v1.DaemonS
 	volumeMounts := []corev1.VolumeMount{}
 	volumes := []corev1.Volume{}
 	if coll.Spec.Kafka.Enable && coll.Spec.Kafka.TLS.Enable {
-		// NOTE: secrets need to be copied from the base network-observability namespace to the privileged one.
+		// NOTE: secrets need to be copied from the base netobserv namespace to the privileged one.
 		// This operation must currently be performed manually (run "make fix-ebpf-kafka-tls"). It could be automated here.
 		volumes, volumeMounts = helper.AppendCertVolumes(volumes, volumeMounts, &coll.Spec.Kafka.TLS, kafkaCerts)
 	}

--- a/controllers/ebpf/internal/permissions/permissions.go
+++ b/controllers/ebpf/internal/permissions/permissions.go
@@ -72,7 +72,7 @@ func (c *Reconciler) reconcileNamespace(ctx context.Context) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: c.privilegedNamespace,
 			Labels: map[string]string{
-				"app":                                "network-observability-operator",
+				"app":                                constants.OperatorName,
 				"pod-security.kubernetes.io/enforce": "privileged",
 				"pod-security.kubernetes.io/audit":   "privileged",
 			},

--- a/controllers/flowcollector_controller_console_test.go
+++ b/controllers/flowcollector_controller_console_test.go
@@ -25,7 +25,7 @@ const cpNamespace = "namespace-console-specs"
 // nolint:cyclop
 func flowCollectorConsolePluginSpecs() {
 	cpKey := types.NamespacedName{
-		Name:      "network-observability-plugin",
+		Name:      "netobserv-plugin",
 		Namespace: cpNamespace,
 	}
 	configKey := types.NamespacedName{
@@ -177,21 +177,21 @@ func flowCollectorConsolePluginSpecs() {
 
 	Context("Configuring the Loki URL", func() {
 		It("Should be initially configured with default Loki URL", func() {
-			Eventually(getContainerArgumentAfter("network-observability-plugin", "-loki", cpKey),
+			Eventually(getContainerArgumentAfter("netobserv-plugin", "-loki", cpKey),
 				timeout, interval).Should(Equal("http://loki:3100/"))
 		})
 		It("Should update the Loki URL in the Console Plugin if it changes in the Spec", func() {
 			UpdateCR(crKey, func(fc *flowsv1alpha1.FlowCollector) {
 				fc.Spec.Loki.URL = "http://loki.namespace:8888"
 			})
-			Eventually(getContainerArgumentAfter("network-observability-plugin", "-loki", cpKey),
+			Eventually(getContainerArgumentAfter("netobserv-plugin", "-loki", cpKey),
 				timeout, interval).Should(Equal("http://loki.namespace:8888"))
 		})
 		It("Should use the Loki Querier URL instead of the Loki URL, if the first is defined", func() {
 			UpdateCR(crKey, func(fc *flowsv1alpha1.FlowCollector) {
 				fc.Spec.Loki.QuerierURL = "http://loki-querier:6789"
 			})
-			Eventually(getContainerArgumentAfter("network-observability-plugin", "-loki", cpKey),
+			Eventually(getContainerArgumentAfter("netobserv-plugin", "-loki", cpKey),
 				timeout, interval).Should(Equal("http://loki-querier:6789"))
 		})
 	})
@@ -204,7 +204,7 @@ func flowCollectorConsolePluginSpecs() {
 					return err
 				}
 				return cr.Spec.Plugins
-			}, timeout, interval).Should(Equal([]string{"network-observability-plugin"}))
+			}, timeout, interval).Should(Equal([]string{"netobserv-plugin"}))
 		})
 
 		It("Should be unregistered", func() {

--- a/controllers/flowcollector_controller_ebpf_test.go
+++ b/controllers/flowcollector_controller_ebpf_test.go
@@ -116,11 +116,11 @@ func flowCollectorEBPFSpecs() {
 				fmt.Sprintf("expected FLOWS_TARGET_HOST env var in %+v", spec.Containers[0].Env))
 
 			ns := v1.Namespace{}
-			By("expecting to create the network-observability-privileged namespace")
+			By("expecting to create the netobserv-privileged namespace")
 			Expect(k8sClient.Get(ctx, nsKey, &ns)).To(Succeed())
 			Expect(ns.Labels).To(Satisfy(func(labels map[string]string) bool {
 				return helper.IsSubSet(ns.Labels, map[string]string{
-					"app":                                "network-observability-operator",
+					"app":                                constants.OperatorName,
 					"pod-security.kubernetes.io/enforce": "privileged",
 					"pod-security.kubernetes.io/audit":   "privileged",
 				})
@@ -195,7 +195,7 @@ func flowCollectorEBPFSpecs() {
 			}).WithTimeout(timeout).WithPolling(interval).
 				Should(BeGarbageCollectedBy(flowCR))
 
-			By("expecting to delete the network-observability-privileged namespace")
+			By("expecting to delete the netobserv-privileged namespace")
 			Eventually(func() interface{} {
 				ns := &v1.Namespace{}
 				if err := k8sClient.Get(ctx, nsKey, ns); err != nil {

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -60,11 +60,11 @@ func flowCollectorControllerSpecs() {
 		Namespace: operatorNamespace,
 	}
 	cpKey1 := types.NamespacedName{
-		Name:      "network-observability-plugin",
+		Name:      "netobserv-plugin",
 		Namespace: operatorNamespace,
 	}
 	cpKey2 := types.NamespacedName{
-		Name:      "network-observability-plugin",
+		Name:      "netobserv-plugin",
 		Namespace: otherNamespace,
 	}
 
@@ -540,17 +540,17 @@ func flowCollectorControllerSpecs() {
 			By("Expecting deployment in previous namespace to be deleted")
 			Eventually(func() interface{} {
 				return k8sClient.Get(ctx, cpKey1, &appsv1.Deployment{})
-			}, timeout, interval).Should(MatchError(`deployments.apps "network-observability-plugin" not found`))
+			}, timeout, interval).Should(MatchError(`deployments.apps "netobserv-plugin" not found`))
 
 			By("Expecting service in previous namespace to be deleted")
 			Eventually(func() interface{} {
 				return k8sClient.Get(ctx, cpKey1, &v1.Service{})
-			}, timeout, interval).Should(MatchError(`services "network-observability-plugin" not found`))
+			}, timeout, interval).Should(MatchError(`services "netobserv-plugin" not found`))
 
 			By("Expecting service account in previous namespace to be deleted")
 			Eventually(func() interface{} {
 				return k8sClient.Get(ctx, cpKey1, &v1.ServiceAccount{})
-			}, timeout, interval).Should(MatchError(`serviceaccounts "network-observability-plugin" not found`))
+			}, timeout, interval).Should(MatchError(`serviceaccounts "netobserv-plugin" not found`))
 
 			By("Expecting deployment to be created in new namespace")
 			Eventually(func() interface{} {

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -451,7 +451,7 @@ consolePlugin defines the settings related to the OpenShift Console plugin, when
         <td><b>register</b></td>
         <td>boolean</td>
         <td>
-          register allows, when set to true, to automatically register the provided console plugin with the OpenShift Console operator. When set to false, you can still register it manually by editing console.operator.openshift.io/cluster. E.g: oc patch console.operator.openshift.io cluster --type='json' -p '[{"op": "add", "path": "/spec/plugins/-", "value": "network-observability-plugin"}]'<br/>
+          register allows, when set to true, to automatically register the provided console plugin with the OpenShift Console operator. When set to false, you can still register it manually by editing console.operator.openshift.io/cluster. E.g: oc patch console.operator.openshift.io cluster --type='json' -p '[{"op": "add", "path": "/spec/plugins/-", "value": "netobserv-plugin"}]'<br/>
           <br/>
             <i>Default</i>: true<br/>
         </td>
@@ -2168,7 +2168,7 @@ processor defines the settings of the component that receives the flows from the
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b><a href="#flowcollectorspecflowlogspipelineprometheus">prometheus</a></b></td>
+        <td><b><a href="#flowcollectorspecprocessorprometheus">prometheus</a></b></td>
         <td>object</td>
         <td>
           Prometheus endpoint configuration<br/>
@@ -3107,8 +3107,8 @@ target specifies the target value for the given metric
 </table>
 
 
-### FlowCollector.spec.flowlogsPipeline.prometheus
-<sup><sup>[↩ Parent](#flowcollectorspecflowlogspipeline)</sup></sup>
+### FlowCollector.spec.processor.prometheus
+<sup><sup>[↩ Parent](#flowcollectorspecprocessor)</sup></sup>
 
 
 
@@ -3136,7 +3136,7 @@ Prometheus endpoint configuration
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b><a href="#flowcollectorspecflowlogspipelineprometheustls">tls</a></b></td>
+        <td><b><a href="#flowcollectorspecprocessorprometheustls">tls</a></b></td>
         <td>object</td>
         <td>
           TLS configuration.<br/>
@@ -3146,8 +3146,8 @@ Prometheus endpoint configuration
 </table>
 
 
-### FlowCollector.spec.flowlogsPipeline.prometheus.tls
-<sup><sup>[↩ Parent](#flowcollectorspecflowlogspipelineprometheus)</sup></sup>
+### FlowCollector.spec.processor.prometheus.tls
+<sup><sup>[↩ Parent](#flowcollectorspecprocessorprometheus)</sup></sup>
 
 
 
@@ -3163,7 +3163,7 @@ TLS configuration.
         </tr>
     </thead>
     <tbody><tr>
-        <td><b><a href="#flowcollectorspecflowlogspipelineprometheustlsprovided">provided</a></b></td>
+        <td><b><a href="#flowcollectorspecprocessorprometheustlsprovided">provided</a></b></td>
         <td>object</td>
         <td>
           TLS configuration.<br/>
@@ -3183,8 +3183,8 @@ TLS configuration.
 </table>
 
 
-### FlowCollector.spec.flowlogsPipeline.prometheus.tls.provided
-<sup><sup>[↩ Parent](#flowcollectorspecflowlogspipelineprometheustls)</sup></sup>
+### FlowCollector.spec.processor.prometheus.tls.provided
+<sup><sup>[↩ Parent](#flowcollectorspecprocessorprometheustls)</sup></sup>
 
 
 
@@ -3203,28 +3203,28 @@ TLS configuration.
         <td><b>certFile</b></td>
         <td>string</td>
         <td>
-          Certificate file name within the ConfigMap / Secret<br/>
+          certFile defines the path to the certificate file name within the ConfigMap / Secret<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>certKey</b></td>
         <td>string</td>
         <td>
-          Certificate private key file name within the ConfigMap / Secret. Omit when the key is not necessary.<br/>
+          certKey defines the path to the certificate private key file name within the ConfigMap / Secret. Omit when the key is not necessary.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Name of the ConfigMap or Secret containing certificates<br/>
+          name of the ConfigMap or Secret containing certificates<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Reference type: configmap or secret<br/>
+          type for the certificate reference: configmap or secret<br/>
           <br/>
             <i>Enum</i>: configmap, secret<br/>
         </td>

--- a/hack/deploy-grafana.sh
+++ b/hack/deploy-grafana.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-namespace=${1-network-observability}
+namespace=${1-netobserv}
 
 create_grafana_deployment() {
   echo "--> Creating grafana deployment (ConfigMap, Pod and Service) "
@@ -63,7 +63,7 @@ data:
       isDefault: true
       name: loki
       type: loki
-      url: http://loki.network-observability.svc.cluster.local:3100
+      url: http://loki.netobserv.svc.cluster.local:3100
       version: 1
 ---
 EOF

--- a/main.go
+++ b/main.go
@@ -40,10 +40,11 @@ import (
 
 	flowsv1alpha1 "github.com/netobserv/network-observability-operator/api/v1alpha1"
 	"github.com/netobserv/network-observability-operator/controllers"
+	"github.com/netobserv/network-observability-operator/controllers/constants"
 	//+kubebuilder:scaffold:imports
 )
 
-const app = "network-observability-operator"
+const app = constants.OperatorName
 
 var (
 	buildVersion = "unknown"


### PR DESCRIPTION
- Use "netobserv" instead of "network-observability" (e.g. as default namespace)

Other required PRs:

- console: https://github.com/netobserv/network-observability-console-plugin/pull/191
- docs: https://github.com/netobserv/documents/pull/26
