### PR TITLE
CSV: replace placeholder by netobserv namespace name

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -193,7 +193,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/netobserv/network-observability-operator
   name: netobserv-operator.v0.2.0
-  namespace: placeholder
+  namespace: netobserv
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:

--- a/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     description: Network flows collector and monitoring solution
     repository: https://github.com/netobserv/network-observability-operator
   name: netobserv-operator.v0.0.0
-  namespace: placeholder
+  namespace: netobserv
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:


### PR DESCRIPTION
I'm not sure if `placeholder` value was se there by a reason or it was just a mistake.