### PR TITLE
[4.12 backport] NETOBSERV-730 Change operator limits (#229)

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -478,8 +478,7 @@ spec:
                   periodSeconds: 10
                 resources:
                   limits:
-                    cpu: 200m
-                    memory: 200Mi
+                    memory: 400Mi
                   requests:
                     cpu: 100m
                     memory: 100Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,8 +58,7 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 200m
-            memory: 200Mi
+            memory: 400Mi
           requests:
             cpu: 100m
             memory: 100Mi


### PR DESCRIPTION
- Remove CPU limit
- Set memory limit to 400MiB