### PR TITLE
NETOBSERV-772 check volume change in reconcile loop

### DIFF
--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -30,10 +30,6 @@ const configPath = "/opt/app-root/"
 const lokiCerts = "loki-certs"
 const tokensPath = "/var/run/secrets/tokens/"
 
-// PodConfigurationDigest is an annotation name to facilitate pod restart after
-// any external configuration change
-const PodConfigurationDigest = "flows.netobserv.io/" + configMapName
-
 type builder struct {
 	namespace   string
 	labels      map[string]string
@@ -230,7 +226,7 @@ func (b *builder) podTemplate(cmDigest string) *corev1.PodTemplateSpec {
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: b.labels,
 			Annotations: map[string]string{
-				PodConfigurationDigest: cmDigest,
+				constants.PodConfigurationDigest: cmDigest,
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -15,6 +15,10 @@ const (
 	EBPFSecurityContext    = EBPFAgentName
 
 	OpenShiftCertificateAnnotation = "service.beta.openshift.io/serving-cert-secret-name"
+
+	// PodConfigurationDigest is an annotation name to facilitate pod restart after
+	// any external configuration change
+	PodConfigurationDigest = "flows.netobserv.io/config-digest"
 )
 
 var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "DstK8S_Namespace", "DstK8S_OwnerName", "FlowDirection"}

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -123,9 +123,9 @@ func flowCollectorControllerSpecs() {
 				if err := k8sClient.Get(ctx, flpKey1, &ds); err != nil {
 					return err
 				}
-				digest = ds.Spec.Template.Annotations[flowlogspipeline.PodConfigurationDigest]
+				digest = ds.Spec.Template.Annotations[constants.PodConfigurationDigest]
 				if digest == "" {
-					return fmt.Errorf("%q annotation can't be empty", flowlogspipeline.PodConfigurationDigest)
+					return fmt.Errorf("%q annotation can't be empty", constants.PodConfigurationDigest)
 				}
 				return nil
 			}, timeout, interval).Should(Succeed())
@@ -646,9 +646,9 @@ func UpdateCR(key types.NamespacedName, updater func(*flowsv1alpha1.FlowCollecto
 }
 
 func checkDigestUpdate(oldDigest *string, annots map[string]string) error {
-	newDigest := annots[flowlogspipeline.PodConfigurationDigest]
+	newDigest := annots[constants.PodConfigurationDigest]
 	if newDigest == "" {
-		return fmt.Errorf("%q annotation can't be empty", flowlogspipeline.PodConfigurationDigest)
+		return fmt.Errorf("%q annotation can't be empty", constants.PodConfigurationDigest)
 	} else if newDigest == *oldDigest {
 		return fmt.Errorf("expect digest to change, but is still %s", *oldDigest)
 	}

--- a/controllers/flowlogspipeline/flp_common_objects.go
+++ b/controllers/flowlogspipeline/flp_common_objects.go
@@ -57,10 +57,6 @@ var FlpConfSuffix = map[ConfKind]string{
 	ConfKafkaTransformer: "-transformer",
 }
 
-// PodConfigurationDigest is an annotation name to facilitate pod restart after
-// any external configuration change
-const PodConfigurationDigest = "flows.netobserv.io/configDigest"
-
 type builder struct {
 	namespace       string
 	labels          map[string]string
@@ -236,9 +232,9 @@ func (b *builder) podTemplate(hasHostPort, hasLokiInterface, hostNetwork bool, c
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: b.labels,
 			Annotations: map[string]string{
-				PodConfigurationDigest:      configDigest,
-				"prometheus.io/scrape":      "true",
-				"prometheus.io/scrape_port": fmt.Sprint(b.desired.Processor.Metrics.Server.Port),
+				constants.PodConfigurationDigest: configDigest,
+				"prometheus.io/scrape":           "true",
+				"prometheus.io/scrape_port":      fmt.Sprint(b.desired.Processor.Metrics.Server.Port),
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/controllers/flowlogspipeline/flp_ingest_reconciler.go
+++ b/controllers/flowlogspipeline/flp_ingest_reconciler.go
@@ -11,6 +11,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	flowsv1alpha1 "github.com/netobserv/network-observability-operator/api/v1alpha1"
+	"github.com/netobserv/network-observability-operator/controllers/constants"
+	"github.com/netobserv/network-observability-operator/pkg/helper"
 )
 
 // flpIngesterReconciler reconciles the current flowlogs-pipeline-ingester state with the desired configuration
@@ -110,7 +112,7 @@ func (r *flpIngesterReconciler) reconcile(ctx context.Context, desired *flowsv1a
 		return err
 	}
 
-	return r.reconcileDaemonSet(ctx, &desired.Spec.Processor, &builder, configDigest)
+	return r.reconcileDaemonSet(ctx, builder.daemonSet(configDigest))
 }
 
 func (r *flpIngesterReconciler) reconcilePrometheusService(ctx context.Context, builder *ingestBuilder) error {
@@ -126,7 +128,7 @@ func (r *flpIngesterReconciler) reconcilePrometheusService(ctx context.Context, 
 		return nil
 	}
 	newSVC := builder.fromPromService(r.owned.promService)
-	if serviceNeedsUpdate(r.owned.promService, newSVC) {
+	if helper.ServiceChanged(r.owned.promService, newSVC) {
 		if err := r.UpdateOwned(ctx, r.owned.promService, newSVC); err != nil {
 			return err
 		}
@@ -134,11 +136,11 @@ func (r *flpIngesterReconciler) reconcilePrometheusService(ctx context.Context, 
 	return nil
 }
 
-func (r *flpIngesterReconciler) reconcileDaemonSet(ctx context.Context, desiredFLP *flpSpec, builder *ingestBuilder, configDigest string) error {
+func (r *flpIngesterReconciler) reconcileDaemonSet(ctx context.Context, desiredDS *appsv1.DaemonSet) error {
 	if !r.nobjMngr.Exists(r.owned.daemonSet) {
-		return r.CreateOwned(ctx, builder.daemonSet(configDigest))
-	} else if daemonSetNeedsUpdate(r.owned.daemonSet, desiredFLP, r.image, configDigest) {
-		return r.UpdateOwned(ctx, r.owned.daemonSet, builder.daemonSet(configDigest))
+		return r.CreateOwned(ctx, desiredDS)
+	} else if helper.PodChanged(&r.owned.daemonSet.Spec.Template, &desiredDS.Spec.Template, constants.FLPName) {
+		return r.UpdateOwned(ctx, r.owned.daemonSet, desiredDS)
 	} else {
 		// DaemonSet up to date, check if it's ready
 		r.CheckDaemonSetInProgress(r.owned.daemonSet)

--- a/controllers/ovs/flowsconfig_ovnk_reconciler.go
+++ b/controllers/ovs/flowsconfig_ovnk_reconciler.go
@@ -15,6 +15,7 @@ import (
 
 	flowsv1alpha1 "github.com/netobserv/network-observability-operator/api/v1alpha1"
 	"github.com/netobserv/network-observability-operator/controllers/reconcilers"
+	"github.com/netobserv/network-observability-operator/pkg/helper"
 )
 
 type FlowsConfigOVNKController struct {
@@ -54,7 +55,7 @@ func (c *FlowsConfigOVNKController) updateEnv(ctx context.Context, target *flows
 		return err
 	}
 
-	ovnkubeNode := reconcilers.FindContainer(&ds.Spec.Template.Spec, target.Spec.Agent.IPFIX.OVNKubernetes.ContainerName)
+	ovnkubeNode := helper.FindContainer(&ds.Spec.Template.Spec, target.Spec.Agent.IPFIX.OVNKubernetes.ContainerName)
 	if ovnkubeNode == nil {
 		return errors.New("could not find container ovnkube-node")
 	}

--- a/controllers/reconcilers/client_helper.go
+++ b/controllers/reconcilers/client_helper.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/netobserv/network-observability-operator/pkg/helper"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -82,16 +81,6 @@ func (c *ClientHelper) CheckDaemonSetInProgress(ds *appsv1.DaemonSet) {
 	if ds.Status.NumberAvailable < ds.Status.DesiredNumberScheduled {
 		c.deplInProgress = true
 	}
-}
-
-// FindContainer searches in pod containers one that matches the provided name
-func FindContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {
-	for i := range podSpec.Containers {
-		if podSpec.Containers[i].Name == name {
-			return &podSpec.Containers[i]
-		}
-	}
-	return nil
 }
 
 func (c *ClientHelper) ReconcileClusterRoleBinding(ctx context.Context, desired *rbacv1.ClusterRoleBinding) error {

--- a/pkg/helper/comparators.go
+++ b/pkg/helper/comparators.go
@@ -1,8 +1,6 @@
 package helper
 
 import (
-	"reflect"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 
@@ -33,14 +31,14 @@ func configChanged(old, new *corev1.PodTemplateSpec) bool {
 }
 
 func volumesChanged(old, new *corev1.PodTemplateSpec) bool {
-	return !reflect.DeepEqual(old.Spec.Volumes, new.Spec.Volumes)
+	return !equality.Semantic.DeepDerivative(new.Spec.Volumes, old.Spec.Volumes)
 }
 
 func containerChanged(old, new *corev1.Container) bool {
 	return new.Image != old.Image ||
 		new.ImagePullPolicy != old.ImagePullPolicy ||
-		!equality.Semantic.DeepDerivative(old.Args, new.Args) ||
-		!equality.Semantic.DeepDerivative(old.Resources, new.Resources) ||
+		!equality.Semantic.DeepDerivative(new.Args, old.Args) ||
+		!equality.Semantic.DeepDerivative(new.Resources, old.Resources) ||
 		!equality.Semantic.DeepEqual(old.LivenessProbe, new.LivenessProbe) ||
 		!equality.Semantic.DeepEqual(old.StartupProbe, new.StartupProbe)
 }

--- a/pkg/helper/comparators.go
+++ b/pkg/helper/comparators.go
@@ -1,0 +1,61 @@
+package helper
+
+import (
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+
+	"github.com/netobserv/network-observability-operator/controllers/constants"
+)
+
+func PodChanged(old, new *corev1.PodTemplateSpec, containerName string) bool {
+	if configChanged(old, new) || volumesChanged(old, new) {
+		return true
+	}
+	// Find containers
+	oldContainer := FindContainer(&old.Spec, containerName)
+	if oldContainer == nil {
+		return true
+	}
+	newContainer := FindContainer(&new.Spec, containerName)
+	if newContainer == nil {
+		return true
+	}
+	return containerChanged(oldContainer, newContainer)
+}
+
+func configChanged(old, new *corev1.PodTemplateSpec) bool {
+	if old.Annotations == nil && new.Annotations == nil {
+		return false
+	}
+	return old.Annotations[constants.PodConfigurationDigest] != new.Annotations[constants.PodConfigurationDigest]
+}
+
+func volumesChanged(old, new *corev1.PodTemplateSpec) bool {
+	return !reflect.DeepEqual(old.Spec.Volumes, new.Spec.Volumes)
+}
+
+func containerChanged(old, new *corev1.Container) bool {
+	return new.Image != old.Image ||
+		new.ImagePullPolicy != old.ImagePullPolicy ||
+		!equality.Semantic.DeepDerivative(old.Args, new.Args) ||
+		!equality.Semantic.DeepDerivative(old.Resources, new.Resources) ||
+		!equality.Semantic.DeepEqual(old.LivenessProbe, new.LivenessProbe) ||
+		!equality.Semantic.DeepEqual(old.StartupProbe, new.StartupProbe)
+}
+
+func ServiceChanged(old, new *corev1.Service) bool {
+	return !equality.Semantic.DeepDerivative(new.ObjectMeta, old.ObjectMeta) ||
+		!equality.Semantic.DeepDerivative(new.Spec, old.Spec)
+}
+
+// FindContainer searches in pod containers one that matches the provided name
+func FindContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == name {
+			return &podSpec.Containers[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
- Both for console plugin and FLP, need to check whether volumes changes in reconcile loop
- Some refactoring to share common comparison functions
- Remove namespace comparisons in several places because they are handled differently (namespace changes doesn't trigger the usual workload updates, it deletes all / recreate all)
- Add some tests