### PR TITLE
Update golangci-lint (release-4.12)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,5 @@
 linters:
   enable:
-    - deadcode
     - errcheck
     - errorlint
     - cyclop
@@ -8,20 +7,18 @@ linters:
     - exhaustive
     - exportloopref
     - gocritic
-    - goimports
+    - gofmt
     - gosimple
     - govet
     - ineffassign
     - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unused
-    - varcheck
 linters-settings:
   stylecheck:
-    go: "1.17"
+    go: "1.18"
   gocritic:
     enabled-checks:
       - hugeParam

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ IMG_SHA = $(IMAGE_TAG_BASE):$(BUILD_SHA)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
-GOLANGCI_LINT_VERSION = v1.42.1
+GOLANGCI_LINT_VERSION = v1.50.1
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
Backport of https://github.com/netobserv/network-observability-operator/pull/227