### PR TITLE
NETOBSERV-727 Update bundle process

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,22 @@
+name: pull request checks
+
+on:
+  pull_request:
+    branches: ['*']
+
+jobs:
+  bundle-check:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        go: ['1.17']
+    name: Checking bundle up-to-date
+    steps:
+    - name: install make
+      run: sudo apt-get install make
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: generate bundle
+      run: make generate bundle
+    - name: check bundle clean state
+      run: git diff HEAD -I "createdAt" -I "operator-sdk-v" --exit-code

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ BUILD_DATE := $(shell date +%Y-%m-%d\ %H:%M)
 BUILD_SHA := $(shell git rev-parse --short HEAD)
 
 # Other component versions when building bundle / release
-PREVIOUS_VERSION ?= tochange
+PREVIOUS_VERSION ?= v0.1.4
+BUNDLE_VERSION ?= 0.2.0
 # console plugin
 export PLG_VERSION ?= v0.1.5
 # flowlogs-pipeline
@@ -28,7 +29,7 @@ PORT_FWD ?= true
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
 # - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
 # - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
-CHANNELS := v1.0.x
+CHANNELS := v0.2.x
 ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
 endif
@@ -38,7 +39,7 @@ endif
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
 # - use the DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
 # - use environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
-DEFAULT_CHANNEL := v1.0.x
+DEFAULT_CHANNEL := v0.2.x
 ifneq ($(origin DEFAULT_CHANNEL), undefined)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
@@ -48,16 +49,16 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# netobserv/network-observability-operator-bundle:$VERSION and netobserv/network-observability-operator-catalog:$VERSION.
+# netobserv/network-observability-operator-bundle:$BUNDLE_VERSION and netobserv/network-observability-operator-catalog:$BUNDLE_VERSION.
 IMAGE_TAG_BASE ?= quay.io/netobserv/network-observability-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
-BUNDLE_VERSION ?= $(VERSION)
+BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(BUNDLE_VERSION)
 
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
+IMG_FOR_BUNDLE ?= $(IMAGE_TAG_BASE):$(BUNDLE_VERSION)
 IMG_SHA = $(IMAGE_TAG_BASE):$(BUILD_SHA)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
@@ -90,8 +91,6 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 NAMESPACE ?= netobserv
-
-CSV_DESC ?= description-upstream.md
 
 all: help
 
@@ -237,20 +236,21 @@ endif
 .PHONY: bundle-prepare
 bundle-prepare: OPSDK generate kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPSDK) generate kustomize manifests -q
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG_FOR_BUNDLE)
 	$(SED) -i -r 's~ebpf-agent:main~ebpf-agent:$(BPF_VERSION)~' ./config/manager/manager.yaml
 	$(SED) -i -r 's~flowlogs-pipeline:main~flowlogs-pipeline:$(FLP_VERSION)~' ./config/manager/manager.yaml
 	$(SED) -i -r 's~console-plugin:main~console-plugin:$(PLG_VERSION)~' ./config/manager/manager.yaml
-	$(SED) -i -r 's~blob/[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?/~blob/$(VERSION)/~g' ./config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
-	$(SED) -i -r 's~blob/[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?/~blob/$(VERSION)/~g' ./config/manifests/bases/$(CSV_DESC)
+	$(SED) -i -r 's~blob/[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?/~blob/$(BUNDLE_VERSION)/~g' ./config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
+	$(SED) -i -r 's~blob/[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?/~blob/$(BUNDLE_VERSION)/~g' ./config/manifests/bases/description-upstream.md
+	$(SED) -i -r 's~blob/[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?/~blob/$(BUNDLE_VERSION)/~g' ./config/manifests/bases/description-ocp.md
 	$(SED) -i -r 's~replaces: netobserv-operator\.v.*~replaces: netobserv-operator\.$(PREVIOUS_VERSION)~' ./config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
 	cp config/samples/flows_v1alpha1_flowcollector.yaml config/samples/flows_v1alpha1_flowcollector_versioned.yaml
 
 .PHONY: bundle
 bundle: bundle-prepare
-	$(SED) -e 's/^/    /' config/manifests/bases/$(CSV_DESC) > tmp-desc
+	$(SED) -e 's/^/    /' config/manifests/bases/description-upstream.md > tmp-desc
 	$(KUSTOMIZE) build config/manifests \
