### PR TITLE
NETOBSERV-712 Add metric to measure number of flows per namespace

### DIFF
--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -557,13 +557,14 @@ func TestMergeMetricsConfigurationNoIgnore(t *testing.T) {
 	assert.True(validatePipelineConfig(stages, parameters))
 	jsonStages, _ := json.Marshal(stages)
 	assert.Equal(`[{"name":"ipfix"},{"name":"enrich","follows":"ipfix"},{"name":"loki","follows":"enrich"},{"name":"stdout","follows":"enrich"},{"name":"prometheus","follows":"enrich"}]`, string(jsonStages))
-	assert.Len(parameters[4].Encode.Prom.Metrics, 6)
-	assert.Equal("node_egress_bytes_total", parameters[4].Encode.Prom.Metrics[0].Name)
-	assert.Equal("node_ingress_bytes_total", parameters[4].Encode.Prom.Metrics[1].Name)
-	assert.Equal("workload_egress_bytes_total", parameters[4].Encode.Prom.Metrics[2].Name)
-	assert.Equal("workload_egress_packets_total", parameters[4].Encode.Prom.Metrics[3].Name)
-	assert.Equal("workload_ingress_bytes_total", parameters[4].Encode.Prom.Metrics[4].Name)
-	assert.Equal("workload_ingress_packets_total", parameters[4].Encode.Prom.Metrics[5].Name)
+	assert.Len(parameters[4].Encode.Prom.Metrics, 7)
+	assert.Equal("namespace_flows_total", parameters[4].Encode.Prom.Metrics[0].Name)
+	assert.Equal("node_egress_bytes_total", parameters[4].Encode.Prom.Metrics[1].Name)
+	assert.Equal("node_ingress_bytes_total", parameters[4].Encode.Prom.Metrics[2].Name)
+	assert.Equal("workload_egress_bytes_total", parameters[4].Encode.Prom.Metrics[3].Name)
+	assert.Equal("workload_egress_packets_total", parameters[4].Encode.Prom.Metrics[4].Name)
+	assert.Equal("workload_ingress_bytes_total", parameters[4].Encode.Prom.Metrics[5].Name)
+	assert.Equal("workload_ingress_packets_total", parameters[4].Encode.Prom.Metrics[6].Name)
 	assert.Equal("netobserv_", parameters[4].Encode.Prom.Prefix)
 }
 
@@ -579,8 +580,8 @@ func TestMergeMetricsConfigurationWithIgnore(t *testing.T) {
 	assert.True(validatePipelineConfig(stages, parameters))
 	jsonStages, _ := json.Marshal(stages)
 	assert.Equal(`[{"name":"ipfix"},{"name":"enrich","follows":"ipfix"},{"name":"loki","follows":"enrich"},{"name":"stdout","follows":"enrich"},{"name":"prometheus","follows":"enrich"}]`, string(jsonStages))
-	assert.Len(parameters[4].Encode.Prom.Metrics, 4)
-	assert.Equal("workload_egress_bytes_total", parameters[4].Encode.Prom.Metrics[0].Name)
+	assert.Len(parameters[4].Encode.Prom.Metrics, 5)
+	assert.Equal("namespace_flows_total", parameters[4].Encode.Prom.Metrics[0].Name)
 	assert.Equal("netobserv_", parameters[4].Encode.Prom.Prefix)
 }
 

--- a/controllers/flowlogspipeline/metrics_definitions/namespace_flows_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/namespace_flows_total.yaml
@@ -1,0 +1,19 @@
+#flp_confgen
+description:
+  This metric counts flows per namespace
+details:
+  Counting flows per source and destination namespaces
+usage:
+  Evaluate number of flows per source and destination namespaces
+tags:
+  - flows
+  - namespaces
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: namespace_flows_total
+        type: counter
+        labels:
+          - SrcK8S_Namespace
+          - DstK8S_Namespace


### PR DESCRIPTION
E.g. to get netobserv flows in percentage of total:

```
100 * (sum (rate(netobserv_namespace_flows_total{SrcK8S_Namespace="netobserv"}[1m])) + sum (rate(netobserv_namespace_flows_total{SrcK8S_Namespace!="netobserv", DstK8S_Namespace="netobserv"}[1m]))) / sum (rate(netobserv_namespace_flows_total[1m]))
```

![image](https://user-images.githubusercontent.com/2153442/202511919-94308e15-47c1-4ed5-b804-420c491fda93.png)
