### PR TITLE
added metrics service to operator

### DIFF
--- a/.mk/ocp.mk
+++ b/.mk/ocp.mk
@@ -38,6 +38,9 @@ ocp-deploy-operator: ## run flp from the operator
 undeploy-operator: ## stop the operator locally
 	-PID=$$(pgrep --oldest --full "main.go"); pkill -P $$PID; pkill $$PID
 	kubectl delete ds flowlogs-pipeline || true
+	kubectl delete service flowlogs-pipeline-prom || true
+	kubectl delete service netobserv-plugin || true
+	kubectl delete deployment netobserv-plugin || true
 
 .PHONY: ocp-refresh-ovs
 ocp-refresh-ovs:

--- a/config/kubernetes/deployment-prometheus.yaml
+++ b/config/kubernetes/deployment-prometheus.yaml
@@ -73,18 +73,6 @@ data:
       - /etc/prometheus/prometheus.rules
     scrape_configs:
       - job_name: 'flowlogs-pipeline'
-        kubernetes_sd_configs:
-          - role: pod
+        static_configs:
+          - targets: ['flowlogs-pipeline-metrics.netobserv.svc.cluster.local:9102']
 
-        relabel_configs:
-        # Scrape only pods that have "prometheus.io/scrape = true" annotation.
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-          regex: "true"
-          replacement: $1
-          action: keep
-        # Scrape only single, desired port for the pod based on pod "prometheus.io/scrape_port = <port>" annotation.
-        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_scrape_port]
-          action: replace
-          regex: ([^:]+)(?::\d+)?;(\d+)
-          replacement: $1:$2
-          target_label: __address__

--- a/controllers/flowlogspipeline/flp_ingest_objects.go
+++ b/controllers/flowlogspipeline/flp_ingest_objects.go
@@ -79,6 +79,13 @@ func (b *ingestBuilder) fromPromService(old *corev1.Service) *corev1.Service {
 	return b.generic.fromPromService(old)
 }
 
+func (b *ingestBuilder) newMetricsService() *corev1.Service {
+	return b.generic.newMetricsService()
+}
+
+func (b *ingestBuilder) fromMetricsService(old *corev1.Service) *corev1.Service {
+	return b.generic.fromMetricsService(old)
+}
 func buildClusterRoleIngester(useOpenShiftSCC bool) *rbacv1.ClusterRole {
 	cr := rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/flowlogspipeline/flp_monolith_objects.go
+++ b/controllers/flowlogspipeline/flp_monolith_objects.go
@@ -77,6 +77,14 @@ func (b *monolithBuilder) fromPromService(old *corev1.Service) *corev1.Service {
 	return b.generic.fromPromService(old)
 }
 
+func (b *monolithBuilder) newMetricsService() *corev1.Service {
+	return b.generic.newMetricsService()
+}
+
+func (b *monolithBuilder) fromMetricsService(old *corev1.Service) *corev1.Service {
+	return b.generic.fromMetricsService(old)
+}
+
 func (b *monolithBuilder) serviceAccount() *corev1.ServiceAccount {
 	return b.generic.serviceAccount()
 }

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -457,6 +457,13 @@ func TestLabels(t *testing.T) {
 	assert.Equal("flowlogs-pipeline", svc.Spec.Selector["app"])
 	assert.Equal("dev", svc.Labels["version"])
 	assert.Empty(svc.Spec.Selector["version"])
+
+	// Service (metrics)
+	svc2 := builder.newMetricsService()
+	assert.Equal("flowlogs-pipeline", svc2.Labels["app"])
+	assert.Equal("flowlogs-pipeline", svc2.Spec.Selector["app"])
+	assert.Equal("dev", svc2.Labels["version"])
+	assert.Empty(svc2.Spec.Selector["version"])
 }
 
 // This function validate that each stage has its matching parameter

--- a/controllers/flowlogspipeline/flp_transfo_objects.go
+++ b/controllers/flowlogspipeline/flp_transfo_objects.go
@@ -82,6 +82,14 @@ func (b *transfoBuilder) fromPromService(old *corev1.Service) *corev1.Service {
 	return b.generic.fromPromService(old)
 }
 
+func (b *transfoBuilder) newMetricsService() *corev1.Service {
+	return b.generic.newMetricsService()
+}
+
+func (b *transfoBuilder) fromMetricsService(old *corev1.Service) *corev1.Service {
+	return b.generic.fromMetricsService(old)
+}
+
 func (b *transfoBuilder) autoScaler() *ascv2.HorizontalPodAutoscaler {
 	return &ascv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This PR adds the creation of the flowlogs-pipeline-metrics service to the operator.
The next step is to add the ServiceMonitor to expose these metrics to the Openshift console.