### PR TITLE
NETOBSERV-489: Use authorize feature from console plugin API

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -416,6 +416,15 @@ type FlowCollectorLoki struct {
 	TLS ClientTLS `json:"tls"`
 }
 
+const (
+	IgnoreUserToken  = "IGNORE"
+	ForwardUserToken = "FORWARD"
+)
+
+func (spec *FlowCollectorConsolePlugin) ForwardUserToken() bool {
+	return spec.UserToken == ForwardUserToken
+}
+
 // FlowCollectorConsolePlugin defines the desired ConsolePlugin state of FlowCollector
 type FlowCollectorConsolePlugin struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
@@ -446,10 +455,11 @@ type FlowCollectorConsolePlugin struct {
 	// imagePullPolicy is the Kubernetes pull policy for the image defined above
 	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
 
-	//+kubebuilder:default:=false
+	// +kubebuilder:validation:Enum:="IGNORE";"FORWARD"
+	//+kubebuilder:default:="IGNORE"
 	// sendAuthToken is a flag to enable or disable forwarind auth token
 	// if enabled, this overide loki.sendAuthToken
-	ForwardUserAuthToken bool `json:"forwardUserAuthToken,omitempty"`
+	UserToken string `json:"forwardUserAuthToken,omitempty"`
 
 	//+kubebuilder:default:={requests:{memory:"50Mi",cpu:"100m"},limits:{memory:"100Mi"}}
 	// resources, in terms of compute resources, required by this container.

--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -446,6 +446,11 @@ type FlowCollectorConsolePlugin struct {
 	// imagePullPolicy is the Kubernetes pull policy for the image defined above
 	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
 
+	//+kubebuilder:default:=false
+	// sendAuthToken is a flag to enable or disable forwarind auth token
+	// if enabled, this overide loki.sendAuthToken
+	ForwardUserAuthToken bool `json:"forwardUserAuthToken,omitempty"`
+
 	//+kubebuilder:default:={requests:{memory:"50Mi",cpu:"100m"},limits:{memory:"100Mi"}}
 	// resources, in terms of compute resources, required by this container.
 	// Cannot be updated.

--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -352,6 +352,24 @@ type FlowCollectorHPA struct {
 	Metrics []ascv2.MetricSpec `json:"metrics"`
 }
 
+const (
+	LokiAuthDisabled         = "DISABLED"
+	LokiAuthUseHostToken     = "HOST"
+	LokiAuthForwardUserToken = "FORWARD"
+)
+
+func (spec *FlowCollectorLoki) NoAuthToken() bool {
+	return spec.AuthToken == LokiAuthDisabled
+}
+
+func (spec *FlowCollectorLoki) UseHostToken() bool {
+	return spec.AuthToken == LokiAuthUseHostToken
+}
+
+func (spec *FlowCollectorLoki) ForwardUserToken() bool {
+	return spec.AuthToken == LokiAuthForwardUserToken
+}
+
 // FlowCollectorLoki defines the desired state for FlowCollector's Loki client
 type FlowCollectorLoki struct {
 	//+kubebuilder:default:="http://loki:3100/"
@@ -375,10 +393,13 @@ type FlowCollectorLoki struct {
 	// it will be ignored if instanceSpec is specified
 	TenantID string `json:"tenantID,omitempty"`
 
-	//+kubebuilder:default:=false
-	// sendAuthToken is a flag to enable or disable Authorization header from service account secret
-	// It allows authentication to loki operator gateway
-	SendAuthToken bool `json:"sendAuthToken,omitempty"`
+	// +kubebuilder:validation:Enum:="DISABLED";"HOST";"FORWARD"
+	//+kubebuilder:default:="DISABLED"
+	// AuthToken describe the way to get a token to authenticate to Loki
+	// DISABLED will not send any token with the request
+	// HOST will use the local pod service account to authenticate to Loki
+	// FORWARD will forward user token, in this mode, pod that are not receiving user request like the processor will use the local pod service account. Similar to HOST mode.
+	AuthToken string `json:"authToken,omitempty"`
 
 	//+kubebuilder:default:="1s"
 	// batchWait is max time to wait before sending a batch
@@ -416,15 +437,6 @@ type FlowCollectorLoki struct {
 	TLS ClientTLS `json:"tls"`
 }
 
-const (
-	IgnoreUserToken  = "IGNORE"
-	ForwardUserToken = "FORWARD"
-)
-
-func (spec *FlowCollectorConsolePlugin) ForwardUserToken() bool {
-	return spec.UserToken == ForwardUserToken
-}
-
 // FlowCollectorConsolePlugin defines the desired ConsolePlugin state of FlowCollector
 type FlowCollectorConsolePlugin struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
@@ -454,12 +466,6 @@ type FlowCollectorConsolePlugin struct {
 	//+kubebuilder:default:=IfNotPresent
 	// imagePullPolicy is the Kubernetes pull policy for the image defined above
 	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
-
-	// +kubebuilder:validation:Enum:="IGNORE";"FORWARD"
-	//+kubebuilder:default:="IGNORE"
-	// sendAuthToken is a flag to enable or disable forwarind auth token
-	// if enabled, this overide loki.sendAuthToken
-	UserToken string `json:"forwardUserAuthToken,omitempty"`
 
 	//+kubebuilder:default:={requests:{memory:"50Mi",cpu:"100m"},limits:{memory:"100Mi"}}
 	// resources, in terms of compute resources, required by this container.

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -787,14 +787,6 @@ spec:
                     required:
                     - maxReplicas
                     type: object
-                  forwardUserAuthToken:
-                    default: IGNORE
-                    description: sendAuthToken is a flag to enable or disable forwarind
-                      auth token if enabled, this overide loki.sendAuthToken
-                    enum:
-                    - IGNORE
-                    - FORWARD
-                    type: string
                   image:
                     default: quay.io/netobserv/network-observability-console-plugin:main
                     description: image is the plugin image (including domain and tag)
@@ -992,6 +984,19 @@ spec:
               loki:
                 description: loki, the flow store, client settings.
                 properties:
+                  authToken:
+                    default: DISABLED
+                    description: AuthToken describe the way to get a token to authenticate
+                      to Loki DISABLED will not send any token with the request HOST
+                      will use the local pod service account to authenticate to Loki
+                      FORWARD will forward user token, in this mode, pod that are
+                      not receiving user request like the processor will use the local
+                      pod service account. Similar to HOST mode.
+                    enum:
+                    - DISABLED
+                    - HOST
+                    - FORWARD
+                    type: string
                   batchSize:
                     default: 102400
                     description: batchSize is max batch size (in bytes) of logs to
@@ -1026,12 +1031,6 @@ spec:
                       If empty, the URL value will be used (assuming that the Loki
                       ingester and querier are in the same server).
                     type: string
-                  sendAuthToken:
-                    default: false
-                    description: sendAuthToken is a flag to enable or disable Authorization
-                      header from service account secret It allows authentication
-                      to loki operator gateway
-                    type: boolean
                   staticLabels:
                     additionalProperties:
                       type: string

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -787,6 +787,11 @@ spec:
                     required:
                     - maxReplicas
                     type: object
+                  forwardUserAuthToken:
+                    default: false
+                    description: sendAuthToken is a flag to enable or disable forwarind
+                      auth token if enabled, this overide loki.sendAuthToken
+                    type: boolean
                   image:
                     default: quay.io/netobserv/network-observability-console-plugin:main
                     description: image is the plugin image (including domain and tag)

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -788,10 +788,13 @@ spec:
                     - maxReplicas
                     type: object
                   forwardUserAuthToken:
-                    default: false
+                    default: IGNORE
                     description: sendAuthToken is a flag to enable or disable forwarind
                       auth token if enabled, this overide loki.sendAuthToken
-                    type: boolean
+                    enum:
+                    - IGNORE
+                    - FORWARD
+                    type: string
                   image:
                     default: quay.io/netobserv/network-observability-console-plugin:main
                     description: image is the plugin image (including domain and tag)

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -84,7 +84,7 @@ spec:
         certFile: service-ca.crt
   consolePlugin:
     register: true
-    forwardUserAuthToken: false
+    forwardUserAuthToken: IGNORE
     image: 'quay.io/netobserv/network-observability-console-plugin:main'
     imagePullPolicy: IfNotPresent
     port: 9001

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -84,6 +84,7 @@ spec:
         certFile: service-ca.crt
   consolePlugin:
     register: true
+    forwardUserAuthToken: false
     image: 'quay.io/netobserv/network-observability-console-plugin:main'
     imagePullPolicy: IfNotPresent
     port: 9001

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -84,7 +84,6 @@ spec:
         certFile: service-ca.crt
   consolePlugin:
     register: true
-    forwardUserAuthToken: IGNORE
     image: 'quay.io/netobserv/network-observability-console-plugin:main'
     imagePullPolicy: IfNotPresent
     port: 9001

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -102,7 +102,7 @@ func (b *builder) deployment(cmDigest string) *appsv1.Deployment {
 }
 
 func tokenPath(desiredLoki *flowsv1alpha1.FlowCollectorLoki) string {
-	if desiredLoki.SendAuthToken {
+	if desiredLoki.UseHostToken() {
 		return tokensPath + constants.PluginName
 	}
 	return ""
@@ -122,7 +122,7 @@ func buildArgs(desired *flowsv1alpha1.FlowCollectorConsolePlugin, desiredLoki *f
 		"-frontend-config", filepath.Join(configPath, configFile),
 	}
 
-	if desired.ForwardUserToken() {
+	if desiredLoki.ForwardUserToken() {
 		args = append(args, "-loki-forward-user-token")
 	}
 
@@ -137,7 +137,7 @@ func buildArgs(desired *flowsv1alpha1.FlowCollectorConsolePlugin, desiredLoki *f
 			args = append(args, "--loki-ca-path", helper.GetCACertPath(&desiredLoki.TLS, lokiCerts))
 		}
 	}
-	if desiredLoki.SendAuthToken {
+	if desiredLoki.UseHostToken() {
 		args = append(args, "-loki-token-path", tokenPath(desiredLoki))
 	}
 	return args
@@ -179,7 +179,7 @@ func (b *builder) podTemplate(cmDigest string) *corev1.PodTemplateSpec {
 		volumes, volumeMounts = helper.AppendCertVolumes(volumes, volumeMounts, &b.desiredLoki.TLS, lokiCerts)
 	}
 
-	if b.desiredLoki.SendAuthToken {
+	if b.desiredLoki.UseHostToken() {
 		volumes, volumeMounts = helper.AppendTokenVolume(volumes, volumeMounts, constants.PluginName, constants.PluginName)
 	}
 

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -71,8 +71,9 @@ func (b *builder) consolePlugin() *osv1alpha1.ConsolePlugin {
 				BasePath:  "/",
 			},
 			Proxy: []osv1alpha1.ConsolePluginProxy{{
-				Type:  osv1alpha1.ProxyTypeService,
-				Alias: proxyAlias,
+				Type:      osv1alpha1.ProxyTypeService,
+				Alias:     proxyAlias,
+				Authorize: true,
 				Service: osv1alpha1.ConsolePluginProxyServiceConfig{
 					Name:      constants.PluginName,
 					Namespace: b.namespace,
@@ -119,6 +120,10 @@ func buildArgs(desired *flowsv1alpha1.FlowCollectorConsolePlugin, desiredLoki *f
 		"-loki-tenant-id", desiredLoki.TenantID,
 		"-loglevel", desired.LogLevel,
 		"-frontend-config", filepath.Join(configPath, configFile),
+	}
+
+	if desired.ForwardUserAuthToken {
+		args = append(args, "-loki-forward-user-token")
 	}
 
 	if querierURL != statusURL {

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -122,7 +122,7 @@ func buildArgs(desired *flowsv1alpha1.FlowCollectorConsolePlugin, desiredLoki *f
 		"-frontend-config", filepath.Join(configPath, configFile),
 	}
 
-	if desired.ForwardUserAuthToken {
+	if desired.ForwardUserToken() {
 		args = append(args, "-loki-forward-user-token")
 	}
 

--- a/controllers/flowlogspipeline/flp_common_objects.go
+++ b/controllers/flowlogspipeline/flp_common_objects.go
@@ -174,7 +174,7 @@ func (b *builder) podTemplate(hasHostPort, hasLokiInterface, hostNetwork bool, c
 		if b.desired.Loki.TLS.Enable {
 			volumes, volumeMounts = helper.AppendCertVolumes(volumes, volumeMounts, &b.desired.Loki.TLS, lokiCerts)
 		}
-		if b.desired.Loki.SendAuthToken {
+		if b.desired.Loki.UseHostToken() {
 			volumes, volumeMounts = helper.AppendTokenVolume(volumes, volumeMounts, lokiToken, constants.FLPName)
 		}
 	}
@@ -333,7 +333,7 @@ func (b *builder) addTransformStages(stage *config.PipelineBuilderStage) error {
 	}
 
 	var authorization *promConfig.Authorization
-	if b.desired.Loki.SendAuthToken {
+	if b.desired.Loki.UseHostToken() {
 		authorization = &promConfig.Authorization{
 			Type:            "Bearer",
 			CredentialsFile: helper.TokensPath + constants.FLPName,

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -522,11 +522,12 @@ consolePlugin defines the settings related to the OpenShift Console plugin, when
         <td>false</td>
       </tr><tr>
         <td><b>forwardUserAuthToken</b></td>
-        <td>boolean</td>
+        <td>enum</td>
         <td>
           sendAuthToken is a flag to enable or disable forwarind auth token if enabled, this overide loki.sendAuthToken<br/>
           <br/>
-            <i>Default</i>: false<br/>
+            <i>Enum</i>: IGNORE, FORWARD<br/>
+            <i>Default</i>: IGNORE<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -521,6 +521,15 @@ consolePlugin defines the settings related to the OpenShift Console plugin, when
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>forwardUserAuthToken</b></td>
+        <td>boolean</td>
+        <td>
+          sendAuthToken is a flag to enable or disable forwarind auth token if enabled, this overide loki.sendAuthToken<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>image</b></td>
         <td>string</td>
         <td>

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -521,16 +521,6 @@ consolePlugin defines the settings related to the OpenShift Console plugin, when
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>forwardUserAuthToken</b></td>
-        <td>enum</td>
-        <td>
-          sendAuthToken is a flag to enable or disable forwarind auth token if enabled, this overide loki.sendAuthToken<br/>
-          <br/>
-            <i>Enum</i>: IGNORE, FORWARD<br/>
-            <i>Default</i>: IGNORE<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b>image</b></td>
         <td>string</td>
         <td>
@@ -1797,6 +1787,16 @@ loki, the flow store, client settings.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>authToken</b></td>
+        <td>enum</td>
+        <td>
+          AuthToken describe the way to get a token to authenticate to Loki DISABLED will not send any token with the request HOST will use the local pod service account to authenticate to Loki FORWARD will forward user token, in this mode, pod that are not receiving user request like the processor will use the local pod service account. Similar to HOST mode.<br/>
+          <br/>
+            <i>Enum</i>: DISABLED, HOST, FORWARD<br/>
+            <i>Default</i>: DISABLED<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>batchSize</b></td>
         <td>integer</td>
         <td>
@@ -1850,15 +1850,6 @@ loki, the flow store, client settings.
         <td>string</td>
         <td>
           querierURL specifies the address of the Loki querier service, in case it is different from the Loki ingester URL. If empty, the URL value will be used (assuming that the Loki ingester and querier are in the same server).<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>sendAuthToken</b></td>
-        <td>boolean</td>
-        <td>
-          sendAuthToken is a flag to enable or disable Authorization header from service account secret It allows authentication to loki operator gateway<br/>
-          <br/>
-            <i>Default</i>: false<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
This PR enable the new option from the console from this PR:

https://github.com/netobserv/network-observability-console-plugin/pull/198