-		| $(SED) -e 's~:container-image:~$(IMG)~' \
+		| $(SED) -e 's~:container-image:~$(IMG_FOR_BUNDLE)~' \
 		| $(SED) -e 's~:created-at:~$(DATE)~' \
 		| $(SED) -e "/':full-description:'/r tmp-desc" \
 		| $(SED) -e "s/':full-description:'/|\-/" \

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -5,9 +5,9 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=netobserv-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=v1.0.x
-LABEL operators.operatorframework.io.bundle.channel.default.v1=v1.0.x
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.2
+LABEL operators.operatorframework.io.bundle.channels.v1=v0.2.x
+LABEL operators.operatorframework.io.bundle.channel.default.v1=v0.2.x
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.22.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -214,8 +214,8 @@ spec:
                           IPFIX-based flow reporter. It is not recommended to sample
                           all the traffic with IPFIX, as it may generate cluster instability.
                           If you REALLY want to do that, set this flag to true. Use
-                          at your own risks. When it is set to true, the value of
-                          "sampling" is ignored.
+                          at your own risk. When it is set to true, the value of "sampling"
+                          is ignored.
                         type: boolean
                       ovnKubernetes:
                         description: ovnKubernetes defines the settings of the OVN-Kubernetes

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -972,7 +972,9 @@ spec:
                           description: address of the Kafka server
                           type: string
                         tls:
