### PR TITLE
[4.12] [doc] Fix typos in CSV desc (#244)

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -213,7 +213,7 @@ spec:
 
     ### Kafka
 
-    [Apache Kafka](https://kafka.apache.org/) can optionnaly be used for a more resilient and scalable architecture. You can use for instance [Strimzi](https://strimzi.io/), an operator-based distribution of Kafka for Kubernetes and OpenShift.
+    [Apache Kafka](https://kafka.apache.org/) can optionally be used for a more resilient and scalable architecture. You can use for instance [Strimzi](https://strimzi.io/), an operator-based distribution of Kafka for Kubernetes and OpenShift.
 
     ### Grafana
 
@@ -247,7 +247,7 @@ spec:
 
     ## Further reading
 
-    Please refer to the documentation on GitHub more more information.
+    Please refer to the documentation on GitHub for more information.
 
     This documentation includes:
 

--- a/config/manifests/bases/description-ocp.md
+++ b/config/manifests/bases/description-ocp.md
@@ -24,7 +24,7 @@ kubectl apply -f <(curl -L https://raw.githubusercontent.com/netobserv/documents
 
 ### Kafka
 
-[Apache Kafka](https://kafka.apache.org/) can optionnaly be used for a more resilient and scalable architecture. You can use for instance [Strimzi](https://strimzi.io/), an operator-based distribution of Kafka for Kubernetes and OpenShift.
+[Apache Kafka](https://kafka.apache.org/) can optionally be used for a more resilient and scalable architecture. You can use for instance [Strimzi](https://strimzi.io/), an operator-based distribution of Kafka for Kubernetes and OpenShift.
 
 ### Grafana
 
@@ -56,7 +56,7 @@ A couple of settings deserve special attention:
 
 ## Further reading
 
-Please refer to the documentation on GitHub more more information.
+Please refer to the documentation on GitHub for more information.
 
 This documentation includes:
 

--- a/config/manifests/bases/description-upstream.md
+++ b/config/manifests/bases/description-upstream.md
@@ -24,7 +24,7 @@ kubectl apply -f <(curl -L https://raw.githubusercontent.com/netobserv/documents
 
 ### Kafka
 
-[Apache Kafka](https://kafka.apache.org/) can optionnaly be used for a more resilient and scalable architecture. You can use for instance [Strimzi](https://strimzi.io/), an operator-based distribution of Kafka for Kubernetes and OpenShift.
+[Apache Kafka](https://kafka.apache.org/) can optionally be used for a more resilient and scalable architecture. You can use for instance [Strimzi](https://strimzi.io/), an operator-based distribution of Kafka for Kubernetes and OpenShift.
 
 ### Grafana
 
@@ -58,7 +58,7 @@ A couple of settings deserve special attention:
 
 ## Further reading
 
-Please refer to the documentation on GitHub more more information.
+Please refer to the documentation on GitHub for more information.
 
 This documentation includes:
 


### PR DESCRIPTION
Suggesting to backport this fix, as the typos show up in the Operator description in operatorhub