### PR TITLE
[4.12 backport] CRD doc update - simplified sample (#224)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ ifeq (,$(shell which operator-sdk 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPSDK)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPSDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.22.1/operator-sdk_$${OS}_$${ARCH} ;\
+	curl -sSLo $(OPSDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.25.3/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OPSDK) ;\
 	}
 else

--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -196,9 +196,11 @@ type FlowCollectorEBPF struct {
 	// logLevel defines the log level for the NetObserv eBPF Agent
 	LogLevel string `json:"logLevel,omitempty"`
 
-	// privileged mode for the eBPF Agent container. If false, the operator will add the following
-	// capabilities to the container, to enable its correct operation:
-	// BPF, PERFMON, NET_ADMIN, SYS_RESOURCE.
+	// privileged mode for the eBPF Agent container. In general this setting can be ignored or set to false:
+	// in that case, the operator will set granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE)
+	// to the container, to enable its correct operation.
+	// If for some reason these capabilities cannot be set (e.g. old kernel version not knowing CAP_BPF)
+	// then you can turn on this mode for more global privileges.
 	// +optional
 	Privileged bool `json:"privileged,omitempty"`
 
@@ -226,7 +228,8 @@ type FlowCollectorKafka struct {
 	// kafka topic to use. It must exist, NetObserv will not create it.
 	Topic string `json:"topic"`
 
-	// tls client configuration. Note that, when eBPF agents are used, Kafka certificate needs to be copied in the agent namespace (by default it's netobserv-privileged).
+	// tls client configuration. When using TLS, make sure the address matches the Kafka port used for TLS, generally 9093.
+	// Note that, when eBPF agents are used, Kafka certificate needs to be copied in the agent namespace (by default it's netobserv-privileged).
 	// +optional
 	TLS ClientTLS `json:"tls"`
 }
@@ -615,7 +618,7 @@ type ClientTLS struct {
 	// caCert defines the reference of the certificate for the Certificate Authority
 	CACert CertificateReference `json:"caCert,omitempty"`
 
-	// userCert defines the user certificate reference
+	// userCert defines the user certificate reference, used for mTLS (you can ignore it when using regular, one-way TLS)
 	// +optional
 	UserCert CertificateReference `json:"userCert,omitempty"`
 }

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=netobserv-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=v1.0.x
 LABEL operators.operatorframework.io.bundle.channel.default.v1=v1.0.x
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.3
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -143,9 +143,13 @@ spec:
                         type: string
                       privileged:
                         description: 'privileged mode for the eBPF Agent container.
-                          If false, the operator will add the following capabilities
-                          to the container, to enable its correct operation: BPF,
-                          PERFMON, NET_ADMIN, SYS_RESOURCE.'
+                          In general this setting can be ignored or set to false:
+                          in that case, the operator will set granular capabilities
+                          (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container,
+                          to enable its correct operation. If for some reason these
+                          capabilities cannot be set (e.g. old kernel version not
+                          knowing CAP_BPF) then you can turn on this mode for more
+                          global privileges.'
                         type: boolean
                       resources:
                         default:
@@ -980,9 +984,11 @@ spec:
                           description: address of the Kafka server
                           type: string
                         tls:
-                          description: tls client configuration. Note that, when eBPF
-                            agents are used, Kafka certificate needs to be copied
-                            in the agent namespace (by default it's netobserv-privileged).
+                          description: tls client configuration. When using TLS, make
+                            sure the address matches the Kafka port used for TLS,
+                            generally 9093. Note that, when eBPF agents are used,
+                            Kafka certificate needs to be copied in the agent namespace
+                            (by default it's netobserv-privileged).
                           properties:
                             caCert:
                               description: caCert defines the reference of the certificate
@@ -1020,7 +1026,9 @@ spec:
                                 CACert field will be ignored
                               type: boolean
                             userCert:
-                              description: userCert defines the user certificate reference
+                              description: userCert defines the user certificate reference,
+                                used for mTLS (you can ignore it when using regular,
+                                one-way TLS)
                               properties:
                                 certFile:
                                   description: certFile defines the path to the certificate
@@ -1073,9 +1081,10 @@ spec:
                     description: address of the Kafka server
                     type: string
                   tls:
-                    description: tls client configuration. Note that, when eBPF agents
-                      are used, Kafka certificate needs to be copied in the agent
-                      namespace (by default it's netobserv-privileged).
+                    description: tls client configuration. When using TLS, make sure
+                      the address matches the Kafka port used for TLS, generally 9093.
+                      Note that, when eBPF agents are used, Kafka certificate needs
+                      to be copied in the agent namespace (by default it's netobserv-privileged).
                     properties:
                       caCert:
                         description: caCert defines the reference of the certificate
@@ -1113,7 +1122,9 @@ spec:
                           field will be ignored
                         type: boolean
                       userCert:
-                        description: userCert defines the user certificate reference
+                        description: userCert defines the user certificate reference,
+                          used for mTLS (you can ignore it when using regular, one-way
+                          TLS)
                         properties:
                           certFile:
                             description: certFile defines the path to the certificate
@@ -1261,7 +1272,9 @@ spec:
                           field will be ignored
                         type: boolean
                       userCert:
-                        description: userCert defines the user certificate reference
+                        description: userCert defines the user certificate reference,
+                          used for mTLS (you can ignore it when using regular, one-way
+                          TLS)
                         properties:
                           certFile:
                             description: certFile defines the path to the certificate

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -22,7 +22,6 @@ metadata:
                 "interfaces": [],
                 "kafkaBatchSize": 10485760,
                 "logLevel": "info",
-                "privileged": false,
                 "resources": {
                   "limits": {
                     "memory": "800Mi"
@@ -33,19 +32,6 @@ metadata:
                   }
                 },
                 "sampling": 50
-              },
-              "ipfix": {
-                "cacheActiveTimeout": "20s",
-                "cacheMaxFlows": 400,
-                "clusterNetworkOperator": {
-                  "namespace": "openshift-network-operator"
-                },
-                "ovnKubernetes": {
-                  "containerName": "ovnkube-node",
-                  "daemonSetName": "ovnkube-node",
-                  "namespace": "ovn-kubernetes"
-                },
-                "sampling": 400
               },
               "type": "EBPF"
             },
@@ -135,9 +121,6 @@ metadata:
               "maxBackoff": "5s",
               "maxRetries": 2,
               "minBackoff": "1s",
-              "staticLabels": {
-                "app": "netobserv-flowcollector"
-              },
               "tls": {
                 "caCert": {
                   "certFile": "service-ca.crt",
@@ -152,8 +135,6 @@ metadata:
             "namespace": "netobserv",
             "processor": {
               "dropUnusedFields": true,
-              "enableKubeProbes": true,
-              "healthPort": 8080,
               "imagePullPolicy": "IfNotPresent",
               "kafkaConsumerAutoscaler": null,
               "kafkaConsumerBatchSize": 10485760,
@@ -190,7 +171,7 @@ metadata:
     containerImage: quay.io/netobserv/network-observability-operator:1.0.0
     createdAt: "2022-12-13T09:38:43Z"
     description: Network flows collector and monitoring solution
-    operators.operatorframework.io/builder: operator-sdk-v1.25.2
+    operators.operatorframework.io/builder: operator-sdk-v1.25.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/netobserv/network-observability-operator
   name: netobserv-operator.v1.0.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: netobserv-operator
   operators.operatorframework.io.bundle.channels.v1: v1.0.x
   operators.operatorframework.io.bundle.channel.default.v1: v1.0.x
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.2
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.3
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -141,9 +141,13 @@ spec:
                         type: string
                       privileged:
                         description: 'privileged mode for the eBPF Agent container.
-                          If false, the operator will add the following capabilities
-                          to the container, to enable its correct operation: BPF,
-                          PERFMON, NET_ADMIN, SYS_RESOURCE.'
+                          In general this setting can be ignored or set to false:
+                          in that case, the operator will set granular capabilities
+                          (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container,
+                          to enable its correct operation. If for some reason these
+                          capabilities cannot be set (e.g. old kernel version not
+                          knowing CAP_BPF) then you can turn on this mode for more
+                          global privileges.'
                         type: boolean
                       resources:
                         default:
@@ -978,9 +982,11 @@ spec:
                           description: address of the Kafka server
                           type: string
                         tls:
-                          description: tls client configuration. Note that, when eBPF
-                            agents are used, Kafka certificate needs to be copied
-                            in the agent namespace (by default it's netobserv-privileged).
+                          description: tls client configuration. When using TLS, make
+                            sure the address matches the Kafka port used for TLS,
+                            generally 9093. Note that, when eBPF agents are used,
+                            Kafka certificate needs to be copied in the agent namespace
+                            (by default it's netobserv-privileged).
                           properties:
                             caCert:
                               description: caCert defines the reference of the certificate
@@ -1018,7 +1024,9 @@ spec:
                                 CACert field will be ignored
                               type: boolean
                             userCert:
-                              description: userCert defines the user certificate reference
+                              description: userCert defines the user certificate reference,
+                                used for mTLS (you can ignore it when using regular,
+                                one-way TLS)
                               properties:
                                 certFile:
                                   description: certFile defines the path to the certificate
@@ -1071,9 +1079,10 @@ spec:
                     description: address of the Kafka server
                     type: string
                   tls:
-                    description: tls client configuration. Note that, when eBPF agents
-                      are used, Kafka certificate needs to be copied in the agent
-                      namespace (by default it's netobserv-privileged).
+                    description: tls client configuration. When using TLS, make sure
+                      the address matches the Kafka port used for TLS, generally 9093.
+                      Note that, when eBPF agents are used, Kafka certificate needs
+                      to be copied in the agent namespace (by default it's netobserv-privileged).
                     properties:
                       caCert:
                         description: caCert defines the reference of the certificate
@@ -1111,7 +1120,9 @@ spec:
                           field will be ignored
                         type: boolean
                       userCert:
-                        description: userCert defines the user certificate reference
+                        description: userCert defines the user certificate reference,
+                          used for mTLS (you can ignore it when using regular, one-way
+                          TLS)
                         properties:
                           certFile:
                             description: certFile defines the path to the certificate
@@ -1259,7 +1270,9 @@ spec:
                           field will be ignored
                         type: boolean
                       userCert:
-                        description: userCert defines the user certificate reference
+                        description: userCert defines the user certificate reference,
+                          used for mTLS (you can ignore it when using regular, one-way
+                          TLS)
                         properties:
                           certFile:
                             description: certFile defines the path to the certificate

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -7,16 +7,6 @@ spec:
   deploymentModel: DIRECT
   agent:
     type: EBPF
-    ipfix:
-      cacheActiveTimeout: 20s
-      cacheMaxFlows: 400
-      sampling: 400
-      clusterNetworkOperator:
-        namespace: openshift-network-operator
-      ovnKubernetes:
-        namespace: ovn-kubernetes
-        daemonSetName: ovnkube-node
-        containerName: ovnkube-node
     ebpf:
       imagePullPolicy: IfNotPresent
       sampling: 50
@@ -25,7 +15,6 @@ spec:
       interfaces: [ ]
       excludeInterfaces: [ "lo" ]
       logLevel: info
-      privileged: false
       resources:
         requests:
           memory: 50Mi
@@ -37,8 +26,6 @@ spec:
     port: 2055
     imagePullPolicy: IfNotPresent
     logLevel: info
-    enableKubeProbes: true
-    healthPort: 8080
     profilePort: 6060
     metrics:
       server:
@@ -89,8 +76,6 @@ spec:
     minBackoff: 1s
     maxBackoff: 5s
     maxRetries: 2
-    staticLabels:
-      app: netobserv-flowcollector
   consolePlugin:
     register: true
     imagePullPolicy: IfNotPresent

--- a/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
@@ -7,16 +7,6 @@ spec:
   deploymentModel: DIRECT
   agent:
     type: EBPF
-    ipfix:
-      cacheActiveTimeout: 20s
-      cacheMaxFlows: 400
-      sampling: 400
-      clusterNetworkOperator:
-        namespace: openshift-network-operator
-      ovnKubernetes:
-        namespace: ovn-kubernetes
-        daemonSetName: ovnkube-node
-        containerName: ovnkube-node
     ebpf:
       imagePullPolicy: IfNotPresent
       sampling: 50
@@ -25,7 +15,6 @@ spec:
       interfaces: [ ]
       excludeInterfaces: [ "lo" ]
       logLevel: info
-      privileged: false
       resources:
         requests:
           memory: 50Mi
@@ -37,8 +26,6 @@ spec:
     port: 2055
     imagePullPolicy: IfNotPresent
     logLevel: info
-    enableKubeProbes: true
-    healthPort: 8080
     profilePort: 6060
     metrics:
       server:
@@ -89,8 +76,6 @@ spec:
     minBackoff: 1s
     maxBackoff: 5s
     maxRetries: 2
-    staticLabels:
-      app: netobserv-flowcollector
   consolePlugin:
     register: true
     imagePullPolicy: IfNotPresent

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -284,7 +284,7 @@ ebpf describes the settings related to the eBPF-based flow reporter when the "ag
         <td><b>privileged</b></td>
         <td>boolean</td>
         <td>
-          privileged mode for the eBPF Agent container. If false, the operator will add the following capabilities to the container, to enable its correct operation: BPF, PERFMON, NET_ADMIN, SYS_RESOURCE.<br/>
+          privileged mode for the eBPF Agent container. In general this setting can be ignored or set to false: in that case, the operator will set granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container, to enable its correct operation. If for some reason these capabilities cannot be set (e.g. old kernel version not knowing CAP_BPF) then you can turn on this mode for more global privileges.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1733,7 +1733,7 @@ kafka describes the kafka configuration (address, topic...) to send enriched flo
         <td><b><a href="#flowcollectorspecexportersindexkafkatls">tls</a></b></td>
         <td>object</td>
         <td>
-          tls client configuration. Note that, when eBPF agents are used, Kafka certificate needs to be copied in the agent namespace (by default it's netobserv-privileged).<br/>
+          tls client configuration. When using TLS, make sure the address matches the Kafka port used for TLS, generally 9093. Note that, when eBPF agents are used, Kafka certificate needs to be copied in the agent namespace (by default it's netobserv-privileged).<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1745,7 +1745,7 @@ kafka describes the kafka configuration (address, topic...) to send enriched flo
 
 
 
-tls client configuration. Note that, when eBPF agents are used, Kafka certificate needs to be copied in the agent namespace (by default it's netobserv-privileged).
+tls client configuration. When using TLS, make sure the address matches the Kafka port used for TLS, generally 9093. Note that, when eBPF agents are used, Kafka certificate needs to be copied in the agent namespace (by default it's netobserv-privileged).
 
 <table>
     <thead>
@@ -1785,7 +1785,7 @@ tls client configuration. Note that, when eBPF agents are used, Kafka certificat
         <td><b><a href="#flowcollectorspecexportersindexkafkatlsusercert">userCert</a></b></td>
         <td>object</td>
         <td>
-          userCert defines the user certificate reference<br/>
+          userCert defines the user certificate reference, used for mTLS (you can ignore it when using regular, one-way TLS)<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1847,7 +1847,7 @@ caCert defines the reference of the certificate for the Certificate Authority
 
 
 
-userCert defines the user certificate reference
+userCert defines the user certificate reference, used for mTLS (you can ignore it when using regular, one-way TLS)
 
 <table>
     <thead>
@@ -1930,7 +1930,7 @@ kafka configuration, allowing to use Kafka as a broker as part of the flow colle
         <td><b><a href="#flowcollectorspeckafkatls">tls</a></b></td>
         <td>object</td>
         <td>
-          tls client configuration. Note that, when eBPF agents are used, Kafka certificate needs to be copied in the agent namespace (by default it's netobserv-privileged).<br/>
+          tls client configuration. When using TLS, make sure the address matches the Kafka port used for TLS, generally 9093. Note that, when eBPF agents are used, Kafka certificate needs to be copied in the agent namespace (by default it's netobserv-privileged).<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1942,7 +1942,7 @@ kafka configuration, allowing to use Kafka as a broker as part of the flow colle
 
 
 
-tls client configuration. Note that, when eBPF agents are used, Kafka certificate needs to be copied in the agent namespace (by default it's netobserv-privileged).
+tls client configuration. When using TLS, make sure the address matches the Kafka port used for TLS, generally 9093. Note that, when eBPF agents are used, Kafka certificate needs to be copied in the agent namespace (by default it's netobserv-privileged).
 
 <table>
     <thead>
@@ -1982,7 +1982,7 @@ tls client configuration. Note that, when eBPF agents are used, Kafka certificat
         <td><b><a href="#flowcollectorspeckafkatlsusercert">userCert</a></b></td>
         <td>object</td>
         <td>
-          userCert defines the user certificate reference<br/>
+          userCert defines the user certificate reference, used for mTLS (you can ignore it when using regular, one-way TLS)<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2044,7 +2044,7 @@ caCert defines the reference of the certificate for the Certificate Authority
 
 
 
-userCert defines the user certificate reference
+userCert defines the user certificate reference, used for mTLS (you can ignore it when using regular, one-way TLS)
 
 <table>
     <thead>
@@ -2270,7 +2270,7 @@ tls client configuration.
         <td><b><a href="#flowcollectorspeclokitlsusercert">userCert</a></b></td>
         <td>object</td>
         <td>
-          userCert defines the user certificate reference<br/>
+          userCert defines the user certificate reference, used for mTLS (you can ignore it when using regular, one-way TLS)<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2332,7 +2332,7 @@ caCert defines the reference of the certificate for the Certificate Authority
 
 
 
-userCert defines the user certificate reference
+userCert defines the user certificate reference, used for mTLS (you can ignore it when using regular, one-way TLS)
 
 <table>
     <thead>


### PR DESCRIPTION
Backport of https://github.com/netobserv/network-observability-operator/pull/224

* CRD doc update - simplified sample

- add some explanation about agent's privileged mode
- add some hints when configuring kafka & TLS
- add some hints about mTLS
- remove IPFIX from the sample CR (it still exists but wouldn't show up as the sample CR when installing from OLM console)
- remove a couple of other much unused fields from the sample CR

* update operator-sdk default version