-                          description: tls client configuration.
+                          description: tls client configuration. Note that, when eBPF
+                            agents are used, Kafka certificate needs to be copied
+                            in the agent namespace (by default it's netobserv-privileged).
                           properties:
                             caCert:
                               description: caCert defines the reference of the certificate
@@ -1006,7 +1008,8 @@ spec:
                             insecureSkipVerify:
                               default: false
                               description: insecureSkipVerify allows skipping client-side
-                                verification of the server certificate
+                                verification of the server certificate If set to true,
+                                CACert field will be ignored
                               type: boolean
                             userCert:
                               description: userCert defines the user certificate reference
@@ -1062,7 +1065,9 @@ spec:
                     description: address of the Kafka server
                     type: string
                   tls:
-                    description: tls client configuration.
+                    description: tls client configuration. Note that, when eBPF agents
+                      are used, Kafka certificate needs to be copied in the agent
+                      namespace (by default it's netobserv-privileged).
                     properties:
                       caCert:
                         description: caCert defines the reference of the certificate
@@ -1096,7 +1101,8 @@ spec:
                       insecureSkipVerify:
                         default: false
                         description: insecureSkipVerify allows skipping client-side
-                          verification of the server certificate
+                          verification of the server certificate If set to true, CACert
+                          field will be ignored
                         type: boolean
                       userCert:
                         description: userCert defines the user certificate reference
@@ -1243,7 +1249,8 @@ spec:
                       insecureSkipVerify:
                         default: false
                         description: insecureSkipVerify allows skipping client-side
-                          verification of the server certificate
+                          verification of the server certificate If set to true, CACert
+                          field will be ignored
                         type: boolean
                       userCert:
                         description: userCert defines the user certificate reference

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -188,7 +188,7 @@ metadata:
     categories: Monitoring
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: quay.io/netobserv/network-observability-operator:0.2.0
-    createdAt: "2022-11-30T14:57:13Z"
+    createdAt: "2022-12-02T10:20:33Z"
     description: Network flows collector and monitoring solution
     operators.operatorframework.io/builder: operator-sdk-v1.22.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -208,7 +208,7 @@ spec:
   description: |-
     NetObserv Operator is an OpenShift / Kubernetes operator for network observability. It deploys a monitoring pipeline to collect and enrich network flows. These flows can be produced by the NetObserv eBPF agent, or by any device or CNI able to export flows in IPFIX format, such as OVN-Kubernetes.
 
-    The operator provides dashboards, metrics, and keeps flows accessible in a queryable log store, Grafana Loki. When used in OpenShift, new dashboards are available in the Console.
+    The operator provides dashboards, metrics, and keeps flows accessible in a queryable log store, Grafana Loki. When used in OpenShift, new views are available in the Console.
 
     ## Dependencies
 
@@ -262,7 +262,7 @@ spec:
 
     - Kafka (`spec.deploymentModel: KAFKA` and `spec.kafka`): when enabled, integrates the flow collection pipeline with Kafka, by splitting ingestion from transformation (kube enrichment, derived metrics, ...). Kafka can provide better scalability, resiliency and high availability ([view more details](https://www.redhat.com/en/topics/integration/what-is-apache-kafka)). Assumes Kafka is already deployed and a topic is created.
 
-    - Exporters (`spec.exporters`, _experimental_) an optional list of exporters to which to send enriched flows. Currently only KAFKA is supported. This allows you to define any custom storage or processing that can read from Kafka. This feature is flagged as _experimental_ as it has not been thoroughly or stress tested yet, so use at your own risks.
+    - Exporters (`spec.exporters`, _experimental_) an optional list of exporters to which to send enriched flows. Currently only KAFKA is supported. This allows you to define any custom storage or processing that can read from Kafka. This feature is flagged as _experimental_ as it has not been thoroughly or stress tested yet, so use at your own risk.
 
     ## Further reading
 

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -141,10 +141,11 @@ metadata:
               "tls": {
                 "caCert": {
                   "certFile": "service-ca.crt",
-                  "name": "loki",
+                  "name": "loki-ca-bundle",
                   "type": "configmap"
                 },
-                "enable": false
+                "enable": false,
+                "insecureSkipVerify": false
               },
               "url": "http://loki.netobserv.svc:3100/"
             },
@@ -187,9 +188,9 @@ metadata:
     categories: Monitoring
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: quay.io/netobserv/network-observability-operator:0.2.0
-    createdAt: "2022-10-25T09:40:09Z"
+    createdAt: "2022-11-30T14:57:13Z"
     description: Network flows collector and monitoring solution
-    operators.operatorframework.io/builder: operator-sdk-v1.25.2
+    operators.operatorframework.io/builder: operator-sdk-v1.22.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/netobserv/network-observability-operator
   name: netobserv-operator.v0.2.0
@@ -211,59 +212,68 @@ spec:
 
     ## Dependencies
 
-    - [Loki](https://grafana.com/oss/loki/) is required, it is used as a store for all collected flows.
-    For a scalable deployment, please refer to [our distributed Loki guide](https://github.com/netobserv/documents/blob/main/loki_distributed.md) or [Grafana's official documentation](https://grafana.com/docs/loki/latest/).
-    For a quick install that is not suitable for production (it deploys a single pod, configures a 1GB storage PVC, with 24 hours of retention), run the following commands:
+    ### Loki
+
+    [Loki](https://grafana.com/oss/loki/), from GrafanaLabs, is the backend that is used to store all collected flows. The NetObserv Operator does not install Loki directly, however we provide some guidance to help you there.
+
+    For a normal usage, we recommend two options:
+
+    - Installing the [Loki Operator](https://loki-operator.dev/docs/prologue/quickstart.md/). We have written [a guide](https://github.com/netobserv/documents/blob/main/loki_operator.md) to help you through those steps. Please note that it requires configuring an object storage. Note also that the Loki Operator can also be used for [OpenShift cluster logging](https://docs.openshift.com/container-platform/4.11/logging/cluster-logging.html). If you do so, you should not share the same `LokiStack` for Logging and NetObserv.
+
+    - Installing using [Grafana's official documentation](https://grafana.com/docs/loki/latest/). Here also we wrote a ["distributed Loki" step by step guide](https://github.com/netobserv/documents/blob/main/loki_distributed.md).
+
+    For a quick try that is not suitable for production and not scalable (it deploys a single pod, configures a 1GB storage PVC, with 24 hours of retention), you can simply run the following commands:
 
     ```
     kubectl create namespace netobserv
-    kubectl apply -f <(curl -L https://raw.githubusercontent.com/netobserv/documents/f0a1816aa15ea27185cae1cd597f982a5c72935d/examples/zero-click-loki/1-storage.yaml) -n netobserv
-    kubectl apply -f <(curl -L https://raw.githubusercontent.com/netobserv/documents/f0a1816aa15ea27185cae1cd597f982a5c72935d/examples/zero-click-loki/2-loki.yaml) -n netobserv
+    kubectl apply -f <(curl -L https://raw.githubusercontent.com/netobserv/documents/3c42f1ff9c775dd0b746a92dc08c043f9a05f47f/examples/zero-click-loki/1-storage.yaml) -n netobserv
+    kubectl apply -f <(curl -L https://raw.githubusercontent.com/netobserv/documents/3c42f1ff9c775dd0b746a92dc08c043f9a05f47f/examples/zero-click-loki/2-loki.yaml) -n netobserv
     ```
 
-    - [Grafana](https://grafana.com/oss/grafana/) can optionally be installed for custom dashboards and query capabilities.
+    ### Kafka
+
+    [Apache Kafka](https://kafka.apache.org/) can optionnaly be used for a more resilient and scalable architecture. You can use for instance [Strimzi](https://strimzi.io/), an operator-based distribution of Kafka for Kubernetes and OpenShift.
+
+    ### Grafana
+
+    [Grafana](https://grafana.com/oss/grafana/) can optionally be installed for custom dashboards and query capabilities.
 
     ## Configuration
 
-    The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/0.1.4/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/0.1.4/config/samples/flows_v1alpha1_flowcollector.yaml).
+    The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/0.2.0/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/0.2.0/config/samples/flows_v1alpha1_flowcollector.yaml).
+
+    To edit configuration in cluster, run:
+
+    ```bash
+    kubectl edit flowcollector cluster
+    ```
 
     As it operates cluster-wide, only a single `FlowCollector` is allowed, and it has to be named `cluster`.
 
     A couple of settings deserve special attention:
 
-    - Agent (`spec.agent.type`) can be `EBPF` or `IPFIX`. eBPF is recommended, as it should work in more situations and offers better performances. If you can't, or don't want to use eBPF, note that the IPFIX option is fully functional only when using [OVN-Kubernetes](https://github.com/ovn-org/ovn-kubernetes/) CNI. Other CNIs are not officially supported, but you may still be able to configure them manually if they allow IPFIX exports.
+    - Agent (`spec.agent.type`) can be `EBPF` (default) or `IPFIX`. eBPF is recommended, as it should work in more situations and offers better performances. If you can't, or don't want to use eBPF, note that the IPFIX option is fully functional only when using [OVN-Kubernetes](https://github.com/ovn-org/ovn-kubernetes/) CNI. Other CNIs are not officially supported, but you may still be able to configure them manually if they allow IPFIX exports.
 
-    - Sampling (`spec.agent.ebpf.sampling` and `spec.agent.ipfix.sampling`): 24/7, 1:1 sampled flow collection may consume a non-negligible amount of resources. While we are doing our best to make it a viable option in production, it is still sometimes necessary to mitigate by setting a sampling ratio. A value of `100` means: one flow every 100 is sampled. `1` means all flows are sampled. The lower it is, the more flows you get, and the more accurate are derived metrics. By default, sampling is set to 50 (ie. 1:50) for eBPF and 400 (1:400) for IPFIX. Note that more sampled flows also means more storage needed. We recommend to start with default values and refine empirically, to figure out which setting your cluster can manage.
+    - Sampling (`spec.agent.ebpf.sampling` and `spec.agent.ipfix.sampling`): a value of `100` means: one flow every 100 is sampled. `1` means all flows are sampled. The lower it is, the more flows you get, and the more accurate are derived metrics, but the higher amount of resources are consumed. By default, sampling is set to 50 (ie. 1:50) for eBPF and 400 (1:400) for IPFIX. Note that more sampled flows also means more storage needed. We recommend to start with default values and refine empirically, to figure out which setting your cluster can manage.
 
     - Loki (`spec.loki`): configure here how to reach Loki. The default values match the Loki quick install paths mentioned above, but you may have to configure differently if you used another installation method.
 
-    - Kafka (`spec.kafka`): when enabled, integrate the flow collection pipeline with Kafka, by splitting ingestion from transformation (kube enrichment, derived metrics, ...). Kafka can provide better scalability, resiliency and high availability ([view more details](https://www.redhat.com/en/topics/integration/what-is-apache-kafka)). Assumes Kafka is already deployed and a topic is created.
+    - Quick filters (`spec.consolePlugin.quickFilters`): configure preset filters to be displayed in the Console plugin. They offer a way to quickly switch from filters to others, such as showing / hiding pods network, or infrastructure network, or application network, etc. They can be tuned to reflect the different workloads running on your cluster. For a list of available filters, [check this page](https://github.com/netobserv/network-observability-operator/blob/0.2.0/docs/QuickFilters.md).
 
-    ## Overview
+    - Kafka (`spec.deploymentModel: KAFKA` and `spec.kafka`): when enabled, integrates the flow collection pipeline with Kafka, by splitting ingestion from transformation (kube enrichment, derived metrics, ...). Kafka can provide better scalability, resiliency and high availability ([view more details](https://www.redhat.com/en/topics/integration/what-is-apache-kafka)). Assumes Kafka is already deployed and a topic is created.
 
-    ### OpenShift Console
+    - Exporters (`spec.exporters`, _experimental_) an optional list of exporters to which to send enriched flows. Currently only KAFKA is supported. This allows you to define any custom storage or processing that can read from Kafka. This feature is flagged as _experimental_ as it has not been thoroughly or stress tested yet, so use at your own risks.
 
-    _Pre-requisite: OpenShift 4.10 or above_
+    ## Further reading
 
-    If the OpenShift Console is detected in the cluster, a console plugin is deployed when `FlowCollector` is installed. It adds new pages and tabs to the console:
+    Please refer to the documentation on GitHub more more information.
 
-    - A flow table, with powerful filtering and display options
+    This documentation includes:
 
-    - A network topology, with the same filtering options and several levels of aggregations (nodes, namespaces, owner controllers, pods). A side panel provides contextual insight and metrics.
-
-    These components are accessible directly from the main menu, and also as contextual tabs for any Pod, Deployment, Service (etc.) in their details page.
-
-    ### Grafana
-
-    Grafana can be used to retrieve and show the collected flows from Loki. In Grafana, add a new Loki data source that matches your setup. If you used the quick install commands provided above to install Loki, its access URL is `http://loki:3100`.
-
-    To get dashboards, import [this file](https://github.com/netobserv/network-observability-operator/blob/0.1.4/config/samples/dashboards/Network%20Observability.json) into Grafana. It includes a table of the flows and some graphs showing the volumetry per source or destination namespaces or workload:
-
-    See more info and screenshots on [GitHub's readme](https://github.com/netobserv/network-observability-operator/blob/0.1.4/README.md)
-
-    ## F.A.Q / Troubleshooting
-
-    See [the F.A.Q on GitHub](https://github.com/netobserv/network-observability-operator#faq--troubleshooting)
+    - An [overview](https://github.com/netobserv/network-observability-operator#openshift-console) of the features, with screenshots
+    - A [performance](https://github.com/netobserv/network-observability-operator#performance-fine-tuning) section, for fine-tuning
+    - A [security](https://github.com/netobserv/network-observability-operator#securing-data-and-communications) section
+    - A [F.A.Q](https://github.com/netobserv/network-observability-operator#faq--troubleshooting) section
   displayName: NetObserv Operator
   icon:
   - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI2LjAuMiwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMDAgMTAwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAxMDAgMTAwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6dXJsKCNTVkdJRF8xXyk7fQoJLnN0MXtmaWxsOiNGRkZGRkY7fQoJLnN0MntvcGFjaXR5OjAuNjt9Cgkuc3Qze29wYWNpdHk6MC41O30KCS5zdDR7b3BhY2l0eTowLjQ7fQo8L3N0eWxlPgo8Zz4KCTxnPgoJCTxnPgoJCQk8cmFkaWFsR3JhZGllbnQgaWQ9IlNWR0lEXzFfIiBjeD0iMTQuNzc1OCIgY3k9Ii0yLjk3NzEiIHI9IjkxLjYyNyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgoJCQkJPHN0b3AgIG9mZnNldD0iMCIgc3R5bGU9InN0b3AtY29sb3I6IzNDM0ZBNiIvPgoJCQkJPHN0b3AgIG9mZnNldD0iMSIgc3R5bGU9InN0b3AtY29sb3I6IzNCMDM0MCIvPgoJCQk8L3JhZGlhbEdyYWRpZW50PgoJCQk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNTAsOTljLTEzLjMsMC0yNS40LTUuMy0zNC4yLTEzLjlDNi43LDc2LjIsMSw2My43LDEsNTBDMSwyMi45LDIyLjksMSw1MCwxYzEzLjcsMCwyNi4yLDUuNywzNS4xLDE0LjgKCQkJCUM5My43LDI0LjYsOTksMzYuNyw5OSw1MEM5OSw3Ny4xLDc3LjEsOTksNTAsOTl6Ii8+CgkJPC9nPgoJCTxnPgoJCQk8Y2lyY2xlIGNsYXNzPSJzdDEiIGN4PSIzNy41IiBjeT0iODEuOSIgcj0iNSIvPgoJCTwvZz4KCQk8cGF0aCBjbGFzcz0ic3QxIiBkPSJNNDguNiw5MS45bDE4LjgtNDMuM2MtMi41LTAuMS01LTAuNy03LjItMkwzMy4yLDY4LjJsMS40LTEuOGwyMC0yNS4xYy0xLjUtMi40LTIuMy01LjEtMi4zLTcuOUw5LDUyLjIKCQkJbDQ3LjYtMjkuOWwwLDBjMC4xLTAuMSwwLjItMC4yLDAuMi0wLjJjNi4xLTYuMSwxNS45LTYuMSwyMiwwbDAuMSwwLjFjNiw2LjEsNiwxNS45LTAuMSwyMS45Yy0wLjEsMC4xLTAuMiwwLjItMC4yLDAuMmwwLDAKCQkJTDQ4LjYsOTEuOXoiLz4KCQk8ZyBjbGFzcz0ic3QyIj4KCQkJPGNpcmNsZSBjbGFzcz0ic3QxIiBjeD0iNTAuMyIgY3k9IjE0LjciIHI9IjMuMSIvPgoJCTwvZz4KCQk8ZyBjbGFzcz0ic3QzIj4KCQkJPGNpcmNsZSBjbGFzcz0ic3QxIiBjeD0iMjcuNyIgY3k9IjU4IiByPSIxLjciLz4KCQk8L2c+CgkJPGc+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9Ijc3LjQiIGN5PSI2OS4zIiByPSIxLjciLz4KCQk8L2c+CgkJPGc+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9IjE2LjMiIGN5PSIzNi42IiByPSIxLjciLz4KCQk8L2c+CgkJPGcgY2xhc3M9InN0NCI+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9IjYzLjciIGN5PSI4NS45IiByPSIyLjIiLz4KCQk8L2c+CgkJPGc+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9IjI5LjQiIGN5PSIxOS42IiByPSI0LjgiLz4KCQk8L2c+CgkJPGcgY2xhc3M9InN0MyI+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9Ijg4IiBjeT0iNTAiIHI9IjQuOCIvPgoJCTwvZz4KCTwvZz4KPC9nPgo8L3N2Zz4K
@@ -465,11 +475,11 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_EBPF_AGENT
-                  value: quay.io/netobserv/netobserv-ebpf-agent:main
+                  value: quay.io/netobserv/netobserv-ebpf-agent:v0.2.1
                 - name: RELATED_IMAGE_FLOWLOGS_PIPELINE
-                  value: quay.io/netobserv/flowlogs-pipeline:main
+                  value: quay.io/netobserv/flowlogs-pipeline:v0.1.4
                 - name: RELATED_IMAGE_CONSOLE_PLUGIN
-                  value: quay.io/netobserv/network-observability-console-plugin:main
+                  value: quay.io/netobserv/network-observability-console-plugin:v0.1.5
                 image: quay.io/netobserv/network-observability-operator:0.2.0
                 imagePullPolicy: Always
                 livenessProbe:
@@ -495,16 +505,16 @@ spec:
                 securityContext:
                   allowPrivilegeEscalation: false
               - args:
-                  - --secure-listen-address=0.0.0.0:8443
-                  - --upstream=http://127.0.0.1:8080/
-                  - --logtostderr=true
-                  - --v=10
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
                 image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
                 name: kube-rbac-proxy
                 ports:
-                  - containerPort: 8443
-                    name: https
-                    protocol: TCP
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
                 resources: {}
               securityContext:
                 runAsNonRoot: true
@@ -583,5 +593,12 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
+  relatedImages:
+  - image: quay.io/netobserv/netobserv-ebpf-agent:v0.2.1
+    name: ebpf-agent
+  - image: quay.io/netobserv/flowlogs-pipeline:v0.1.4
+    name: flowlogs-pipeline
+  - image: quay.io/netobserv/network-observability-console-plugin:v0.1.5
+    name: console-plugin
   replaces: netobserv-operator.v0.1.4
   version: 0.2.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,9 +4,9 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: netobserv-operator
-  operators.operatorframework.io.bundle.channels.v1: v1.0.x
-  operators.operatorframework.io.bundle.channel.default.v1: v1.0.x
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.2
+  operators.operatorframework.io.bundle.channels.v1: v0.2.x
+  operators.operatorframework.io.bundle.channel.default.v1: v0.2.x
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.22.2
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,11 +34,11 @@ spec:
         - --console-plugin-image=$(RELATED_IMAGE_CONSOLE_PLUGIN)"
         env:
           - name: RELATED_IMAGE_EBPF_AGENT
-            value: quay.io/netobserv/netobserv-ebpf-agent:main
+            value: quay.io/netobserv/netobserv-ebpf-agent:v0.2.1
           - name: RELATED_IMAGE_FLOWLOGS_PIPELINE
-            value: quay.io/netobserv/flowlogs-pipeline:main
+            value: quay.io/netobserv/flowlogs-pipeline:v0.1.4
           - name: RELATED_IMAGE_CONSOLE_PLUGIN
-            value: quay.io/netobserv/network-observability-console-plugin:main
+            value: quay.io/netobserv/network-observability-console-plugin:v0.1.5
         image: controller:latest
         name: manager
         imagePullPolicy: Always

--- a/config/manifests/bases/description-ocp.md
+++ b/config/manifests/bases/description-ocp.md
@@ -32,7 +32,7 @@ kubectl apply -f <(curl -L https://raw.githubusercontent.com/netobserv/documents
 
 ## Configuration
 
-The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/0.1.4/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/0.1.4/config/samples/flows_v1alpha1_flowcollector.yaml).
+The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/0.2.0/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/0.2.0/config/samples/flows_v1alpha1_flowcollector.yaml).
 
 To edit configuration in cluster, run:
 
@@ -48,7 +48,7 @@ A couple of settings deserve special attention:
 
 - Loki (`spec.loki`): configure here how to reach Loki. The default values match the Loki quick install paths mentioned above, but you may have to configure differently if you used another installation method.
 
-- Quick filters (`spec.consolePlugin.quickFilters`): configure preset filters to be displayed in the Console plugin. They offer a way to quickly switch from filters to others, such as showing / hiding pods network, or infrastructure network, or application network, etc. They can be tuned to reflect the different workloads running on your cluster. For a list of available filters, [check this page](https://github.com/netobserv/network-observability-operator/blob/0.1.4/docs/QuickFilters.md).
+- Quick filters (`spec.consolePlugin.quickFilters`): configure preset filters to be displayed in the Console plugin. They offer a way to quickly switch from filters to others, such as showing / hiding pods network, or infrastructure network, or application network, etc. They can be tuned to reflect the different workloads running on your cluster. For a list of available filters, [check this page](https://github.com/netobserv/network-observability-operator/blob/0.2.0/docs/QuickFilters.md).
 
 - Kafka (`spec.deploymentModel: KAFKA` and `spec.kafka`): when enabled, integrates the flow collection pipeline with Kafka, by splitting ingestion from transformation (kube enrichment, derived metrics, ...). Kafka can provide better scalability, resiliency and high availability ([view more details](https://www.redhat.com/en/topics/integration/what-is-apache-kafka)). Assumes Kafka is already deployed and a topic is created.
 

--- a/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
@@ -73,6 +73,17 @@ spec:
         certKey: user.key
   loki:
     url: 'http://loki.netobserv.svc:3100/'
+    # Uncomment lines below for typical installation with loki-operator (5.6+ needed)
+    # url: 'https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network/'
+    # statusUrl: 'https://loki-query-frontend-http.netobserv.svc:3100/'
+    # authToken: HOST
+    tls:
+      enable: false
+      caCert:
+        type: configmap
+        name: loki-ca-bundle
+        certFile: service-ca.crt
+      insecureSkipVerify: false
     batchWait: 1s
     batchSize: 10485760
     minBackoff: 1s
@@ -80,12 +91,6 @@ spec:
     maxRetries: 2
     staticLabels:
       app: netobserv-flowcollector
-    tls:
-      enable: false
-      caCert:
-        type: configmap
-        name: loki
-        certFile: service-ca.crt
   consolePlugin:
     register: true
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Requires https://github.com/netobserv/network-observability-operator/pull/200

The bundle process needs to work both for upstream and downstream
Every time someone changes something that would alter the bundle (e.g.
CSV description), they should run "make bundle" (with no options)

It will generate the CSV with injected upstream description.
The downstream description will be updated too, but not injected: this
step will be done later on, in midstream.