### PR TITLE
NETOBSERV-750: fix to enable being in the 4.12 catalog (release-4.12 backport)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,12 @@ bundle: bundle-prepare
 		| $(SED) -e "s/':full-description:'/|\-/" \
 		| $(OPSDK) generate bundle -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS)
 	rm tmp-desc
-	$(OPSDK) bundle validate ./bundle
+	sh -c '\
+	VALIDATION_OUTPUT=$$($(OPSDK) bundle validate ./bundle --select-optional suite=operatorframework); \
+	echo $${VALIDATION_OUTPUT}; \
+	if [ $$(echo $${VALIDATION_OUTPUT} | grep -i 'warning' | wc -c) -gt 0 ]; then echo "please correct warnings and errors first"; exit -1 ; fi \
+	'
+
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -16,7 +16,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	ascv2 "k8s.io/api/autoscaling/v2beta2"
+	ascv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/autoscaling/v2beta2"
+	"k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -285,7 +285,7 @@ func (in *FlowCollectorHPA) DeepCopyInto(out *FlowCollectorHPA) {
 	}
 	if in.Metrics != nil {
 		in, out := &in.Metrics, &out.Metrics
-		*out = make([]v2beta2.MetricSpec, len(*in))
+		*out = make([]v2.MetricSpec, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -301,7 +301,7 @@ spec:
                             should be set at once).
                           properties:
                             containerResource:
-                              description: container resource refers to a resource
+                              description: containerResource refers to a resource
                                 metric (such as those specified in requests and limits)
                                 known to Kubernetes describing a single container
                                 in each pod of the current scale target (e.g. CPU
@@ -483,9 +483,8 @@ spec:
                                 on an Ingress object).
                               properties:
                                 describedObject:
-                                  description: CrossVersionObjectReference contains
-                                    enough information to let you identify the referred
-                                    resource.
+                                  description: describedObject specifies the descriptions
+                                    of a object,such as kind,name apiVersion
                                   properties:
                                     apiVersion:
                                       description: API version of the referent
@@ -1380,7 +1379,7 @@ spec:
                             should be set at once).
                           properties:
                             containerResource:
-                              description: container resource refers to a resource
+                              description: containerResource refers to a resource
                                 metric (such as those specified in requests and limits)
                                 known to Kubernetes describing a single container
                                 in each pod of the current scale target (e.g. CPU
@@ -1562,9 +1561,8 @@ spec:
                                 on an Ingress object).
                               properties:
                                 describedObject:
-                                  description: CrossVersionObjectReference contains
-                                    enough information to let you identify the referred
-                                    resource.
+                                  description: describedObject specifies the descriptions
+                                    of a object,such as kind,name apiVersion
                                   properties:
                                     apiVersion:
                                       description: API version of the referent

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -1,4 +1,4 @@
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: operators.coreos.com/v1
 kind: ClusterServiceVersion
 metadata:
   annotations:
@@ -169,7 +169,7 @@ metadata:
     categories: Monitoring
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: quay.io/netobserv/network-observability-operator:1.0.0
-    createdAt: "2022-12-13T09:38:43Z"
+    createdAt: "2022-12-16T08:09:30Z"
     description: Network flows collector and monitoring solution
     operators.operatorframework.io/builder: operator-sdk-v1.25.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -496,7 +496,13 @@ spec:
                 - containerPort: 8443
                   name: https
                   protocol: TCP
-                resources: {}
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: netobserv-controller-manager
@@ -571,6 +577,7 @@ spec:
   - email: ocazade@redhat.com
     name: Olivier Cazade
   maturity: alpha
+  minKubeVersion: 1.23.0
   provider:
     name: Red Hat
     url: https://www.redhat.com

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -299,7 +299,7 @@ spec:
                             should be set at once).
                           properties:
                             containerResource:
-                              description: container resource refers to a resource
+                              description: containerResource refers to a resource
                                 metric (such as those specified in requests and limits)
                                 known to Kubernetes describing a single container
                                 in each pod of the current scale target (e.g. CPU
@@ -481,9 +481,8 @@ spec:
                                 on an Ingress object).
                               properties:
                                 describedObject:
-                                  description: CrossVersionObjectReference contains
-                                    enough information to let you identify the referred
-                                    resource.
+                                  description: describedObject specifies the descriptions
+                                    of a object,such as kind,name apiVersion
                                   properties:
                                     apiVersion:
                                       description: API version of the referent
@@ -1378,7 +1377,7 @@ spec:
                             should be set at once).
                           properties:
                             containerResource:
-                              description: container resource refers to a resource
+                              description: containerResource refers to a resource
                                 metric (such as those specified in requests and limits)
                                 known to Kubernetes describing a single container
                                 in each pod of the current scale target (e.g. CPU
@@ -1560,9 +1559,8 @@ spec:
                                 on an Ingress object).
                               properties:
                                 describedObject:
-                                  description: CrossVersionObjectReference contains
-                                    enough information to let you identify the referred
-                                    resource.
+                                  description: describedObject specifies the descriptions
+                                    of a object,such as kind,name apiVersion
                                   properties:
                                     apiVersion:
                                       description: API version of the referent

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -28,3 +28,10 @@ spec:
           - containerPort: 8443
             protocol: TCP
             name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi

