### PR TITLE
Bug NETOBSERV-743: update build image & CI tests to Go 1.18 (backport to 4.12)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     name: Checking bundle up-to-date
     steps:
     - name: install make

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
       - name: install make
         run: sudo apt-get install make

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
       - name: install make
         run: sudo apt-get install make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.17 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18 as builder
 ARG BUILD_VERSION="unknown"
 
 WORKDIR /opt/app-root


### PR DESCRIPTION
Backport of https://github.com/netobserv/network-observability-operator/pull/217