### PR TITLE
NETOBSERV-793 Change default loki CA configmap name

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -124,7 +124,7 @@ metadata:
               "tls": {
                 "caCert": {
                   "certFile": "service-ca.crt",
-                  "name": "loki-ca-bundle",
+                  "name": "loki-gateway-ca-bundle",
                   "type": "configmap"
                 },
                 "enable": false,
@@ -169,7 +169,7 @@ metadata:
     categories: Monitoring
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: quay.io/netobserv/network-observability-operator:1.0.1
-    createdAt: "2023-01-25T18:13:58Z"
+    createdAt: "2023-01-27T09:18:44Z"
     description: Network flows collector and monitoring solution
     operators.operatorframework.io/builder: operator-sdk-v1.25.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -68,7 +68,7 @@ spec:
       enable: false
       caCert:
         type: configmap
-        name: loki-ca-bundle
+        name: loki-gateway-ca-bundle
         certFile: service-ca.crt
       insecureSkipVerify: false
     batchWait: 1s

--- a/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
@@ -68,7 +68,7 @@ spec:
       enable: false
       caCert:
         type: configmap
-        name: loki-ca-bundle
+        name: loki-gateway-ca-bundle
         certFile: service-ca.crt
       insecureSkipVerify: false
     batchWait: 1s


### PR DESCRIPTION
Changing to "loki-gateway-ca-bundle" so that it matches loki operator 5.6 name

JIRA: https://issues.redhat.com/browse/NETOBSERV-793