### PR TITLE
NETOBSERV-693: use ISO8601 for logging timestamps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/openshift/api v0.0.0-20220112145620-704957ce4980
 	github.com/prometheus/common v0.32.1
 	github.com/stretchr/testify v1.7.1
+	go.uber.org/zap v1.19.1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ import (
 	"os"
 
 	"github.com/netobserv/network-observability-operator/controllers/operator"
+	"go.uber.org/zap/zapcore"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
@@ -85,6 +87,7 @@ func main() {
 	flag.BoolVar(&versionFlag, "v", false, "print version")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,6 +167,7 @@ go.uber.org/atomic
 # go.uber.org/multierr v1.7.0
 go.uber.org/multierr
 # go.uber.org/zap v1.19.1
+## explicit
 go.uber.org/zap
 go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool


### PR DESCRIPTION
Changed timestamps in epoch milliseconds by something like `2022-12-01T09:53:35.484Z`.
