### PR TITLE
NETOBSERV-707: cut image version labels > 63 chars

### DIFF
--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -47,7 +47,7 @@ func newBuilder(ns string, desired *flowsv1alpha1.FlowCollectorConsolePlugin, de
 		namespace: ns,
 		labels: map[string]string{
 			"app":     constants.PluginName,
-			"version": version,
+			"version": helper.MaxLabelLength(version),
 		},
 		selector: map[string]string{
 			"app": constants.PluginName,

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -168,7 +168,7 @@ func (c *AgentController) desired(coll *flowsv1alpha1.FlowCollector) *v1.DaemonS
 			Namespace: c.privilegedNamespace,
 			Labels: map[string]string{
 				"app":     constants.EBPFAgentName,
-				"version": version,
+				"version": helper.MaxLabelLength(version),
 			},
 		},
 		Spec: v1.DaemonSetSpec{

--- a/controllers/flowcollector_controller_ebpf_test.go
+++ b/controllers/flowcollector_controller_ebpf_test.go
@@ -54,7 +54,8 @@ func flowCollectorEBPFSpecs() {
 					Agent: flowsv1alpha1.FlowCollectorAgent{
 						Type: "EBPF",
 						EBPF: flowsv1alpha1.FlowCollectorEBPF{
-							Image:              "netobserv-ebpf-agent:latest",
+							// Test that version labels will be properly cut to max 63 chars
+							Image:              "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-ebpf-agent@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
 							Sampling:           pointer.Int32Ptr(123),
 							CacheActiveTimeout: "15s",
 							CacheMaxFlows:      100,

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -90,7 +90,8 @@ func flowCollectorControllerSpecs() {
 						Port:            9999,
 						ImagePullPolicy: "Never",
 						LogLevel:        "error",
-						Image:           "testimg:latest",
+						// Test that version labels will be properly cut to max 63 chars
+						Image: "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-flowlogs-pipeline@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
 						Env: map[string]string{
 							"GOGC": "200",
 						},
@@ -104,7 +105,8 @@ func flowCollectorControllerSpecs() {
 					ConsolePlugin: flowsv1alpha1.FlowCollectorConsolePlugin{
 						Port:            9001,
 						ImagePullPolicy: "Never",
-						Image:           "testimg:latest",
+						// Test that version labels will be properly cut to max 63 chars
+						Image: "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-console-plugin@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
 						PortNaming: flowsv1alpha1.ConsolePluginPortConfig{
 							Enable: true,
 							PortNames: map[string]string{
@@ -181,6 +183,15 @@ func flowCollectorControllerSpecs() {
 				"cacheMaxFlows":      "400",
 				"cacheActiveTimeout": "20s",
 			}))
+
+			By("Expecting flowlogs-pipeline-config configmap to be created")
+			Eventually(func() interface{} {
+				cm := v1.ConfigMap{}
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "flowlogs-pipeline-config",
+					Namespace: operatorNamespace,
+				}, &cm)
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("Should update successfully", func() {

--- a/controllers/flowlogspipeline/flp_common_objects.go
+++ b/controllers/flowlogspipeline/flp_common_objects.go
@@ -90,7 +90,7 @@ func newBuilder(ns string, desired *flowsv1alpha1.FlowCollectorSpec, ck ConfKind
 		namespace: ns,
 		labels: map[string]string{
 			"app":     name,
-			"version": version,
+			"version": helper.MaxLabelLength(version),
 		},
 		selector: map[string]string{
 			"app": name,

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// maximum length of a metadata label in Kubernetes
+const maxLabelLength = 63
+
 func ContainsString(slice []string, s string) bool {
 	for _, item := range slice {
 		if item == s {
@@ -55,4 +58,13 @@ func KeySorted(set map[string]string) [][2]string {
 		return vals[i][0] < vals[j][0]
 	})
 	return vals
+}
+
+// MaxLabelLength cuts an input string it ifs length is largen than 63, the maximum length allowed
+// by Kubernetes metadata
+func MaxLabelLength(in string) string {
+	if len(in) <= maxLabelLength {
+		return in
+	}
+	return in[:maxLabelLength]
 }

--- a/pkg/helper/helpers_test.go
+++ b/pkg/helper/helpers_test.go
@@ -59,3 +59,14 @@ func TestKeySorted(t *testing.T) {
 		[][2]string{{"a", "3"}, {"b", "1"}, {"c", "2"}, {"d", "4"}},
 		KeySorted(set))
 }
+
+func TestMaxLabelLengt_Cut(t *testing.T) {
+	assert.Equal(t, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde",
+		MaxLabelLength("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde_CUT_HERE"))
+}
+
+func TestMaxLabelLengt_NoCut(t *testing.T) {
+	assert.Equal(t, "0123456789", MaxLabelLength("0123456789"))
+	assert.Equal(t, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde",
+		MaxLabelLength("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde"))
+}


### PR DESCRIPTION
Using downstream images prevents the flowcollector from being deployed as they use very long sha digests for the version.