--- a/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
@@ -1,4 +1,4 @@
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: operators.coreos.com/v1
 kind: ClusterServiceVersion
 metadata:
   annotations:
@@ -66,6 +66,7 @@ spec:
   - email: ocazade@redhat.com
     name: Olivier Cazade
   maturity: alpha
+  minKubeVersion: 1.23.0
   provider:
     name: Red Hat
     url: https://www.redhat.com

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -9,7 +9,7 @@ import (
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
-	ascv2 "k8s.io/api/autoscaling/v2beta2"
+	ascv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/controllers/consoleplugin/consoleplugin_reconciler.go
+++ b/controllers/consoleplugin/consoleplugin_reconciler.go
@@ -7,7 +7,7 @@ import (
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	operatorsv1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	ascv2 "k8s.io/api/autoscaling/v2beta2"
+	ascv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/controllers/consoleplugin/consoleplugin_test.go
+++ b/controllers/consoleplugin/consoleplugin_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	ascv2 "k8s.io/api/autoscaling/v2beta2"
+	ascv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -9,7 +9,7 @@ import (
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	securityv1 "github.com/openshift/api/security/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	ascv2 "k8s.io/api/autoscaling/v2beta2"
+	ascv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/controllers/flowcollector_controller_console_test.go
+++ b/controllers/flowcollector_controller_console_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	operatorsv1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	ascv2 "k8s.io/api/autoscaling/v2beta2"
+	ascv2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	ascv2 "k8s.io/api/autoscaling/v2beta2"
+	ascv2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/stretchr/testify/assert"
-	ascv2 "k8s.io/api/autoscaling/v2beta2"
+	ascv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/flowlogspipeline/flp_transfo_objects.go
+++ b/controllers/flowlogspipeline/flp_transfo_objects.go
@@ -2,7 +2,7 @@ package flowlogspipeline
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	ascv2 "k8s.io/api/autoscaling/v2beta2"
+	ascv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/flowlogspipeline/flp_transfo_reconciler.go
+++ b/controllers/flowlogspipeline/flp_transfo_reconciler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	appsv1 "k8s.io/api/apps/v1"
-	ascv2 "k8s.io/api/autoscaling/v2beta2"
+	ascv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -28,7 +28,7 @@ import (
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	operatorsv1 "github.com/openshift/api/operator/v1"
 	"github.com/stretchr/testify/mock"
-	ascv2 "k8s.io/api/autoscaling/v2beta2"
+	ascv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -711,7 +711,7 @@ MetricSpec specifies how to scale based on a single metric (only `type` and one 
         <td><b><a href="#flowcollectorspecconsolepluginautoscalermetricsindexcontainerresource">containerResource</a></b></td>
         <td>object</td>
         <td>
-          container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.<br/>
+          containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -751,7 +751,7 @@ MetricSpec specifies how to scale based on a single metric (only `type` and one 
 
 
 
-container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
+containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
 
 <table>
     <thead>
@@ -1050,7 +1050,7 @@ object refers to a metric describing a single kubernetes object (for example, hi
         <td><b><a href="#flowcollectorspecconsolepluginautoscalermetricsindexobjectdescribedobject">describedObject</a></b></td>
         <td>object</td>
         <td>
-          CrossVersionObjectReference contains enough information to let you identify the referred resource.<br/>
+          describedObject specifies the descriptions of a object,such as kind,name apiVersion<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -1076,7 +1076,7 @@ object refers to a metric describing a single kubernetes object (for example, hi
 
 
 
-CrossVersionObjectReference contains enough information to let you identify the referred resource.
+describedObject specifies the descriptions of a object,such as kind,name apiVersion
 
 <table>
     <thead>
@@ -2639,7 +2639,7 @@ MetricSpec specifies how to scale based on a single metric (only `type` and one 
         <td><b><a href="#flowcollectorspecprocessorkafkaconsumerautoscalermetricsindexcontainerresource">containerResource</a></b></td>
         <td>object</td>
         <td>
-          container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.<br/>
+          containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2679,7 +2679,7 @@ MetricSpec specifies how to scale based on a single metric (only `type` and one 
 
 
 
-container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
+containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
 
 <table>
     <thead>
@@ -2978,7 +2978,7 @@ object refers to a metric describing a single kubernetes object (for example, hi
         <td><b><a href="#flowcollectorspecprocessorkafkaconsumerautoscalermetricsindexobjectdescribedobject">describedObject</a></b></td>
         <td>object</td>
         <td>
-          CrossVersionObjectReference contains enough information to let you identify the referred resource.<br/>
+          describedObject specifies the descriptions of a object,such as kind,name apiVersion<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -3004,7 +3004,7 @@ object refers to a metric describing a single kubernetes object (for example, hi
 
 
 
-CrossVersionObjectReference contains enough information to let you identify the referred resource.
+describedObject specifies the descriptions of a object,such as kind,name apiVersion
 
 <table>
     <thead>

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	operatorsv1 "github.com/openshift/api/operator/v1"
 	securityv1 "github.com/openshift/api/security/v1"
-	ascv2 "k8s.io/api/autoscaling/v2beta2"
+	ascv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"


### PR DESCRIPTION
Backport of https://github.com/netobserv/network-observability-operator/pull/226