### PR TITLE
NETOBSERV-690 (spike): move eBPF image pullspec from CRD to CSV

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -130,3 +130,16 @@ The NetObserv Operator is available in OperatorHub: https://operatorhub.io/opera
 ## Publish on central OperatorHub
 
 See [RELEASE.md](./RELEASE.md#publishing-on-operatorhub).
+
+## Using custom operand image
+
+Patch `RELATED_IMAGE_EBPF_AGENT` environment variable's value with your custom operand image:
+
+In the operator's deployment:
+
+```sh
+# netobserv-controller-manager has index 1
+# "RELATED_IMAGE_EBPF_AGENT" environment variable has index 0
+oc -n netobserv patch deployment netobserv-controller-manager --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/1/env/0/value", "value":"<CUSTOM_IMAGE_TAG>"}]'
+```
+

--- a/Makefile
+++ b/Makefile
@@ -233,13 +233,14 @@ endif
 
 .PHONY: bundle-prepare
 bundle-prepare: OPSDK generate kustomize ## Generate bundle manifests and metadata, then validate generated files.
+	# TODO: remove this line when we move all images to CSV
 	envsubst < config/crd/patches/version_in_flowcollectors_envtpl.yaml > config/crd/patches/version_in_flowcollectors.yaml
 	$(OPSDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	$(SED) -i -r 's~ebpf-agent:main~ebpf-agent:$(BPF_VERSION)~' ./config/manager/manager.yaml
 	cp config/samples/flows_v1alpha1_flowcollector.yaml config/samples/flows_v1alpha1_flowcollector_versioned.yaml
 	$(SED) -i -r 's~flowlogs-pipeline:main~flowlogs-pipeline:$(FLP_VERSION)~' config/samples/flows_v1alpha1_flowcollector_versioned.yaml
 	$(SED) -i -r 's~console-plugin:main~console-plugin:$(PLG_VERSION)~' config/samples/flows_v1alpha1_flowcollector_versioned.yaml
-	$(SED) -i -r 's~ebpf-agent:main~ebpf-agent:$(BPF_VERSION)~' config/samples/flows_v1alpha1_flowcollector_versioned.yaml
 	$(SED) -i -r 's~blob/[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)\?/~blob/$(VERSION)/~g' ./config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
 	$(SED) -i -r 's~replaces: netobserv-operator\.v.*~replaces: netobserv-operator\.$(PREVIOUS_VERSION)~' ./config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
 

--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -150,10 +150,6 @@ type FlowCollectorIPFIX struct {
 type FlowCollectorEBPF struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
 
-	//+kubebuilder:default:="quay.io/netobserv/netobserv-ebpf-agent:main"
-	// image is the NetObserv Agent image (including domain and tag)
-	Image string `json:"image,omitempty"`
-
 	//+kubebuilder:validation:Enum=IfNotPresent;Always;Never
 	//+kubebuilder:default:=IfNotPresent
 	// imagePullPolicy is the Kubernetes pull policy for the image defined above

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -95,11 +95,6 @@ spec:
                         items:
                           type: string
                         type: array
-                      image:
-                        default: quay.io/netobserv/netobserv-ebpf-agent:v0.2.1
-                        description: image is the NetObserv Agent image (including
-                          domain and tag)
-                        type: string
                       imagePullPolicy:
                         default: IfNotPresent
                         description: imagePullPolicy is the Kubernetes pull policy

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -18,7 +18,6 @@ metadata:
                 "excludeInterfaces": [
                   "lo"
                 ],
-                "image": "quay.io/netobserv/netobserv-ebpf-agent:v0.2.1",
                 "imagePullPolicy": "IfNotPresent",
                 "interfaces": [],
                 "kafkaBatchSize": 10485760,
@@ -190,7 +189,7 @@ metadata:
     categories: Monitoring
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: quay.io/netobserv/network-observability-operator:0.2.0
-    createdAt: "2022-11-15T09:15:46Z"
+    createdAt: "2022-10-25T09:40:09Z"
     description: Network flows collector and monitoring solution
     operators.operatorframework.io/builder: operator-sdk-v1.25.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -473,8 +472,12 @@ spec:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
+                - --ebpf-agent-image=$(RELATED_IMAGE_EBPF_AGENT)
                 command:
                 - /manager
+                env:
+                - name: RELATED_IMAGE_EBPF_AGENT
+                  value: quay.io/netobserv/netobserv-ebpf-agent:main
                 image: quay.io/netobserv/network-observability-operator:0.2.0
                 imagePullPolicy: Always
                 livenessProbe:

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -93,11 +93,6 @@ spec:
                         items:
                           type: string
                         type: array
-                      image:
-                        default: quay.io/netobserv/netobserv-ebpf-agent:main
-                        description: image is the NetObserv Agent image (including
-                          domain and tag)
-                        type: string
                       imagePullPolicy:
                         default: IfNotPresent
                         description: imagePullPolicy is the Kubernetes pull policy

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -21,7 +21,7 @@ patches:
     kind: CustomResourceDefinition
     name: flowcollectors.flows.netobserv.io
   path: patches/singleton_in_flowcollectors.yaml
-- target:
+- target: # TODO: remove when we move all the related images to the CSV
     kind: CustomResourceDefinition
     name: flowcollectors.flows.netobserv.io
   path: patches/version_in_flowcollectors.yaml

--- a/config/crd/patches/version_in_flowcollectors.yaml
+++ b/config/crd/patches/version_in_flowcollectors.yaml
@@ -5,6 +5,3 @@
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/processor/properties/image/default
   value: "quay.io/netobserv/flowlogs-pipeline:v0.1.4"
-- op: add
-  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/agent/properties/ebpf/properties/image/default
-  value: "quay.io/netobserv/netobserv-ebpf-agent:v0.2.1"

--- a/config/crd/patches/version_in_flowcollectors_envtpl.yaml
+++ b/config/crd/patches/version_in_flowcollectors_envtpl.yaml
@@ -5,6 +5,3 @@
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/processor/properties/image/default
   value: "quay.io/netobserv/flowlogs-pipeline:$FLP_VERSION"
-- op: add
-  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/agent/properties/ebpf/properties/image/default
-  value: "quay.io/netobserv/netobserv-ebpf-agent:$BPF_VERSION"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -25,3 +25,4 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        - "--ebpf-agent-image=$(RELATED_IMAGE_EBPF_AGENT)"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,11 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --ebpf-agent-image=$(RELATED_IMAGE_EBPF_AGENT)
+        env:
+          # images MUST be defined in this order for a proper replacement
+          - name: RELATED_IMAGE_EBPF_AGENT
+            value: quay.io/netobserv/netobserv-ebpf-agent:main
         image: controller:latest
         name: manager
         imagePullPolicy: Always

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -18,7 +18,6 @@ spec:
         daemonSetName: ovnkube-node
         containerName: ovnkube-node
     ebpf:
-      image: 'quay.io/netobserv/netobserv-ebpf-agent:main'
       imagePullPolicy: IfNotPresent
       sampling: 50
       cacheActiveTimeout: 5s

--- a/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
@@ -18,7 +18,6 @@ spec:
         daemonSetName: ovnkube-node
         containerName: ovnkube-node
     ebpf:
-      image: 'quay.io/netobserv/netobserv-ebpf-agent:v0.2.1'
       imagePullPolicy: IfNotPresent
       sampling: 50
       cacheActiveTimeout: 5s

--- a/controllers/flowcollector_controller_ebpf_test.go
+++ b/controllers/flowcollector_controller_ebpf_test.go
@@ -54,8 +54,6 @@ func flowCollectorEBPFSpecs() {
 					Agent: flowsv1alpha1.FlowCollectorAgent{
 						Type: "EBPF",
 						EBPF: flowsv1alpha1.FlowCollectorEBPF{
-							// Test that version labels will be properly cut to max 63 chars
-							Image:              "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-ebpf-agent@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
 							Sampling:           pointer.Int32Ptr(123),
 							CacheActiveTimeout: "15s",
 							CacheMaxFlows:      100,

--- a/controllers/operator/config.go
+++ b/controllers/operator/config.go
@@ -1,0 +1,16 @@
+package operator
+
+import "errors"
+
+// Config of the operator.
+type Config struct {
+	// EBPFAgentImage is the image of the eBPF agent that is manged by the operator
+	EBPFAgentImage string
+}
+
+func (cfg *Config) Validate() error {
+	if cfg.EBPFAgentImage == "" {
+		return errors.New("eBPF agent image argument can't be empty")
+	}
+	return nil
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/netobserv/network-observability-operator/controllers/operator"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
@@ -154,6 +155,9 @@ func NewTestFlowCollectorReconciler(client client.Client, scheme *runtime.Scheme
 		Client:   client,
 		Scheme:   scheme,
 		lookupIP: ipResolver.LookupIP,
+		config: &operator.Config{
+			EBPFAgentImage: "ebpf-agent-image:test",
+		},
 	}
 }
 

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -245,15 +245,6 @@ ebpf describes the settings related to the eBPF-based flow reporter when the "ag
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>image</b></td>
-        <td>string</td>
-        <td>
-          image is the NetObserv Agent image (including domain and tag)<br/>
-          <br/>
-            <i>Default</i>: quay.io/netobserv/netobserv-ebpf-agent:main<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b>imagePullPolicy</b></td>
         <td>enum</td>
         <td>


### PR DESCRIPTION
From "[Best Practices](https://docs.engineering.redhat.com/display/CFC/Best_Practices)" document:
> Images to be used for operands MUST be in the relatedImages field and SHOULD be in environment variables to the operator.

As an initial test, I'm moving first only one image to evaluate how will it work with CPaaS. Once we succeed, we will move the rest of images.