### PR TITLE
[1.1 backport] NETOBSERV-691 better document cacheMaxFlows/Timeout (in CRD) (#255)

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -167,12 +167,16 @@ type FlowCollectorEBPF struct {
 	//+optional
 	Sampling *int32 `json:"sampling,omitempty"`
 
-	// cacheActiveTimeout is the max period during which the reporter will aggregate flows before sending
+	// cacheActiveTimeout is the max period during which the reporter will aggregate flows before sending.
+	// Increasing `cacheMaxFlows` and `cacheActiveTimeout` can decrease the network traffic overhead and the CPU load,
+	// however you can expect higher memory consumption and an increased latency in the flow collection.
 	//+kubebuilder:validation:Pattern:=^\d+(ns|ms|s|m)?$
 	//+kubebuilder:default:="5s"
 	CacheActiveTimeout string `json:"cacheActiveTimeout,omitempty"`
 
-	// cacheMaxFlows is the max number of flows in an aggregate; when reached, the reporter sends the flows
+	// cacheMaxFlows is the max number of flows in an aggregate; when reached, the reporter sends the flows.
+	// Increasing `cacheMaxFlows` and `cacheActiveTimeout` can decrease the network traffic overhead and the CPU load,
+	// however you can expect higher memory consumption and an increased latency in the flow collection.
 	//+kubebuilder:validation:Minimum=1
 	//+kubebuilder:default:=100000
 	CacheMaxFlows int32 `json:"cacheMaxFlows,omitempty"`

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -64,13 +64,21 @@ spec:
                       cacheActiveTimeout:
                         default: 5s
                         description: cacheActiveTimeout is the max period during which
-                          the reporter will aggregate flows before sending
+                          the reporter will aggregate flows before sending. Increasing
+                          `cacheMaxFlows` and `cacheActiveTimeout` can decrease the
+                          network traffic overhead and the CPU load, however you can
+                          expect higher memory consumption and an increased latency
+                          in the flow collection.
                         pattern: ^\d+(ns|ms|s|m)?$
                         type: string
                       cacheMaxFlows:
                         default: 100000
                         description: cacheMaxFlows is the max number of flows in an
-                          aggregate; when reached, the reporter sends the flows
+                          aggregate; when reached, the reporter sends the flows. Increasing
+                          `cacheMaxFlows` and `cacheActiveTimeout` can decrease the
+                          network traffic overhead and the CPU load, however you can
+                          expect higher memory consumption and an increased latency
+                          in the flow collection.
                         format: int32
                         minimum: 1
                         type: integer

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -169,7 +169,7 @@ metadata:
     categories: Monitoring
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: quay.io/netobserv/network-observability-operator:1.0.1
-    createdAt: "2023-01-25T18:13:58Z"
+    createdAt: "2023-01-30T08:10:44Z"
     description: Network flows collector and monitoring solution
     operators.operatorframework.io/builder: operator-sdk-v1.25.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -62,13 +62,21 @@ spec:
                       cacheActiveTimeout:
                         default: 5s
                         description: cacheActiveTimeout is the max period during which
-                          the reporter will aggregate flows before sending
+                          the reporter will aggregate flows before sending. Increasing
+                          `cacheMaxFlows` and `cacheActiveTimeout` can decrease the
+                          network traffic overhead and the CPU load, however you can
+                          expect higher memory consumption and an increased latency
+                          in the flow collection.
                         pattern: ^\d+(ns|ms|s|m)?$
                         type: string
                       cacheMaxFlows:
                         default: 100000
                         description: cacheMaxFlows is the max number of flows in an
-                          aggregate; when reached, the reporter sends the flows
+                          aggregate; when reached, the reporter sends the flows. Increasing
+                          `cacheMaxFlows` and `cacheActiveTimeout` can decrease the
+                          network traffic overhead and the CPU load, however you can
+                          expect higher memory consumption and an increased latency
+                          in the flow collection.
                         format: int32
                         minimum: 1
                         type: integer

--- a/controllers/flowcollector_controller_ebpf_test.go
+++ b/controllers/flowcollector_controller_ebpf_test.go
@@ -80,7 +80,9 @@ func flowCollectorEBPFSpecs() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, desired)).Should(Succeed())
+			Eventually(func() interface{} {
+				return k8sClient.Create(ctx, desired)
+			}).WithTimeout(timeout).WithPolling(interval).Should(Succeed())
 
 			ds := appsv1.DaemonSet{}
 			By("Expecting to create the netobserv-ebpf-agent DaemonSet")

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -212,7 +212,7 @@ ebpf describes the settings related to the eBPF-based flow reporter when the "ag
         <td><b>cacheActiveTimeout</b></td>
         <td>string</td>
         <td>
-          cacheActiveTimeout is the max period during which the reporter will aggregate flows before sending<br/>
+          cacheActiveTimeout is the max period during which the reporter will aggregate flows before sending. Increasing `cacheMaxFlows` and `cacheActiveTimeout` can decrease the network traffic overhead and the CPU load, however you can expect higher memory consumption and an increased latency in the flow collection.<br/>
           <br/>
             <i>Default</i>: 5s<br/>
         </td>
@@ -221,7 +221,7 @@ ebpf describes the settings related to the eBPF-based flow reporter when the "ag
         <td><b>cacheMaxFlows</b></td>
         <td>integer</td>
         <td>
-          cacheMaxFlows is the max number of flows in an aggregate; when reached, the reporter sends the flows<br/>
+          cacheMaxFlows is the max number of flows in an aggregate; when reached, the reporter sends the flows. Increasing `cacheMaxFlows` and `cacheActiveTimeout` can decrease the network traffic overhead and the CPU load, however you can expect higher memory consumption and an increased latency in the flow collection.<br/>
           <br/>
             <i>Format</i>: int32<br/>
             <i>Default</i>: 100000<br/>

--- a/docs/flowcollector-flows-netobserv-io-v1alpha1.adoc
+++ b/docs/flowcollector-flows-netobserv-io-v1alpha1.adoc
@@ -159,11 +159,11 @@ Type::
 
 | `cacheActiveTimeout`
 | `string`
-| cacheActiveTimeout is the max period during which the reporter will aggregate flows before sending
+| cacheActiveTimeout is the max period during which the reporter will aggregate flows before sending. Increasing `cacheMaxFlows` and `cacheActiveTimeout` can decrease the network traffic overhead and the CPU load, however you can expect higher memory consumption and an increased latency in the flow collection.
 
 | `cacheMaxFlows`
 | `integer`
-| cacheMaxFlows is the max number of flows in an aggregate; when reached, the reporter sends the flows
+| cacheMaxFlows is the max number of flows in an aggregate; when reached, the reporter sends the flows. Increasing `cacheMaxFlows` and `cacheActiveTimeout` can decrease the network traffic overhead and the CPU load, however you can expect higher memory consumption and an increased latency in the flow collection.
 
 | `debug`
 | `object`


### PR DESCRIPTION
* NETOBSERV-691 better document cacheMaxFlows/Timeout (in CRD)

* Update asciidoc

* Fix missing period

* fix flaky test