### PR TITLE
NETOBSERV-793 [1.2 backport] Change default loki CA configmap name (#254)

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -124,7 +124,7 @@ metadata:
               "tls": {
                 "caCert": {
                   "certFile": "service-ca.crt",
-                  "name": "loki-ca-bundle",
+                  "name": "loki-gateway-ca-bundle",
                   "type": "configmap"
                 },
                 "enable": false,

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -68,7 +68,7 @@ spec:
       enable: false
       caCert:
         type: configmap
-        name: loki-ca-bundle
+        name: loki-gateway-ca-bundle
         certFile: service-ca.crt
       insecureSkipVerify: false
     batchWait: 1s

--- a/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector_versioned.yaml
@@ -68,7 +68,7 @@ spec:
       enable: false
       caCert:
         type: configmap
-        name: loki-ca-bundle
+        name: loki-gateway-ca-bundle
         certFile: service-ca.crt
       insecureSkipVerify: false
     batchWait: 1s


### PR DESCRIPTION
Changing to "loki-gateway-ca-bundle" so that it matches loki operator 5.6 name

Backport of https://github.com/netobserv/network-observability-operator/pull/254