### PR TITLE
update upstream release doc

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -90,8 +90,7 @@ Check also the "Create a discussion for this release" option, in category "Annou
 Before publishing, we should check that upgrading the operator from a previous version isn't broken. We can use `operator-sdk` for that:
 
 ```bash
-# NOTE: on my last try, I needed to pass an index-image that corresponds to the operator-sdk version. This is likely due to a bug and should be eventually removed (cf https://github.com/operator-framework/operator-sdk/issues/5980)
-operator-sdk run bundle quay.io/netobserv/network-observability-operator-bundle:$previous --index-image quay.io/operator-framework/opm:v1.22 --timeout 5m
+operator-sdk run bundle quay.io/netobserv/network-observability-operator-bundle:$previous --timeout 5m
 operator-sdk run bundle-upgrade quay.io/netobserv/network-observability-operator-bundle:$vv --timeout 5m
 ```
 
@@ -120,7 +119,12 @@ After having cloned or updated these repo, copy the bundle content:
 # Here, set correct paths and new version
 path_k8s="../community-operators"
 path_okd="../community-operators-prod"
-version="0.2.0"
+version="0.2.1"
+
+cd $path_k8s && git fetch upstream && git rebase upstream/main
+cd -
+cd $path_okd && git fetch upstream && git rebase upstream/main
+cd -
 
 mkdir -p $path_k8s/operators/netobserv-operator/$version
 mkdir -p $path_okd/operators/netobserv-operator/$version


### PR DESCRIPTION
fwiw, upgrade path worked correctly without the previous hack