### PR TITLE
Grafana dashboards

### DIFF
--- a/.mk/ocp.mk
+++ b/.mk/ocp.mk
@@ -45,7 +45,10 @@ undeploy-operator: ## stop the operator locally
 	kubectl delete servicemonitor flowlogs-pipeline-monitor || true
 	kubectl delete service netobserv-plugin || true
 	kubectl delete deployment netobserv-plugin || true
-	kubectl delete servicemonitor netobserv-console-plugin || true
+	kubectl delete servicemonitor netobserv-plugin || true
+	kubectl delete configmap -n openshift-config-managed flowlogs-pipeline-metrics-dashboard || true
+	kubectl delete configmap -n netobserv flowlogs-pipeline-config || true
+	kubectl delete configmap -n netobserv console-plugin-config || true
 
 .PHONY: ocp-refresh-ovs
 ocp-refresh-ovs:

--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -114,7 +114,7 @@ func (r *FlowCollectorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Create reconcilers
 	flpReconciler := flowlogspipeline.NewReconciler(ctx, clientHelper, ns, previousNamespace, r.config.FlowlogsPipelineImage, &r.permissions, r.availableAPIs)
 	var cpReconciler consoleplugin.CPReconciler
-	if r.availableAPIs.HasConsole() {
+	if r.availableAPIs.HasConsolePlugin() {
 		cpReconciler = consoleplugin.NewReconciler(clientHelper, ns, previousNamespace, r.config.ConsolePluginImage, r.availableAPIs)
 	}
 
@@ -157,7 +157,7 @@ func (r *FlowCollectorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Console plugin
-	if r.availableAPIs.HasConsole() {
+	if r.availableAPIs.HasConsolePlugin() {
 		err := cpReconciler.Reconcile(ctx, desired)
 		if err != nil {
 			return ctrl.Result{}, r.failure(ctx, conditions.ReconcileConsolePluginFailed(err), desired)
@@ -213,7 +213,7 @@ func (r *FlowCollectorReconciler) handleNamespaceChanged(
 		if err != nil {
 			return err
 		}
-		if r.availableAPIs.HasConsole() {
+		if r.availableAPIs.HasConsolePlugin() {
 			err := cpReconciler.InitStaticResources(ctx)
 			if err != nil {
 				return err
@@ -226,7 +226,7 @@ func (r *FlowCollectorReconciler) handleNamespaceChanged(
 		if err != nil {
 			return err
 		}
-		if r.availableAPIs.HasConsole() {
+		if r.availableAPIs.HasConsolePlugin() {
 			err := cpReconciler.PrepareNamespaceChange(ctx)
 			if err != nil {
 				return err
@@ -279,7 +279,7 @@ func (r *FlowCollectorReconciler) setupDiscovery(ctx context.Context, mgr ctrl.M
 		return fmt.Errorf("can't discover available APIs: %w", err)
 	}
 	r.availableAPIs = apis
-	if apis.HasConsole() {
+	if apis.HasConsolePlugin() {
 		builder.Owns(&osv1alpha1.ConsolePlugin{})
 	} else {
 		log.Info("Console not detected: the console plugin is not available")

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -157,14 +157,14 @@ func TestDaemonSetNoChange(t *testing.T) {
 	ns := "namespace"
 	cfg := getConfig()
 	b := newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err := b.configMap()
+	_, digest, _, err := b.configMap()
 	assert.NoError(err)
 	first := b.daemonSet(digest)
 
 	// Check no change
 	cfg = getConfig()
 	b = newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	second := b.daemonSet(digest)
 
@@ -180,14 +180,14 @@ func TestDaemonSetChanged(t *testing.T) {
 	ns := "namespace"
 	cfg := getConfig()
 	b := newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err := b.configMap()
+	_, digest, _, err := b.configMap()
 	assert.NoError(err)
 	first := b.daemonSet(digest)
 
 	// Check probes enabled change
 	cfg.Processor.EnableKubeProbes = true
 	b = newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	second := b.daemonSet(digest)
 
@@ -218,7 +218,7 @@ func TestDaemonSetChanged(t *testing.T) {
 	// Check log level change
 	cfg.Processor.LogLevel = "info"
 	b = newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	third := b.daemonSet(digest)
 
@@ -232,7 +232,7 @@ func TestDaemonSetChanged(t *testing.T) {
 		corev1.ResourceMemory: resource.MustParse("500Gi"),
 	}
 	b = newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	fourth := b.daemonSet(digest)
 
@@ -246,7 +246,7 @@ func TestDaemonSetChanged(t *testing.T) {
 		corev1.ResourceMemory: resource.MustParse("512Mi"),
 	}
 	b = newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	fifth := b.daemonSet(digest)
 
@@ -267,7 +267,7 @@ func TestDaemonSetChanged(t *testing.T) {
 		},
 	}
 	b = newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	sixth := b.daemonSet(digest)
 
@@ -285,7 +285,7 @@ func TestDaemonSetChanged(t *testing.T) {
 		},
 	}
 	b = newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	seventh := b.daemonSet(digest)
 
@@ -301,14 +301,14 @@ func TestDeploymentNoChange(t *testing.T) {
 	ns := "namespace"
 	cfg := getConfig()
 	b := newTransfoBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err := b.configMap()
+	_, digest, _, err := b.configMap()
 	assert.NoError(err)
 	first := b.deployment(digest)
 
 	// Check no change
 	cfg = getConfig()
 	b = newTransfoBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	second := b.deployment(digest)
 
@@ -324,14 +324,14 @@ func TestDeploymentChanged(t *testing.T) {
 	ns := "namespace"
 	cfg := getConfig()
 	b := newTransfoBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err := b.configMap()
+	_, digest, _, err := b.configMap()
 	assert.NoError(err)
 	first := b.deployment(digest)
 
 	// Check probes enabled change
 	cfg.Processor.EnableKubeProbes = true
 	b = newTransfoBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	second := b.deployment(digest)
 
@@ -346,7 +346,7 @@ func TestDeploymentChanged(t *testing.T) {
 	// Check log level change
 	cfg.Processor.LogLevel = "info"
 	b = newTransfoBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	third := b.deployment(digest)
 
@@ -360,7 +360,7 @@ func TestDeploymentChanged(t *testing.T) {
 		corev1.ResourceMemory: resource.MustParse("500Gi"),
 	}
 	b = newTransfoBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	fourth := b.deployment(digest)
 
@@ -374,7 +374,7 @@ func TestDeploymentChanged(t *testing.T) {
 		corev1.ResourceMemory: resource.MustParse("512Mi"),
 	}
 	b = newTransfoBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	fifth := b.deployment(digest)
 
@@ -389,7 +389,7 @@ func TestDeploymentChanged(t *testing.T) {
 	cfg2 := cfg
 	cfg2.Processor.KafkaConsumerReplicas = 5
 	b = newTransfoBuilder(ns, image, &cfg2, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	sixth := b.deployment(digest)
 
@@ -405,7 +405,7 @@ func TestDeploymentChangedReplicasNoHPA(t *testing.T) {
 	ns := "namespace"
 	cfg := getConfigNoHPA()
 	b := newTransfoBuilder(ns, image, &cfg, true, &certWatcher)
-	_, digest, err := b.configMap()
+	_, digest, _, err := b.configMap()
 	assert.NoError(err)
 	first := b.deployment(digest)
 
@@ -413,7 +413,7 @@ func TestDeploymentChangedReplicasNoHPA(t *testing.T) {
 	cfg2 := cfg
 	cfg2.Processor.KafkaConsumerReplicas = 5
 	b = newTransfoBuilder(ns, image, &cfg2, true, &certWatcher)
-	_, digest, err = b.configMap()
+	_, digest, _, err = b.configMap()
 	assert.NoError(err)
 	second := b.deployment(digest)
 
@@ -538,7 +538,7 @@ func TestConfigMapShouldDeserializeAsJSON(t *testing.T) {
 	cfg := getConfig()
 	loki := cfg.Loki
 	b := newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
-	cm, digest, err := b.configMap()
+	cm, digest, _, err := b.configMap()
 	assert.NoError(err)
 	assert.NotEmpty(t, digest)
 
@@ -677,7 +677,7 @@ func TestPipelineConfig(t *testing.T) {
 	cfg := getConfig()
 	cfg.Processor.LogLevel = "info"
 	b := newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
-	stages, parameters, err := b.buildPipelineConfig()
+	stages, parameters, _, err := b.buildPipelineConfig()
 	assert.NoError(err)
 	assert.True(validatePipelineConfig(stages, parameters))
 	jsonStages, _ := json.Marshal(stages)
@@ -694,7 +694,7 @@ func TestPipelineConfig(t *testing.T) {
 
 	// Kafka Transformer
 	bt := newTransfoBuilder(ns, image, &cfg, true, &certWatcher)
-	stages, parameters, err = bt.buildPipelineConfig()
+	stages, parameters, _, err = bt.buildPipelineConfig()
 	assert.NoError(err)
 	assert.True(validatePipelineConfig(stages, parameters))
 	jsonStages, _ = json.Marshal(stages)
@@ -710,7 +710,7 @@ func TestPipelineConfigDropUnused(t *testing.T) {
 	cfg.Processor.LogLevel = "info"
 	cfg.Processor.DropUnusedFields = true
 	b := newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
-	stages, parameters, err := b.buildPipelineConfig()
+	stages, parameters, _, err := b.buildPipelineConfig()
 	assert.NoError(err)
 	assert.True(validatePipelineConfig(stages, parameters))
 	jsonStages, _ := json.Marshal(stages)
@@ -728,7 +728,7 @@ func TestPipelineTraceStage(t *testing.T) {
 	cfg := getConfig()
 
 	b := newMonolithBuilder("namespace", image, &cfg, true, &certWatcher)
-	stages, parameters, err := b.buildPipelineConfig()
+	stages, parameters, _, err := b.buildPipelineConfig()
 	assert.NoError(err)
 	assert.True(validatePipelineConfig(stages, parameters))
 	jsonStages, _ := json.Marshal(stages)
@@ -741,7 +741,7 @@ func TestMergeMetricsConfigurationNoIgnore(t *testing.T) {
 	cfg := getConfig()
 
 	b := newMonolithBuilder("namespace", image, &cfg, true, &certWatcher)
-	stages, parameters, err := b.buildPipelineConfig()
+	stages, parameters, _, err := b.buildPipelineConfig()
 	assert.NoError(err)
 	assert.True(validatePipelineConfig(stages, parameters))
 	jsonStages, _ := json.Marshal(stages)
@@ -764,7 +764,7 @@ func TestMergeMetricsConfigurationWithIgnore(t *testing.T) {
 	cfg.Processor.Metrics.IgnoreTags = []string{"nodes"}
 
 	b := newMonolithBuilder("namespace", image, &cfg, true, &certWatcher)
-	stages, parameters, err := b.buildPipelineConfig()
+	stages, parameters, _, err := b.buildPipelineConfig()
 	assert.NoError(err)
 	assert.True(validatePipelineConfig(stages, parameters))
 	jsonStages, _ := json.Marshal(stages)
@@ -784,7 +784,7 @@ func TestPipelineWithExporter(t *testing.T) {
 	})
 
 	b := newMonolithBuilder("namespace", image, &cfg, true, &certWatcher)
-	stages, parameters, err := b.buildPipelineConfig()
+	stages, parameters, _, err := b.buildPipelineConfig()
 	assert.NoError(err)
 	assert.True(validatePipelineConfig(stages, parameters))
 	jsonStages, _ := json.Marshal(stages)

--- a/controllers/flowlogspipeline/flp_transfo_objects.go
+++ b/controllers/flowlogspipeline/flp_transfo_objects.go
@@ -43,15 +43,16 @@ func (b *transfoBuilder) deployment(configDigest string) *appsv1.Deployment {
 	}
 }
 
-func (b *transfoBuilder) configMap() (*corev1.ConfigMap, string, error) {
-	stages, params, err := b.buildPipelineConfig()
+func (b *transfoBuilder) configMap() (*corev1.ConfigMap, string, *corev1.ConfigMap, error) {
+	stages, params, dashboardConfigMap, err := b.buildPipelineConfig()
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
-	return b.generic.configMap(stages, params)
+	configMap, digest, err := b.generic.configMap(stages, params)
+	return configMap, digest, dashboardConfigMap, err
 }
 
-func (b *transfoBuilder) buildPipelineConfig() ([]config.Stage, []config.StageParam, error) {
+func (b *transfoBuilder) buildPipelineConfig() ([]config.Stage, []config.StageParam, *corev1.ConfigMap, error) {
 	// TODO in a later optimization patch: set ingester <-> transformer communication also via protobuf
 	// For now, we leave this communication via JSON and just setup protobuf ingestion when
 	// the transformer is communicating directly via eBPF agent
@@ -69,11 +70,11 @@ func (b *transfoBuilder) buildPipelineConfig() ([]config.Stage, []config.StagePa
 		PullMaxBytes:      b.generic.desired.Processor.KafkaConsumerBatchSize,
 	})
 
-	err := b.generic.addTransformStages(&pipeline)
+	dashboardConfigMap, err := b.generic.addTransformStages(&pipeline)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return pipeline.GetStages(), pipeline.GetStageParams(), nil
+	return pipeline.GetStages(), pipeline.GetStageParams(), dashboardConfigMap, nil
 }
 
 func (b *transfoBuilder) newPromService() *corev1.Service {

--- a/controllers/flowlogspipeline/flp_transfo_reconciler.go
+++ b/controllers/flowlogspipeline/flp_transfo_reconciler.go
@@ -96,7 +96,7 @@ func (r *flpTransformerReconciler) reconcile(ctx context.Context, desired *flows
 	}
 
 	builder := newTransfoBuilder(r.nobjMngr.Namespace, r.image, &desired.Spec, r.useOpenShiftSCC, r.CertWatcher)
-	newCM, configDigest, err := builder.configMap()
+	newCM, configDigest, dbConfigMap, err := builder.configMap()
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,11 @@ func (r *flpTransformerReconciler) reconcile(ctx context.Context, desired *flows
 			return err
 		}
 	}
-
+	if r.reconcilersCommonInfo.availableAPIs.HasConsoleConfig() {
+		if err := r.reconcileDashboardConfig(ctx, dbConfigMap); err != nil {
+			return err
+		}
+	}
 	if err := r.reconcilePermissions(ctx, &builder); err != nil {
 		return err
 	}

--- a/controllers/flowlogspipeline/metrics_definitions/namespace_flows_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/namespace_flows_total.yaml
@@ -17,3 +17,12 @@ encode:
         labels:
           - SrcK8S_Namespace
           - DstK8S_Namespace
+visualization:
+  type: grafana
+  grafana:
+    - expr: 'topk(5,rate(netobserv_namespace_flows_total[1m]))'
+      legendFormat: '{{pod}} : ({{SrcK8S_Namespace}}) -> ({{DstK8S_Namespace}})'
+      type: graphPanel
+      dashboard: netobserv
+      title:
+        Top 5 flows rates per minute per Namespace

--- a/controllers/flowlogspipeline/metrics_definitions/node_egress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/node_egress_bytes_total.yaml
@@ -22,3 +22,12 @@ encode:
         labels:
           - SrcK8S_HostName
           - DstK8S_HostName
+visualization:
+  type: grafana
+  grafana:
+    - expr: 'topk(5,rate(netobserv_node_egress_bytes_total[1m]))'
+      legendFormat: '{{pod}} : ({{SrcK8S_HostName}}) -> ({{DstK8S_HostName}})'
+      type: graphPanel
+      dashboard: netobserv
+      title:
+        Top 5 Flows rate egress per source and destination nodes

--- a/controllers/flowlogspipeline/metrics_definitions/node_ingress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/node_ingress_bytes_total.yaml
@@ -22,3 +22,12 @@ encode:
         labels:
           - SrcK8S_HostName
           - DstK8S_HostName
+visualization:
+  type: grafana
+  grafana:
+    - expr: 'topk(5,rate(netobserv_node_ingress_bytes_total[1m]))'
+      legendFormat: '{{pod}} : ({{SrcK8S_HostName}}) -> ({{DstK8S_HostName}})'
+      type: graphPanel
+      dashboard: netobserv
+      title:
+        Top 5 Ingress Bandwidth per source and destination nodes

--- a/controllers/flowlogspipeline/metrics_definitions/workload_egress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_egress_bytes_total.yaml
@@ -26,3 +26,12 @@ encode:
           - DstK8S_OwnerName
           - SrcK8S_OwnerType
           - DstK8S_OwnerType
+visualization:
+  type: grafana
+  grafana:
+    - expr: 'topk(5,rate(netobserv_workload_egress_bytes_total[1m]))'
+      legendFormat: '{{pod}} : ({{SrcK8S_Namespace}},{{SrcK8S_OwnerName}}) -> ({{DstK8S_Namespace}},{{DstK8S_OwnerName}})'
+      type: graphPanel
+      dashboard: netobserv
+      title:
+        Top 5 Egress Bandwidth per source and destination namespaces and owners

--- a/controllers/flowlogspipeline/metrics_definitions/workload_egress_packets_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_egress_packets_total.yaml
@@ -26,3 +26,12 @@ encode:
           - DstK8S_OwnerName
           - SrcK8S_OwnerType
           - DstK8S_OwnerType
+visualization:
+  type: grafana
+  grafana:
+    - expr: 'topk(5,netobserv_workload_egress_packets_total)'
+      legendFormat: '{{pod}} : (({{SrcK8S_Namespace}},{{SrcK8S_OwnerName}}) -> ({{DstK8S_Namespace}},{{DstK8S_OwnerName}})'
+      type: graphPanel
+      dashboard: netobserv
+      title:
+        Top 5 Egress packets per source and destination namespaces and owners

--- a/controllers/flowlogspipeline/metrics_definitions/workload_ingress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_ingress_bytes_total.yaml
@@ -26,3 +26,12 @@ encode:
           - DstK8S_OwnerName
           - SrcK8S_OwnerType
           - DstK8S_OwnerType
+visualization:
+  type: grafana
+  grafana:
+    - expr: 'topk(5,rate(netobserv_workload_ingress_bytes_total[1m]))'
+      legendFormat: '{{pod}} : ({{SrcK8S_Namespace}},{{SrcK8S_OwnerName}}) -> ({{DstK8S_Namespace}},{{DstK8S_OwnerName}})'
+      type: graphPanel
+      dashboard: netobserv
+      title:
+        Top 5 Ingress Bandwidth per source and destination namespaces and owners

--- a/controllers/flowlogspipeline/metrics_definitions/workload_ingress_packets_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_ingress_packets_total.yaml
@@ -26,3 +26,12 @@ encode:
           - DstK8S_OwnerName
           - SrcK8S_OwnerType
           - DstK8S_OwnerType
+visualization:
+  type: grafana
+  grafana:
+    - expr: 'topk(5,netobserv_workload_ingress_packets_total)'
+      legendFormat: '{{pod}} : ({{SrcK8S_Namespace}},{{SrcK8S_OwnerName}}) -> ({{DstK8S_Namespace}},{{DstK8S_OwnerName}})'
+      type: graphPanel
+      dashboard: netobserv
+      title:
+        Top 5 Ingress Packets Total per source and destination namespaces and owners

--- a/pkg/discover/apis.go
+++ b/pkg/discover/apis.go
@@ -3,6 +3,7 @@ package discover
 import (
 	"strings"
 
+	configv1 "github.com/openshift/api/config/v1"
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	monitoring "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
@@ -10,9 +11,10 @@ import (
 )
 
 var (
-	console    = "consoleplugins." + osv1alpha1.GroupName
-	cno        = "networks." + operatorv1.GroupName
-	svcMonitor = "servicemonitors." + monitoring.GroupName
+	consolePlugin = "consoleplugins." + osv1alpha1.GroupName
+	consoleConfig = "consoles." + configv1.GroupName
+	cno           = "networks." + operatorv1.GroupName
+	svcMonitor    = "servicemonitors." + monitoring.GroupName
 )
 
 // AvailableAPIs discovers the available APIs in the running cluster
@@ -22,9 +24,10 @@ type AvailableAPIs struct {
 
 func NewAvailableAPIs(client *discovery.DiscoveryClient) (*AvailableAPIs, error) {
 	apiMap := map[string]bool{
-		console:    false,
-		cno:        false,
-		svcMonitor: false,
+		consolePlugin: false,
+		consoleConfig: false,
+		cno:           false,
+		svcMonitor:    false,
 	}
 	_, resources, err := client.ServerGroupsAndResources()
 	if err != nil {
@@ -45,9 +48,14 @@ func NewAvailableAPIs(client *discovery.DiscoveryClient) (*AvailableAPIs, error)
 	return &AvailableAPIs{apisMap: apiMap}, nil
 }
 
-// HasConsole returns true if "consoleplugins.console.openshift.io" API was found
-func (c *AvailableAPIs) HasConsole() bool {
-	return c.apisMap[console]
+// HasConsolePlugin returns true if "consoleplugins.console.openshift.io" API was found
+func (c *AvailableAPIs) HasConsolePlugin() bool {
+	return c.apisMap[consolePlugin]
+}
+
+// HasConsoleConfig returns true if "consoles.config.openshift.io" API was found
+func (c *AvailableAPIs) HasConsoleConfig() bool {
+	return c.apisMap[consoleConfig]
 }
 
 // HasCNO returns true if "networks.operator.openshift.io" API was found


### PR DESCRIPTION
Take grafana dashboards created by flp confgenerator [https://github.com/netobserv/flowlogs-pipeline/pull/369] and insert them in the Openshift console.
It is required to first merge FLP PR369, then update go.mod, go mod vendor, etc, and then to merge this PR.