### PR TITLE
NETOBSERV-665: Fix FLP beeing blocked in creating container state

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -619,6 +619,7 @@ type ClientTLS struct {
 
 	//+kubebuilder:default:=false
 	// insecureSkipVerify allows skipping client-side verification of the server certificate
+	// If set to true, CACert field will be ignored
 	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 
 	// caCert defines the reference of the certificate for the Certificate Authority

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -1008,7 +1008,8 @@ spec:
                             insecureSkipVerify:
                               default: false
                               description: insecureSkipVerify allows skipping client-side
-                                verification of the server certificate
+                                verification of the server certificate If set to true,
+                                CACert field will be ignored
                               type: boolean
                             userCert:
                               description: userCert defines the user certificate reference
@@ -1098,7 +1099,8 @@ spec:
                       insecureSkipVerify:
                         default: false
                         description: insecureSkipVerify allows skipping client-side
-                          verification of the server certificate
+                          verification of the server certificate If set to true, CACert
+                          field will be ignored
                         type: boolean
                       userCert:
                         description: userCert defines the user certificate reference
@@ -1245,7 +1247,8 @@ spec:
                       insecureSkipVerify:
                         default: false
                         description: insecureSkipVerify allows skipping client-side
-                          verification of the server certificate
+                          verification of the server certificate If set to true, CACert
+                          field will be ignored
                         type: boolean
                       userCert:
                         description: userCert defines the user certificate reference

--- a/controllers/flowlogspipeline/flp_common_objects.go
+++ b/controllers/flowlogspipeline/flp_common_objects.go
@@ -171,7 +171,7 @@ func (b *builder) podTemplate(hasHostPort, hasLokiInterface, hostNetwork bool, c
 	}
 
 	if hasLokiInterface {
-		if b.desired.Loki.TLS.Enable {
+		if b.desired.Loki.TLS.Enable && !b.desired.Loki.TLS.InsecureSkipVerify {
 			volumes, volumeMounts = helper.AppendCertVolumes(volumes, volumeMounts, &b.desired.Loki.TLS, lokiCerts)
 		}
 		if b.desired.Loki.UseHostToken() || b.desired.Loki.ForwardUserToken() {

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -1758,7 +1758,7 @@ tls client configuration.
         <td><b>insecureSkipVerify</b></td>
         <td>boolean</td>
         <td>
-          insecureSkipVerify allows skipping client-side verification of the server certificate<br/>
+          insecureSkipVerify allows skipping client-side verification of the server certificate If set to true, CACert field will be ignored<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -1955,7 +1955,7 @@ tls client configuration.
         <td><b>insecureSkipVerify</b></td>
         <td>boolean</td>
         <td>
-          insecureSkipVerify allows skipping client-side verification of the server certificate<br/>
+          insecureSkipVerify allows skipping client-side verification of the server certificate If set to true, CACert field will be ignored<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -2243,7 +2243,7 @@ tls client configuration.
         <td><b>insecureSkipVerify</b></td>
         <td>boolean</td>
         <td>
-          insecureSkipVerify allows skipping client-side verification of the server certificate<br/>
+          insecureSkipVerify allows skipping client-side verification of the server certificate If set to true, CACert field will be ignored<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>


### PR DESCRIPTION
Prevent trying to mount loki cacert in FLP when Insecureskipverify is enabled