### PR TITLE
NETOBSERV-690: move console and FLP image pullspecs from CRD to CSV

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -138,8 +138,10 @@ Patch `RELATED_IMAGE_EBPF_AGENT` environment variable's value with your custom o
 In the operator's deployment:
 
 ```sh
-# netobserv-controller-manager has index 1
+# netobserv-controller-manager's manager container has index 0
 # "RELATED_IMAGE_EBPF_AGENT" environment variable has index 0
-oc -n netobserv patch deployment netobserv-controller-manager --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/1/env/0/value", "value":"<CUSTOM_IMAGE_TAG>"}]'
+# "RELATED_IMAGE_FLOWLOGS_PIPELINE" environment variable has index 1
+# "RELATED_IMAGE_CONSOLE_PLUGIN" environment variable has index 2
+oc -n netobserv patch deployment netobserv-controller-manager --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/env/0/value", "value":"<CUSTOM_IMAGE_TAG>"}]'
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PORT_FWD ?= true
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
 # - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
 # - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
-CHANNELS := v0.2.x
+CHANNELS := v1.0.x
 ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
 endif
@@ -38,7 +38,7 @@ endif
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
 # - use the DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
 # - use environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
-DEFAULT_CHANNEL := v0.2.x
+DEFAULT_CHANNEL := v1.0.x
 ifneq ($(origin DEFAULT_CHANNEL), undefined)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
@@ -233,16 +233,14 @@ endif
 
 .PHONY: bundle-prepare
 bundle-prepare: OPSDK generate kustomize ## Generate bundle manifests and metadata, then validate generated files.
-	# TODO: remove this line when we move all images to CSV
-	envsubst < config/crd/patches/version_in_flowcollectors_envtpl.yaml > config/crd/patches/version_in_flowcollectors.yaml
 	$(OPSDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(SED) -i -r 's~ebpf-agent:main~ebpf-agent:$(BPF_VERSION)~' ./config/manager/manager.yaml
-	cp config/samples/flows_v1alpha1_flowcollector.yaml config/samples/flows_v1alpha1_flowcollector_versioned.yaml
-	$(SED) -i -r 's~flowlogs-pipeline:main~flowlogs-pipeline:$(FLP_VERSION)~' config/samples/flows_v1alpha1_flowcollector_versioned.yaml
-	$(SED) -i -r 's~console-plugin:main~console-plugin:$(PLG_VERSION)~' config/samples/flows_v1alpha1_flowcollector_versioned.yaml
+	$(SED) -i -r 's~flowlogs-pipeline:main~flowlogs-pipeline:$(FLP_VERSION)~' ./config/manager/manager.yaml
+	$(SED) -i -r 's~console-plugin:main~console-plugin:$(PLG_VERSION)~' ./config/manager/manager.yaml
 	$(SED) -i -r 's~blob/[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)\?/~blob/$(VERSION)/~g' ./config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
 	$(SED) -i -r 's~replaces: netobserv-operator\.v.*~replaces: netobserv-operator\.$(PREVIOUS_VERSION)~' ./config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
+	cp config/samples/flows_v1alpha1_flowcollector.yaml config/samples/flows_v1alpha1_flowcollector_versioned.yaml
 
 .PHONY: bundle
 bundle: bundle-prepare

--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -305,10 +305,6 @@ type FlowCollectorFLP struct {
 	// profilePort allows setting up a Go pprof profiler listening to this port
 	ProfilePort int32 `json:"profilePort,omitempty"`
 
-	//+kubebuilder:default:="quay.io/netobserv/flowlogs-pipeline:main"
-	// image of the collector container (including domain and tag)
-	Image string `json:"image,omitempty"`
-
 	//+kubebuilder:validation:Enum=IfNotPresent;Always;Never
 	//+kubebuilder:default:=IfNotPresent
 	// imagePullPolicy is the Kubernetes pull policy for the image defined above
@@ -508,10 +504,6 @@ type FlowCollectorConsolePlugin struct {
 	//+kubebuilder:default:=9001
 	// port is the plugin service port
 	Port int32 `json:"port,omitempty"`
-
-	//+kubebuilder:default:="quay.io/netobserv/network-observability-console-plugin:main"
-	// image is the plugin image (including domain and tag)
-	Image string `json:"image,omitempty"`
 
 	//+kubebuilder:validation:Enum=IfNotPresent;Always;Never
 	//+kubebuilder:default:=IfNotPresent

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -5,9 +5,9 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=netobserv-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=v0.2.x
-LABEL operators.operatorframework.io.bundle.channel.default.v1=v0.2.x
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.1
+LABEL operators.operatorframework.io.bundle.channels.v1=v1.0.x
+LABEL operators.operatorframework.io.bundle.channel.default.v1=v1.0.x
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -799,10 +799,6 @@ spec:
                         - ENABLED
                         type: string
                     type: object
-                  image:
-                    default: quay.io/netobserv/network-observability-console-plugin:v0.1.5
-                    description: image is the plugin image (including domain and tag)
-                    type: string
                   imagePullPolicy:
                     default: IfNotPresent
                     description: imagePullPolicy is the Kubernetes pull policy for
@@ -1317,11 +1313,6 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
-                  image:
-                    default: quay.io/netobserv/flowlogs-pipeline:v0.1.4
-                    description: image of the collector container (including domain
-                      and tag)
-                    type: string
                   imagePullPolicy:
                     default: IfNotPresent
                     description: imagePullPolicy is the Kubernetes pull policy for

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -67,7 +67,6 @@ metadata:
                 "minReplicas": 1,
                 "status": "DISABLED"
               },
-              "image": "quay.io/netobserv/network-observability-console-plugin:v0.1.5",
               "imagePullPolicy": "IfNotPresent",
               "logLevel": "info",
               "port": 9001,
@@ -154,7 +153,6 @@ metadata:
               "dropUnusedFields": true,
               "enableKubeProbes": true,
               "healthPort": 8080,
-              "image": "quay.io/netobserv/flowlogs-pipeline:v0.1.4",
               "imagePullPolicy": "IfNotPresent",
               "kafkaConsumerAutoscaler": null,
               "kafkaConsumerBatchSize": 10485760,
@@ -191,7 +189,7 @@ metadata:
     containerImage: quay.io/netobserv/network-observability-operator:0.2.0
     createdAt: "2022-10-25T09:40:09Z"
     description: Network flows collector and monitoring solution
-    operators.operatorframework.io/builder: operator-sdk-v1.25.1
+    operators.operatorframework.io/builder: operator-sdk-v1.25.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/netobserv/network-observability-operator
   name: netobserv-operator.v0.2.0
@@ -457,27 +455,21 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources: {}
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --ebpf-agent-image=$(RELATED_IMAGE_EBPF_AGENT)
+                - --flowlogs-pipeline-image=$(RELATED_IMAGE_FLOWLOGS_PIPELINE)
+                - --console-plugin-image=$(RELATED_IMAGE_CONSOLE_PLUGIN)
                 command:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_EBPF_AGENT
                   value: quay.io/netobserv/netobserv-ebpf-agent:main
+                - name: RELATED_IMAGE_FLOWLOGS_PIPELINE
+                  value: quay.io/netobserv/flowlogs-pipeline:main
+                - name: RELATED_IMAGE_CONSOLE_PLUGIN
+                  value: quay.io/netobserv/network-observability-console-plugin:main
                 image: quay.io/netobserv/network-observability-operator:0.2.0
                 imagePullPolicy: Always
                 livenessProbe:
@@ -502,6 +494,18 @@ spec:
                     memory: 100Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+              - args:
+                  - --secure-listen-address=0.0.0.0:8443
+                  - --upstream=http://127.0.0.1:8080/
+                  - --logtostderr=true
+                  - --v=10
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                name: kube-rbac-proxy
+                ports:
+                  - containerPort: 8443
+                    name: https
+                    protocol: TCP
+                resources: {}
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: netobserv-controller-manager

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,9 +4,9 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: netobserv-operator
-  operators.operatorframework.io.bundle.channels.v1: v0.2.x
-  operators.operatorframework.io.bundle.channel.default.v1: v0.2.x
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.1
+  operators.operatorframework.io.bundle.channels.v1: v1.0.x
+  operators.operatorframework.io.bundle.channel.default.v1: v1.0.x
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.2
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -797,10 +797,6 @@ spec:
                         - ENABLED
                         type: string
                     type: object
-                  image:
-                    default: quay.io/netobserv/network-observability-console-plugin:main
-                    description: image is the plugin image (including domain and tag)
-                    type: string
                   imagePullPolicy:
                     default: IfNotPresent
                     description: imagePullPolicy is the Kubernetes pull policy for
@@ -1315,11 +1311,6 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
-                  image:
-                    default: quay.io/netobserv/flowlogs-pipeline:main
-                    description: image of the collector container (including domain
-                      and tag)
-                    type: string
                   imagePullPolicy:
                     default: IfNotPresent
                     description: imagePullPolicy is the Kubernetes pull policy for

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -21,10 +21,6 @@ patches:
     kind: CustomResourceDefinition
     name: flowcollectors.flows.netobserv.io
   path: patches/singleton_in_flowcollectors.yaml
-- target: # TODO: remove when we move all the related images to the CSV
-    kind: CustomResourceDefinition
-    name: flowcollectors.flows.netobserv.io
-  path: patches/version_in_flowcollectors.yaml
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/config/crd/patches/version_in_flowcollectors.yaml
+++ b/config/crd/patches/version_in_flowcollectors.yaml
@@ -1,7 +1,0 @@
-# This patch updates the version for default images
-- op: add
-  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/consolePlugin/properties/image/default
-  value: "quay.io/netobserv/network-observability-console-plugin:v0.1.5"
-- op: add
-  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/processor/properties/image/default
-  value: "quay.io/netobserv/flowlogs-pipeline:v0.1.4"

--- a/config/crd/patches/version_in_flowcollectors_envtpl.yaml
+++ b/config/crd/patches/version_in_flowcollectors_envtpl.yaml
@@ -1,7 +1,0 @@
-# This patch updates the version for default images
-- op: add
-  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/consolePlugin/properties/image/default
-  value: "quay.io/netobserv/network-observability-console-plugin:$PLG_VERSION"
-- op: add
-  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/processor/properties/image/default
-  value: "quay.io/netobserv/flowlogs-pipeline:$FLP_VERSION"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -9,20 +9,22 @@ spec:
   template:
     spec:
       containers:
-      - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-        args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=10"
-        ports:
-        - containerPort: 8443
-          protocol: TCP
-          name: https
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
         - "--ebpf-agent-image=$(RELATED_IMAGE_EBPF_AGENT)"
+        - "--flowlogs-pipeline-image=$(RELATED_IMAGE_FLOWLOGS_PIPELINE)"
+        - "--console-plugin-image=$(RELATED_IMAGE_CONSOLE_PLUGIN)"
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        args:
+          - "--secure-listen-address=0.0.0.0:8443"
+          - "--upstream=http://127.0.0.1:8080/"
+          - "--logtostderr=true"
+          - "--v=10"
+        ports:
+          - containerPort: 8443
+            protocol: TCP
+            name: https

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,10 +30,16 @@ spec:
         args:
         - --leader-elect
         - --ebpf-agent-image=$(RELATED_IMAGE_EBPF_AGENT)
+        - --flowlogs-pipeline-image=$(RELATED_IMAGE_FLOWLOGS_PIPELINE)
+        - --console-plugin-image=$(RELATED_IMAGE_CONSOLE_PLUGIN)"
         env:
           # images MUST be defined in this order for a proper replacement
           - name: RELATED_IMAGE_EBPF_AGENT
             value: quay.io/netobserv/netobserv-ebpf-agent:main
+          - name: RELATED_IMAGE_FLOWLOGS_PIPELINE
+            value: quay.io/netobserv/flowlogs-pipeline:main
+          - name: RELATED_IMAGE_CONSOLE_PLUGIN
+            value: quay.io/netobserv/network-observability-console-plugin:main
         image: controller:latest
         name: manager
         imagePullPolicy: Always

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -35,7 +35,6 @@ spec:
       kafkaBatchSize: 10485760
   processor:
     port: 2055
-    image: 'quay.io/netobserv/flowlogs-pipeline:main'
     imagePullPolicy: IfNotPresent
     logLevel: info
     enableKubeProbes: true
@@ -89,7 +88,6 @@ spec:
         certFile: service-ca.crt
   consolePlugin:
     register: true
-    image: 'quay.io/netobserv/network-observability-console-plugin:main'
     imagePullPolicy: IfNotPresent
     port: 9001
     logLevel: info

--- a/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
@@ -35,7 +35,6 @@ spec:
       kafkaBatchSize: 10485760
   processor:
     port: 2055
-    image: 'quay.io/netobserv/flowlogs-pipeline:v0.1.4'
     imagePullPolicy: IfNotPresent
     logLevel: info
     enableKubeProbes: true
@@ -89,7 +88,6 @@ spec:
         certFile: service-ca.crt
   consolePlugin:
     register: true
-    image: 'quay.io/netobserv/network-observability-console-plugin:v0.1.5'
     imagePullPolicy: IfNotPresent
     port: 9001
     logLevel: info

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -39,10 +39,11 @@ type builder struct {
 	selector    map[string]string
 	desired     *flowsv1alpha1.FlowCollectorConsolePlugin
 	desiredLoki *flowsv1alpha1.FlowCollectorLoki
+	imageName   string
 }
 
-func newBuilder(ns string, desired *flowsv1alpha1.FlowCollectorConsolePlugin, desiredLoki *flowsv1alpha1.FlowCollectorLoki) builder {
-	version := helper.ExtractVersion(desired.Image)
+func newBuilder(ns, imageName string, desired *flowsv1alpha1.FlowCollectorConsolePlugin, desiredLoki *flowsv1alpha1.FlowCollectorLoki) builder {
+	version := helper.ExtractVersion(imageName)
 	return builder{
 		namespace: ns,
 		labels: map[string]string{
@@ -54,6 +55,7 @@ func newBuilder(ns string, desired *flowsv1alpha1.FlowCollectorConsolePlugin, de
 		},
 		desired:     desired,
 		desiredLoki: desiredLoki,
+		imageName:   imageName,
 	}
 }
 
@@ -193,7 +195,7 @@ func (b *builder) podTemplate(cmDigest string) *corev1.PodTemplateSpec {
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{
 				Name:            constants.PluginName,
-				Image:           b.desired.Image,
+				Image:           b.imageName,
 				ImagePullPolicy: corev1.PullPolicy(b.desired.ImagePullPolicy),
 				Resources:       *b.desired.Resources.DeepCopy(),
 				VolumeMounts:    volumeMounts,

--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -107,10 +107,10 @@ func (r *FlowCollectorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	previousNamespace := desired.Status.Namespace
 
 	// Create reconcilers
-	flpReconciler := flowlogspipeline.NewReconciler(ctx, clientHelper, ns, previousNamespace, &r.permissions)
+	flpReconciler := flowlogspipeline.NewReconciler(ctx, clientHelper, ns, previousNamespace, r.config.FlowlogsPipelineImage, &r.permissions)
 	var cpReconciler consoleplugin.CPReconciler
 	if r.availableAPIs.HasConsole() {
-		cpReconciler = consoleplugin.NewReconciler(clientHelper, ns, previousNamespace)
+		cpReconciler = consoleplugin.NewReconciler(clientHelper, ns, previousNamespace, r.config.ConsolePluginImage)
 	}
 
 	// Check namespace changed

--- a/controllers/flowcollector_controller_console_test.go
+++ b/controllers/flowcollector_controller_console_test.go
@@ -76,7 +76,6 @@ func flowCollectorConsolePluginSpecs() {
 					ConsolePlugin: flowsv1alpha1.FlowCollectorConsolePlugin{
 						Port:            9001,
 						ImagePullPolicy: "Never",
-						Image:           "testimg:latest",
 						Register:        true,
 						Autoscaler: flowsv1alpha1.FlowCollectorHPA{
 							Status:      flowsv1alpha1.HPAStatusEnabled,

--- a/controllers/flowcollector_controller_ebpf_test.go
+++ b/controllers/flowcollector_controller_ebpf_test.go
@@ -49,7 +49,6 @@ func flowCollectorEBPFSpecs() {
 						Port:            9999,
 						ImagePullPolicy: "Never",
 						LogLevel:        "error",
-						Image:           "testimg:latest",
 					},
 					Agent: flowsv1alpha1.FlowCollectorAgent{
 						Type: "EBPF",

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -90,8 +90,6 @@ func flowCollectorControllerSpecs() {
 						Port:            9999,
 						ImagePullPolicy: "Never",
 						LogLevel:        "error",
-						// Test that version labels will be properly cut to max 63 chars
-						Image: "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-flowlogs-pipeline@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
 						Env: map[string]string{
 							"GOGC": "200",
 						},
@@ -105,8 +103,6 @@ func flowCollectorControllerSpecs() {
 					ConsolePlugin: flowsv1alpha1.FlowCollectorConsolePlugin{
 						Port:            9001,
 						ImagePullPolicy: "Never",
-						// Test that version labels will be properly cut to max 63 chars
-						Image: "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-console-plugin@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
 						PortNaming: flowsv1alpha1.ConsolePluginPortConfig{
 							Enable: true,
 							PortNames: map[string]string{
@@ -200,7 +196,6 @@ func flowCollectorControllerSpecs() {
 					Port:            7891,
 					ImagePullPolicy: "Never",
 					LogLevel:        "error",
-					Image:           "testimg:latest",
 					Env: map[string]string{
 						// we'll test that env vars are sorted, to keep idempotency
 						"GOMAXPROCS": "33",

--- a/controllers/flowlogspipeline/flp_common_objects.go
+++ b/controllers/flowlogspipeline/flp_common_objects.go
@@ -69,10 +69,11 @@ type builder struct {
 	promTLS         *flowsv1alpha1.CertificateReference
 	confKind        ConfKind
 	useOpenShiftSCC bool
+	image           string
 }
 
-func newBuilder(ns string, desired *flowsv1alpha1.FlowCollectorSpec, ck ConfKind, useOpenShiftSCC bool) builder {
-	version := helper.ExtractVersion(desired.Processor.Image)
+func newBuilder(ns, image string, desired *flowsv1alpha1.FlowCollectorSpec, ck ConfKind, useOpenShiftSCC bool) builder {
+	version := helper.ExtractVersion(image)
 	name := name(ck)
 	var promTLS flowsv1alpha1.CertificateReference
 	switch desired.Processor.Metrics.Server.TLS.Type {
@@ -99,6 +100,7 @@ func newBuilder(ns string, desired *flowsv1alpha1.FlowCollectorSpec, ck ConfKind
 		confKind:        ck,
 		useOpenShiftSCC: useOpenShiftSCC,
 		promTLS:         &promTLS,
+		image:           image,
 	}
 }
 
@@ -192,7 +194,7 @@ func (b *builder) podTemplate(hasHostPort, hasLokiInterface, hostNetwork bool, c
 
 	container := corev1.Container{
 		Name:            constants.FLPName,
-		Image:           b.desired.Processor.Image,
+		Image:           b.image,
 		ImagePullPolicy: corev1.PullPolicy(b.desired.Processor.ImagePullPolicy),
 		Args:            []string{fmt.Sprintf(`--config=%s/%s`, configPath, configFile)},
 		Resources:       *b.desired.Processor.Resources.DeepCopy(),

--- a/controllers/flowlogspipeline/flp_ingest_objects.go
+++ b/controllers/flowlogspipeline/flp_ingest_objects.go
@@ -15,8 +15,8 @@ type ingestBuilder struct {
 	generic builder
 }
 
-func newIngestBuilder(ns string, desired *flowsv1alpha1.FlowCollectorSpec, useOpenShiftSCC bool) ingestBuilder {
-	gen := newBuilder(ns, desired, ConfKafkaIngester, useOpenShiftSCC)
+func newIngestBuilder(ns, image string, desired *flowsv1alpha1.FlowCollectorSpec, useOpenShiftSCC bool) ingestBuilder {
+	gen := newBuilder(ns, image, desired, ConfKafkaIngester, useOpenShiftSCC)
 	return ingestBuilder{
 		generic: gen,
 	}

--- a/controllers/flowlogspipeline/flp_monolith_objects.go
+++ b/controllers/flowlogspipeline/flp_monolith_objects.go
@@ -15,8 +15,8 @@ type monolithBuilder struct {
 	generic builder
 }
 
-func newMonolithBuilder(ns string, desired *flowsv1alpha1.FlowCollectorSpec, useOpenShiftSCC bool) monolithBuilder {
-	gen := newBuilder(ns, desired, ConfMonolith, useOpenShiftSCC)
+func newMonolithBuilder(ns, image string, desired *flowsv1alpha1.FlowCollectorSpec, useOpenShiftSCC bool) monolithBuilder {
+	gen := newBuilder(ns, image, desired, ConfMonolith, useOpenShiftSCC)
 	return monolithBuilder{
 		generic: gen,
 	}

--- a/controllers/flowlogspipeline/flp_transfo_objects.go
+++ b/controllers/flowlogspipeline/flp_transfo_objects.go
@@ -16,8 +16,8 @@ type transfoBuilder struct {
 	generic builder
 }
 
-func newTransfoBuilder(ns string, desired *flowsv1alpha1.FlowCollectorSpec, useOpenShiftSCC bool) transfoBuilder {
-	gen := newBuilder(ns, desired, ConfKafkaTransformer, useOpenShiftSCC)
+func newTransfoBuilder(ns, image string, desired *flowsv1alpha1.FlowCollectorSpec, useOpenShiftSCC bool) transfoBuilder {
+	gen := newBuilder(ns, image, desired, ConfKafkaTransformer, useOpenShiftSCC)
 	return transfoBuilder{
 		generic: gen,
 	}

--- a/controllers/operator/config.go
+++ b/controllers/operator/config.go
@@ -4,13 +4,23 @@ import "errors"
 
 // Config of the operator.
 type Config struct {
-	// EBPFAgentImage is the image of the eBPF agent that is manged by the operator
+	// EBPFAgentImage is the image of the eBPF agent that is managed by the operator
 	EBPFAgentImage string
+	// FlowlogsPipelineImage is the image of the Flowlogs-Pipeline that is managed by the operator
+	FlowlogsPipelineImage string
+	// ConsolePluginImage is the image of the Console Plugin that is managed by the operator
+	ConsolePluginImage string
 }
 
 func (cfg *Config) Validate() error {
 	if cfg.EBPFAgentImage == "" {
 		return errors.New("eBPF agent image argument can't be empty")
+	}
+	if cfg.FlowlogsPipelineImage == "" {
+		return errors.New("flowlogs-pipeline image argument can't be empty")
+	}
+	if cfg.ConsolePluginImage == "" {
+		return errors.New("console plugin image argument can't be empty")
 	}
 	return nil
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -156,7 +156,9 @@ func NewTestFlowCollectorReconciler(client client.Client, scheme *runtime.Scheme
 		Scheme:   scheme,
 		lookupIP: ipResolver.LookupIP,
 		config: &operator.Config{
-			EBPFAgentImage: "ebpf-agent-image:test",
+			EBPFAgentImage:        "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-ebpf-agent@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
+			FlowlogsPipelineImage: "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-flowlogs-pipeline@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
+			ConsolePluginImage:    "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-console-plugin@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
 		},
 	}
 }

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -528,15 +528,6 @@ consolePlugin defines the settings related to the OpenShift Console plugin, when
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>image</b></td>
-        <td>string</td>
-        <td>
-          image is the plugin image (including domain and tag)<br/>
-          <br/>
-            <i>Default</i>: quay.io/netobserv/network-observability-console-plugin:main<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b>imagePullPolicy</b></td>
         <td>enum</td>
         <td>
@@ -2410,15 +2401,6 @@ processor defines the settings of the component that receives the flows from the
             <i>Default</i>: 8080<br/>
             <i>Minimum</i>: 1<br/>
             <i>Maximum</i>: 65535<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>image</b></td>
-        <td>string</td>
-        <td>
-          image of the collector container (including domain and tag)<br/>
-          <br/>
-            <i>Default</i>: quay.io/netobserv/flowlogs-pipeline:main<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/main.go
+++ b/main.go
@@ -80,6 +80,8 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&config.EBPFAgentImage, "ebpf-agent-image", "", "The image of the eBPF agent")
+	flag.StringVar(&config.FlowlogsPipelineImage, "flowlogs-pipeline-image", "", "The image of Flowlogs Pipeline")
+	flag.StringVar(&config.ConsolePluginImage, "console-plugin-image", "", "The image of the Console Plugin")
 	flag.BoolVar(&versionFlag, "v", false, "print version")
 	opts := zap.Options{
 		Development: true,


### PR DESCRIPTION
Continuation of PR #690. Now the related images (eBPF agent, FLP and console plugin) aren't specified anymore as part of the FlowCollector spec. If you want to deploy a development image for these components, you should now patch the environment variables of the `netobserv-controller-manager` Deployment, as specified in the DEVELOPERS.md section (see the diff of this PR).