### PR TITLE
Expose new Kafka parameters + tweak defaults

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -155,7 +155,7 @@ type FlowCollectorEBPF struct {
 	// imagePullPolicy is the Kubernetes pull policy for the image defined above
 	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
 
-	//+kubebuilder:default:={requests:{memory:"50Mi",cpu:"100m"},limits:{memory:"100Mi"}}
+	//+kubebuilder:default:={requests:{memory:"50Mi",cpu:"100m"},limits:{memory:"800Mi"}}
 	// resources are the compute resources required by this container.
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -175,7 +175,7 @@ type FlowCollectorEBPF struct {
 
 	// cacheMaxFlows is the max number of flows in an aggregate; when reached, the reporter sends the flows
 	//+kubebuilder:validation:Minimum=1
-	//+kubebuilder:default:=5000
+	//+kubebuilder:default:=100000
 	CacheMaxFlows int32 `json:"cacheMaxFlows,omitempty"`
 
 	// interfaces contains the interface names from where flows will be collected. If empty, the agent
@@ -208,6 +208,11 @@ type FlowCollectorEBPF struct {
 	// BPF, PERFMON, NET_ADMIN, SYS_RESOURCE.
 	// +optional
 	Privileged bool `json:"privileged,omitempty"`
+
+	//+kubebuilder:default:=10485760
+	// +optional
+	// kafkaBatchSize limits the maximum size of a request in bytes before being sent to a partition. Ignored when not using Kafka. Default: 10MB.
+	KafkaBatchSize int `json:"kafkaBatchSize"`
 }
 
 // FlowCollectorKafka defines the desired Kafka config of FlowCollector
@@ -310,7 +315,7 @@ type FlowCollectorFLP struct {
 	// logLevel of the collector runtime
 	LogLevel string `json:"logLevel,omitempty"`
 
-	//+kubebuilder:default:={requests:{memory:"100Mi",cpu:"100m"},limits:{memory:"300Mi"}}
+	//+kubebuilder:default:={requests:{memory:"100Mi",cpu:"100m"},limits:{memory:"800Mi"}}
 	// resources are the compute resources required by this container.
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -335,6 +340,16 @@ type FlowCollectorFLP struct {
 	// This setting is ignored when Kafka is disabled.
 	// +optional
 	KafkaConsumerAutoscaler *FlowCollectorHPA `json:"kafkaConsumerAutoscaler,omitempty"`
+
+	//+kubebuilder:default:=1000
+	// +optional
+	// kafkaConsumerQueueCapacity defines the capacity of the internal message queue used in the Kafka consumer client. Ignored when not using Kafka.
+	KafkaConsumerQueueCapacity int `json:"kafkaConsumerQueueCapacity"`
+
+	//+kubebuilder:default:=10485760
+	// +optional
+	// kafkaConsumerBatchSize indicates to the broker the maximum batch size, in bytes, that the consumer will accept. Ignored when not using Kafka. Default: 10MB.
+	KafkaConsumerBatchSize int `json:"kafkaConsumerBatchSize"`
 }
 
 type FlowCollectorHPA struct {

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -66,7 +66,7 @@ spec:
                         pattern: ^\d+(ns|ms|s|m)?$
                         type: string
                       cacheMaxFlows:
-                        default: 5000
+                        default: 100000
                         description: cacheMaxFlows is the max number of flows in an
                           aggregate; when reached, the reporter sends the flows
                         format: int32
@@ -117,6 +117,12 @@ spec:
                         items:
                           type: string
                         type: array
+                      kafkaBatchSize:
+                        default: 10485760
+                        description: 'kafkaBatchSize limits the maximum size of a
+                          request in bytes before being sent to a partition. Ignored
+                          when not using Kafka. Default: 10MB.'
+                        type: integer
                       logLevel:
                         default: info
                         description: logLevel defines the log level for the NetObserv
@@ -139,7 +145,7 @@ spec:
                       resources:
                         default:
                           limits:
-                            memory: 100Mi
+                            memory: 800Mi
                           requests:
                             cpu: 100m
                             memory: 50Mi
@@ -1688,6 +1694,18 @@ spec:
                     required:
                     - maxReplicas
                     type: object
+                  kafkaConsumerBatchSize:
+                    default: 10485760
+                    description: 'kafkaConsumerBatchSize indicates to the broker the
+                      maximum batch size, in bytes, that the consumer will accept.
+                      Ignored when not using Kafka. Default: 10MB.'
+                    type: integer
+                  kafkaConsumerQueueCapacity:
+                    default: 1000
+                    description: kafkaConsumerQueueCapacity defines the capacity of
+                      the internal message queue used in the Kafka consumer client.
+                      Ignored when not using Kafka.
+                    type: integer
                   kafkaConsumerReplicas:
                     default: 3
                     description: kafkaConsumerReplicas defines the number of replicas
@@ -1778,7 +1796,7 @@ spec:
                   resources:
                     default:
                       limits:
-                        memory: 300Mi
+                        memory: 800Mi
                       requests:
                         cpu: 100m
                         memory: 100Mi

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -22,7 +22,7 @@ spec:
       imagePullPolicy: IfNotPresent
       sampling: 50
       cacheActiveTimeout: 5s
-      cacheMaxFlows: 1000
+      cacheMaxFlows: 100000
       interfaces: [ ]
       excludeInterfaces: [ "lo" ]
       logLevel: info
@@ -32,7 +32,8 @@ spec:
           memory: 50Mi
           cpu: 100m
         limits:
-          memory: 100Mi
+          memory: 800Mi
+      kafkaBatchSize: 10485760
   processor:
     port: 2055
     image: 'quay.io/netobserv/flowlogs-pipeline:main'
@@ -50,9 +51,11 @@ spec:
         memory: 100Mi
         cpu: 100m
       limits:
-        memory: 300Mi
+        memory: 800Mi
     kafkaConsumerReplicas: 3
     kafkaConsumerAutoscaler: null
+    kafkaConsumerQueueCapacity: 1000
+    kafkaConsumerBatchSize: 10485760
   kafka:
     address: "kafka-cluster-kafka-bootstrap.netobserv"
     topic: network-flows
@@ -70,10 +73,10 @@ spec:
   loki:
     url: 'http://loki.netobserv.svc:3100/'
     batchWait: 1s
-    batchSize: 102400
+    batchSize: 10485760
     minBackoff: 1s
-    maxBackoff: 300s
-    maxRetries: 10
+    maxBackoff: 30s
+    maxRetries: 5
     staticLabels:
       app: netobserv-flowcollector
     tls:

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -34,6 +34,8 @@ const (
 	envExport                     = "EXPORT"
 	envKafkaBrokers               = "KAFKA_BROKERS"
 	envKafkaTopic                 = "KAFKA_TOPIC"
+	envKafkaBatchSize             = "KAFKA_BATCH_SIZE"
+	envKafkaBatchMessages         = "KAFKA_BATCH_MESSAGES"
 	envKafkaEnableTLS             = "KAFKA_ENABLE_TLS"
 	envKafkaTLSInsecureSkipVerify = "KAFKA_TLS_INSECURE_SKIP_VERIFY"
 	envKafkaTLSCACertPath         = "KAFKA_TLS_CA_CERT_PATH"
@@ -50,6 +52,7 @@ const (
 )
 
 const kafkaCerts = "kafka-certs"
+const averageMessageSize = 100
 
 type reconcileAction int
 
@@ -240,6 +243,9 @@ func (c *AgentController) envConfig(coll *flowsv1alpha1.FlowCollector) []corev1.
 			corev1.EnvVar{Name: envExport, Value: exportKafka},
 			corev1.EnvVar{Name: envKafkaBrokers, Value: coll.Spec.Kafka.Address},
 			corev1.EnvVar{Name: envKafkaTopic, Value: coll.Spec.Kafka.Topic},
+			corev1.EnvVar{Name: envKafkaBatchSize, Value: strconv.Itoa(coll.Spec.Agent.EBPF.KafkaBatchSize)},
+			// For easier user configuration, we can assume a constant message size per flow (~100B in protobuf)
+			corev1.EnvVar{Name: envKafkaBatchMessages, Value: strconv.Itoa(coll.Spec.Agent.EBPF.KafkaBatchSize / averageMessageSize)},
 		)
 		if coll.Spec.Kafka.TLS.Enable {
 			config = append(config,

--- a/controllers/flowlogspipeline/flp_transfo_objects.go
+++ b/controllers/flowlogspipeline/flp_transfo_objects.go
@@ -58,11 +58,13 @@ func (b *transfoBuilder) buildPipelineConfig() ([]config.Stage, []config.StagePa
 		decoder = api.Decoder{Type: "json"}
 	}
 	pipeline := config.NewKafkaPipeline("kafka-read", api.IngestKafka{
-		Brokers: []string{b.generic.desired.Kafka.Address},
-		Topic:   b.generic.desired.Kafka.Topic,
-		GroupId: b.generic.name(), // Without groupid, each message is delivered to each consumers
-		Decoder: decoder,
-		TLS:     b.generic.getKafkaTLS(),
+		Brokers:           []string{b.generic.desired.Kafka.Address},
+		Topic:             b.generic.desired.Kafka.Topic,
+		GroupId:           b.generic.name(), // Without groupid, each message is delivered to each consumers
+		Decoder:           decoder,
+		TLS:               b.generic.getKafkaTLS(),
+		PullQueueCapacity: b.generic.desired.Processor.KafkaConsumerQueueCapacity,
+		PullMaxBytes:      b.generic.desired.Processor.KafkaConsumerBatchSize,
 	})
 
 	err := b.generic.addTransformStages(&pipeline)

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -217,7 +217,7 @@ ebpf describes the settings related to the eBPF-based flow reporter when the "ag
           cacheMaxFlows is the max number of flows in an aggregate; when reached, the reporter sends the flows<br/>
           <br/>
             <i>Format</i>: int32<br/>
-            <i>Default</i>: 5000<br/>
+            <i>Default</i>: 100000<br/>
             <i>Minimum</i>: 1<br/>
         </td>
         <td>false</td>
@@ -264,6 +264,15 @@ ebpf describes the settings related to the eBPF-based flow reporter when the "ag
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>kafkaBatchSize</b></td>
+        <td>integer</td>
+        <td>
+          kafkaBatchSize limits the maximum size of a request in bytes before being sent to a partition. Ignored when not using Kafka. Default: 10MB.<br/>
+          <br/>
+            <i>Default</i>: 10485760<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>logLevel</b></td>
         <td>enum</td>
         <td>
@@ -286,7 +295,7 @@ ebpf describes the settings related to the eBPF-based flow reporter when the "ag
         <td>
           resources are the compute resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
           <br/>
-            <i>Default</i>: map[limits:map[memory:100Mi] requests:map[cpu:100m memory:50Mi]]<br/>
+            <i>Default</i>: map[limits:map[memory:800Mi] requests:map[cpu:100m memory:50Mi]]<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2137,6 +2146,24 @@ processor defines the settings of the component that receives the flows from the
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>kafkaConsumerBatchSize</b></td>
+        <td>integer</td>
+        <td>
+          kafkaConsumerBatchSize indicates to the broker the maximum batch size, in bytes, that the consumer will accept. Ignored when not using Kafka. Default: 10MB.<br/>
+          <br/>
+            <i>Default</i>: 10485760<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>kafkaConsumerQueueCapacity</b></td>
+        <td>integer</td>
+        <td>
+          kafkaConsumerQueueCapacity defines the capacity of the internal message queue used in the Kafka consumer client. Ignored when not using Kafka.<br/>
+          <br/>
+            <i>Default</i>: 1000<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>kafkaConsumerReplicas</b></td>
         <td>integer</td>
         <td>
@@ -2193,7 +2220,7 @@ processor defines the settings of the component that receives the flows from the
         <td>
           resources are the compute resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
           <br/>
-            <i>Default</i>: map[limits:map[memory:300Mi] requests:map[cpu:100m memory:100Mi]]<br/>
+            <i>Default</i>: map[limits:map[memory:800Mi] requests:map[cpu:100m memory:100Mi]]<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
Follow-up on https://github.com/netobserv/flowlogs-pipeline/pull/309

- PullQueueCapacity: capacity of the kafka consumer client internal
  queue
- PullMaxBytes: indicates to the broker the maximum batch size that the consumer will accept.

**Update**
[Add producerBatchSize, add metric, tweak defaults](https://github.com/netobserv/network-observability-operator/pull/170/commits/3fc9186b02f61ca405f036b590cb7f0b9f364b1d)
[3fc9186](https://github.com/netobserv/network-observability-operator/pull/170/commits/3fc9186b02f61ca405f036b590cb7f0b9f364b1d)

New metric "bandwidth_per_namespace" allows to get flows sizes (ie.
extracted Bytes sum) per source and dest namespace
That proves useful for self-monitoring, eg. to get the overhead of
netobserv's traffic compared to the rest of the traffic.

Also, setting a much higher cacheMaxSize for the ebpf agent, to reduce
traffic overhead.

Also raising limits for agent+FLP to 800MB

And tweaking loki client default to decrease number of retries and increase batch size