### PR TITLE
NETOBSERV-382: Added status field in HPA configuration

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -374,8 +374,8 @@ const (
 type FlowCollectorHPA struct {
 	// +kubebuilder:validation:Enum:=DISABLED;ENABLED
 	// +kubebuilder:default:=DISABLED
-	// AuthToken describe the way to get a token to authenticate to Loki
-	// DISABLED will not send any token with the requestmode.
+	// Status describe the desired status regarding deploying an horizontal pod autoscaler
+	// DISABLED will not deploy an horizontal pod autoscaler
 	// ENABLED will deploy an horizontal pod autoscaler
 	Status string `json:"status,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -165,11 +165,7 @@ func (in *FlowCollectorAgent) DeepCopy() *FlowCollectorAgent {
 func (in *FlowCollectorConsolePlugin) DeepCopyInto(out *FlowCollectorConsolePlugin) {
 	*out = *in
 	in.Resources.DeepCopyInto(&out.Resources)
-	if in.Autoscaler != nil {
-		in, out := &in.Autoscaler, &out.Autoscaler
-		*out = new(FlowCollectorHPA)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Autoscaler.DeepCopyInto(&out.Autoscaler)
 	in.PortNaming.DeepCopyInto(&out.PortNaming)
 }
 
@@ -226,11 +222,7 @@ func (in *FlowCollectorFLP) DeepCopyInto(out *FlowCollectorFLP) {
 	*out = *in
 	in.Metrics.DeepCopyInto(&out.Metrics)
 	in.Resources.DeepCopyInto(&out.Resources)
-	if in.KafkaConsumerAutoscaler != nil {
-		in, out := &in.KafkaConsumerAutoscaler, &out.KafkaConsumerAutoscaler
-		*out = new(FlowCollectorHPA)
-		(*in).DeepCopyInto(*out)
-	}
+	in.KafkaConsumerAutoscaler.DeepCopyInto(&out.KafkaConsumerAutoscaler)
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -793,9 +793,10 @@ spec:
                         type: integer
                       status:
                         default: DISABLED
-                        description: AuthToken describe the way to get a token to
-                          authenticate to Loki DISABLED will not send any token with
-                          the requestmode. ENABLED will deploy an horizontal pod autoscaler
+                        description: Status describe the desired status regarding
+                          deploying an horizontal pod autoscaler DISABLED will not
+                          deploy an horizontal pod autoscaler ENABLED will deploy
+                          an horizontal pod autoscaler
                         enum:
                         - DISABLED
                         - ENABLED
@@ -1712,9 +1713,10 @@ spec:
                         type: integer
                       status:
                         default: DISABLED
-                        description: AuthToken describe the way to get a token to
-                          authenticate to Loki DISABLED will not send any token with
-                          the requestmode. ENABLED will deploy an horizontal pod autoscaler
+                        description: Status describe the desired status regarding
+                          deploying an horizontal pod autoscaler DISABLED will not
+                          deploy an horizontal pod autoscaler ENABLED will deploy
+                          an horizontal pod autoscaler
                         enum:
                         - DISABLED
                         - ENABLED

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -278,6 +278,7 @@ spec:
                       set up for the plugin Deployment.
                     properties:
                       maxReplicas:
+                        default: 3
                         description: maxReplicas is the upper limit for the number
                           of pods that can be set by the autoscaler; cannot be smaller
                           than MinReplicas.
@@ -790,8 +791,15 @@ spec:
                           active as long as at least one metric value is available.
                         format: int32
                         type: integer
-                    required:
-                    - maxReplicas
+                      status:
+                        default: DISABLED
+                        description: AuthToken describe the way to get a token to
+                          authenticate to Loki DISABLED will not send any token with
+                          the requestmode. ENABLED will deploy an horizontal pod autoscaler
+                        enum:
+                        - DISABLED
+                        - ENABLED
+                        type: string
                     type: object
                   image:
                     default: quay.io/netobserv/network-observability-console-plugin:main
@@ -1189,6 +1197,7 @@ spec:
                       is disabled.
                     properties:
                       maxReplicas:
+                        default: 3
                         description: maxReplicas is the upper limit for the number
                           of pods that can be set by the autoscaler; cannot be smaller
                           than MinReplicas.
@@ -1701,8 +1710,15 @@ spec:
                           active as long as at least one metric value is available.
                         format: int32
                         type: integer
-                    required:
-                    - maxReplicas
+                      status:
+                        default: DISABLED
+                        description: AuthToken describe the way to get a token to
+                          authenticate to Loki DISABLED will not send any token with
+                          the requestmode. ENABLED will deploy an horizontal pod autoscaler
+                        enum:
+                        - DISABLED
+                        - ENABLED
+                        type: string
                     type: object
                   kafkaConsumerBatchSize:
                     default: 10485760

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -94,6 +94,17 @@ spec:
     imagePullPolicy: IfNotPresent
     port: 9001
     logLevel: info
+    autoscaler:
+      status: DISABLED
+      minReplicas: 1
+      maxReplicas: 3
+      metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 50
     portNaming:
       enable: true
       portNames:

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -94,7 +94,6 @@ spec:
     imagePullPolicy: IfNotPresent
     port: 9001
     logLevel: info
-    autoscaler: null
     portNaming:
       enable: true
       portNames:

--- a/controllers/consoleplugin/consoleplugin_reconciler.go
+++ b/controllers/consoleplugin/consoleplugin_reconciler.go
@@ -201,7 +201,7 @@ func (r *CPReconciler) reconcileService(ctx context.Context, builder builder, de
 
 func (r *CPReconciler) reconcileHPA(ctx context.Context, builder builder, desired *flowsv1alpha1.FlowCollectorSpec, ns string) error {
 	// Delete or Create / Update Autoscaler according to HPA option
-	if desired.ConsolePlugin.Autoscaler == nil {
+	if desired.ConsolePlugin.Autoscaler.Disabled() {
 		r.nobjMngr.TryDelete(ctx, r.owned.hpa)
 	} else {
 		newASC := builder.autoScaler()
@@ -229,7 +229,7 @@ func deploymentNeedsUpdate(depl *appsv1.Deployment, desired *flowsv1alpha1.FlowC
 	}
 	return containerNeedsUpdate(&depl.Spec.Template.Spec, &desired.ConsolePlugin, &desired.Loki) ||
 		configChanged(&depl.Spec.Template, cmDigest) ||
-		(desired.ConsolePlugin.Autoscaler == nil && *depl.Spec.Replicas != desired.ConsolePlugin.Replicas)
+		(desired.ConsolePlugin.Autoscaler.Disabled() && *depl.Spec.Replicas != desired.ConsolePlugin.Replicas)
 }
 
 func configChanged(tmpl *corev1.PodTemplateSpec, cmDigest string) bool {

--- a/controllers/consoleplugin/consoleplugin_test.go
+++ b/controllers/consoleplugin/consoleplugin_test.go
@@ -43,7 +43,8 @@ func getPluginConfig() flowsv1alpha1.FlowCollectorConsolePlugin {
 		Image:           testImage,
 		ImagePullPolicy: string(testPullPolicy),
 		Resources:       testResources,
-		Autoscaler: &flowsv1alpha1.FlowCollectorHPA{
+		Autoscaler: flowsv1alpha1.FlowCollectorHPA{
+			Status:      flowsv1alpha1.HPAStatusEnabled,
 			MinReplicas: &minReplicas,
 			MaxReplicas: maxReplicas,
 			Metrics: []ascv2.MetricSpec{{

--- a/controllers/flowcollector_controller_console_test.go
+++ b/controllers/flowcollector_controller_console_test.go
@@ -78,7 +78,8 @@ func flowCollectorConsolePluginSpecs() {
 						ImagePullPolicy: "Never",
 						Image:           "testimg:latest",
 						Register:        true,
-						Autoscaler: &flowsv1alpha1.FlowCollectorHPA{
+						Autoscaler: flowsv1alpha1.FlowCollectorHPA{
+							Status:      flowsv1alpha1.HPAStatusEnabled,
 							MinReplicas: pointer.Int32(1),
 							MaxReplicas: 1,
 							Metrics: []ascv2.MetricSpec{{
@@ -152,7 +153,7 @@ func flowCollectorConsolePluginSpecs() {
 				}
 				fc.Spec.ConsolePlugin.Port = 9099
 				fc.Spec.ConsolePlugin.Replicas = 2
-				fc.Spec.ConsolePlugin.Autoscaler = nil
+				fc.Spec.ConsolePlugin.Autoscaler.Status = flowsv1alpha1.HPAStatusDisabled
 				return k8sClient.Update(ctx, &fc)
 			}).Should(Succeed())
 

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -381,7 +381,8 @@ func flowCollectorControllerSpecs() {
 		hpa := ascv2.HorizontalPodAutoscaler{}
 		It("Should update with HPA", func() {
 			UpdateCR(crKey, func(fc *flowsv1alpha1.FlowCollector) {
-				fc.Spec.Processor.KafkaConsumerAutoscaler = &flowsv1alpha1.FlowCollectorHPA{
+				fc.Spec.Processor.KafkaConsumerAutoscaler = flowsv1alpha1.FlowCollectorHPA{
+					Status:      flowsv1alpha1.HPAStatusEnabled,
 					MinReplicas: pointer.Int32(1),
 					MaxReplicas: 1,
 					Metrics: []ascv2.MetricSpec{{

--- a/controllers/flowlogspipeline/flp_transfo_reconciler.go
+++ b/controllers/flowlogspipeline/flp_transfo_reconciler.go
@@ -137,7 +137,7 @@ func (r *flpTransformerReconciler) reconcileDeployment(ctx context.Context, desi
 	}
 
 	// Delete or Create / Update Autoscaler according to HPA option
-	if desiredFLP.KafkaConsumerAutoscaler == nil {
+	if desiredFLP.KafkaConsumerAutoscaler.Disabled() {
 		r.nobjMngr.TryDelete(ctx, r.owned.hpa)
 	} else {
 		newASC := builder.autoScaler()
@@ -182,10 +182,10 @@ func (r *flpTransformerReconciler) reconcilePermissions(ctx context.Context, bui
 func deploymentNeedsUpdate(depl *appsv1.Deployment, desired *flpSpec, configDigest string) bool {
 	return containerNeedsUpdate(&depl.Spec.Template.Spec, desired, false) ||
 		configChanged(&depl.Spec.Template, configDigest) ||
-		(desired.KafkaConsumerAutoscaler == nil && *depl.Spec.Replicas != desired.KafkaConsumerReplicas)
+		(desired.KafkaConsumerAutoscaler.Disabled() && *depl.Spec.Replicas != desired.KafkaConsumerReplicas)
 }
 
-func autoScalerNeedsUpdate(asc *ascv2.HorizontalPodAutoscaler, desired *flowsv1alpha1.FlowCollectorHPA, ns string) bool {
+func autoScalerNeedsUpdate(asc *ascv2.HorizontalPodAutoscaler, desired flowsv1alpha1.FlowCollectorHPA, ns string) bool {
 	if asc.Namespace != ns {
 		return true
 	}

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -649,7 +649,7 @@ autoscaler spec of a horizontal pod autoscaler to set up for the plugin Deployme
         <td><b>status</b></td>
         <td>enum</td>
         <td>
-          AuthToken describe the way to get a token to authenticate to Loki DISABLED will not send any token with the requestmode. ENABLED will deploy an horizontal pod autoscaler<br/>
+          Status describe the desired status regarding deploying an horizontal pod autoscaler DISABLED will not deploy an horizontal pod autoscaler ENABLED will deploy an horizontal pod autoscaler<br/>
           <br/>
             <i>Enum</i>: DISABLED, ENABLED<br/>
             <i>Default</i>: DISABLED<br/>
@@ -2285,7 +2285,7 @@ kafkaConsumerAutoscaler spec of a horizontal pod autoscaler to set up for flowlo
         <td><b>status</b></td>
         <td>enum</td>
         <td>
-          AuthToken describe the way to get a token to authenticate to Loki DISABLED will not send any token with the requestmode. ENABLED will deploy an horizontal pod autoscaler<br/>
+          Status describe the desired status regarding deploying an horizontal pod autoscaler DISABLED will not deploy an horizontal pod autoscaler ENABLED will deploy an horizontal pod autoscaler<br/>
           <br/>
             <i>Enum</i>: DISABLED, ENABLED<br/>
             <i>Default</i>: DISABLED<br/>

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -626,8 +626,9 @@ autoscaler spec of a horizontal pod autoscaler to set up for the plugin Deployme
           maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.<br/>
           <br/>
             <i>Format</i>: int32<br/>
+            <i>Default</i>: 3<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b><a href="#flowcollectorspecconsolepluginautoscalermetricsindex">metrics</a></b></td>
         <td>[]object</td>
@@ -642,6 +643,16 @@ autoscaler spec of a horizontal pod autoscaler to set up for the plugin Deployme
           minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.<br/>
           <br/>
             <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>status</b></td>
+        <td>enum</td>
+        <td>
+          AuthToken describe the way to get a token to authenticate to Loki DISABLED will not send any token with the requestmode. ENABLED will deploy an horizontal pod autoscaler<br/>
+          <br/>
+            <i>Enum</i>: DISABLED, ENABLED<br/>
+            <i>Default</i>: DISABLED<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2251,8 +2262,9 @@ kafkaConsumerAutoscaler spec of a horizontal pod autoscaler to set up for flowlo
           maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.<br/>
           <br/>
             <i>Format</i>: int32<br/>
+            <i>Default</i>: 3<br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b><a href="#flowcollectorspecprocessorkafkaconsumerautoscalermetricsindex">metrics</a></b></td>
         <td>[]object</td>
@@ -2267,6 +2279,16 @@ kafkaConsumerAutoscaler spec of a horizontal pod autoscaler to set up for flowlo
           minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.<br/>
           <br/>
             <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>status</b></td>
+        <td>enum</td>
+        <td>
+          AuthToken describe the way to get a token to authenticate to Loki DISABLED will not send any token with the requestmode. ENABLED will deploy an horizontal pod autoscaler<br/>
+          <br/>
+            <i>Enum</i>: DISABLED, ENABLED<br/>
+            <i>Default</i>: DISABLED<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
This add a status field in HPA section to deploy or not HPA.

At some point in the future we may want a third option: not deploying the HPA but also not reconciling pod count so an external HPA can be used.