### PR TITLE
Fix scc for sample-workload

### DIFF
--- a/.mk/sample.mk
+++ b/.mk/sample.mk
@@ -19,6 +19,7 @@ undeploy-sample-cr:
 deploy-sample-workload:
 	@echo -e "\n==> Deploy sample workload"
 	-kubectl create namespace sample-workload
+	oc adm policy add-scc-to-user privileged system:serviceaccount:sample-workload:default
 	kubectl -n sample-workload apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/main/release/kubernetes-manifests.yaml
 	kubectl -n sample-workload run syn-flood --privileged --image=bilalcaliskan/syn-flood:latest --restart=Never -- --host frontend-external.sample-workload.svc.cluster.local --port 80 --floodType syn
 


### PR DESCRIPTION
In the current implementation, there are no sufficient privileges to deploy the demo workload. This PR adds privileged scc to the default serviceaccount under the namespace sample-workload