### PR TITLE
NETOBSERV-856 Fix infinite reconcile & add more debugging utility

### DIFF
--- a/controllers/flowlogspipeline/flp_ingest_reconciler.go
+++ b/controllers/flowlogspipeline/flp_ingest_reconciler.go
@@ -119,6 +119,9 @@ func (r *flpIngesterReconciler) reconcile(ctx context.Context, desired *flowslat
 }
 
 func (r *flpIngesterReconciler) reconcilePrometheusService(ctx context.Context, builder *ingestBuilder) error {
+	report := helper.NewChangeReport("FLP prometheus service")
+	defer report.LogIfNeeded(ctx)
+
 	if !r.nobjMngr.Exists(r.owned.promService) {
 		if err := r.CreateOwned(ctx, builder.newPromService()); err != nil {
 			return err
@@ -134,7 +137,7 @@ func (r *flpIngesterReconciler) reconcilePrometheusService(ctx context.Context, 
 		return nil
 	}
 	newSVC := builder.fromPromService(r.owned.promService)
-	if helper.ServiceChanged(r.owned.promService, newSVC) {
+	if helper.ServiceChanged(r.owned.promService, newSVC, &report) {
 		if err := r.UpdateOwned(ctx, r.owned.promService, newSVC); err != nil {
 			return err
 		}
@@ -157,13 +160,16 @@ func (r *flpIngesterReconciler) reconcilePrometheusService(ctx context.Context, 
 }
 
 func (r *flpIngesterReconciler) reconcileDaemonSet(ctx context.Context, desiredDS *appsv1.DaemonSet) error {
+	report := helper.NewChangeReport("FLP DaemonSet")
+	defer report.LogIfNeeded(ctx)
+
 	// Annotate pod with certificate reference so that it is reloaded if modified
 	if err := r.CertWatcher.AnnotatePod(ctx, r.Client, &desiredDS.Spec.Template, lokiCerts, kafkaCerts); err != nil {
 		return err
 	}
 	if !r.nobjMngr.Exists(r.owned.daemonSet) {
 		return r.CreateOwned(ctx, desiredDS)
-	} else if helper.PodChanged(&r.owned.daemonSet.Spec.Template, &desiredDS.Spec.Template, constants.FLPName) {
+	} else if helper.PodChanged(&r.owned.daemonSet.Spec.Template, &desiredDS.Spec.Template, constants.FLPName, &report) {
 		return r.UpdateOwned(ctx, r.owned.daemonSet, desiredDS)
 	} else {
 		// DaemonSet up to date, check if it's ready

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	ascv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -158,7 +159,9 @@ func TestDaemonSetNoChange(t *testing.T) {
 	assert.NoError(err)
 	second := b.daemonSet(digest)
 
-	assert.False(helper.PodChanged(&first.Spec.Template, &second.Spec.Template, constants.FLPName))
+	report := helper.NewChangeReport("")
+	assert.False(helper.PodChanged(&first.Spec.Template, &second.Spec.Template, constants.FLPName, &report))
+	assert.Contains(report.String(), "no change")
 }
 
 func TestDaemonSetChanged(t *testing.T) {
@@ -179,7 +182,9 @@ func TestDaemonSetChanged(t *testing.T) {
 	assert.NoError(err)
 	second := b.daemonSet(digest)
 
-	assert.True(helper.PodChanged(&first.Spec.Template, &second.Spec.Template, constants.FLPName))
+	report := helper.NewChangeReport("")
+	assert.True(helper.PodChanged(&first.Spec.Template, &second.Spec.Template, constants.FLPName, &report))
+	assert.Contains(report.String(), "probe changed")
 
 	// Check log level change
 	cfg.Processor.LogLevel = "info"
@@ -188,7 +193,9 @@ func TestDaemonSetChanged(t *testing.T) {
 	assert.NoError(err)
 	third := b.daemonSet(digest)
 
-	assert.True(helper.PodChanged(&second.Spec.Template, &third.Spec.Template, constants.FLPName))
+	report = helper.NewChangeReport("")
+	assert.True(helper.PodChanged(&second.Spec.Template, &third.Spec.Template, constants.FLPName, &report))
+	assert.Contains(report.String(), "config-digest")
 
 	// Check resource change
 	cfg.Processor.Resources.Limits = map[corev1.ResourceName]resource.Quantity{
@@ -200,7 +207,9 @@ func TestDaemonSetChanged(t *testing.T) {
 	assert.NoError(err)
 	fourth := b.daemonSet(digest)
 
-	assert.True(helper.PodChanged(&third.Spec.Template, &fourth.Spec.Template, constants.FLPName))
+	report = helper.NewChangeReport("")
+	assert.True(helper.PodChanged(&third.Spec.Template, &fourth.Spec.Template, constants.FLPName, &report))
+	assert.Contains(report.String(), "req/limit changed")
 
 	// Check reverting limits
 	cfg.Processor.Resources.Limits = map[corev1.ResourceName]resource.Quantity{
@@ -212,8 +221,12 @@ func TestDaemonSetChanged(t *testing.T) {
 	assert.NoError(err)
 	fifth := b.daemonSet(digest)
 
-	assert.True(helper.PodChanged(&fourth.Spec.Template, &fifth.Spec.Template, constants.FLPName))
-	assert.False(helper.PodChanged(&third.Spec.Template, &fifth.Spec.Template, constants.FLPName))
+	report = helper.NewChangeReport("")
+	assert.True(helper.PodChanged(&fourth.Spec.Template, &fifth.Spec.Template, constants.FLPName, &report))
+	assert.Contains(report.String(), "req/limit changed")
+	report = helper.NewChangeReport("")
+	assert.False(helper.PodChanged(&third.Spec.Template, &fifth.Spec.Template, constants.FLPName, &report))
+	assert.Contains(report.String(), "no change")
 
 	// Check Loki config change
 	cfg.Loki.TLS = flowslatest.ClientTLS{
@@ -229,7 +242,9 @@ func TestDaemonSetChanged(t *testing.T) {
 	assert.NoError(err)
 	sixth := b.daemonSet(digest)
 
-	assert.True(helper.PodChanged(&fifth.Spec.Template, &sixth.Spec.Template, constants.FLPName))
+	report = helper.NewChangeReport("")
+	assert.True(helper.PodChanged(&fifth.Spec.Template, &sixth.Spec.Template, constants.FLPName, &report))
+	assert.Contains(report.String(), "config-digest")
 
 	// Check volumes change
 	cfg.Loki.TLS = flowslatest.ClientTLS{
@@ -245,7 +260,9 @@ func TestDaemonSetChanged(t *testing.T) {
 	assert.NoError(err)
 	seventh := b.daemonSet(digest)
 
-	assert.True(helper.PodChanged(&sixth.Spec.Template, &seventh.Spec.Template, constants.FLPName))
+	report = helper.NewChangeReport("")
+	assert.True(helper.PodChanged(&sixth.Spec.Template, &seventh.Spec.Template, constants.FLPName, &report))
+	assert.Contains(report.String(), "Volumes changed")
 }
 
 func TestDeploymentNoChange(t *testing.T) {
@@ -266,8 +283,9 @@ func TestDeploymentNoChange(t *testing.T) {
 	assert.NoError(err)
 	second := b.deployment(digest)
 
-	ftr := flpTransformerReconciler{reconcilersCommonInfo: reconcilersCommonInfo{image: image}}
-	assert.False(ftr.deploymentNeedsUpdate(first, second, &cfg.Processor))
+	report := helper.NewChangeReport("")
+	assert.False(helper.DeploymentChanged(first, second, constants.FLPName, cfg.Processor.KafkaConsumerAutoscaler.Disabled(), cfg.Processor.KafkaConsumerReplicas, &report))
+	assert.Contains(report.String(), "no change")
 }
 
 func TestDeploymentChanged(t *testing.T) {
@@ -288,8 +306,13 @@ func TestDeploymentChanged(t *testing.T) {
 	assert.NoError(err)
 	second := b.deployment(digest)
 
-	ftr := flpTransformerReconciler{reconcilersCommonInfo: reconcilersCommonInfo{image: image}}
-	assert.True(ftr.deploymentNeedsUpdate(first, second, &cfg.Processor))
+	report := helper.NewChangeReport("")
+	checkChanged := func(old, new *appsv1.Deployment, spec flowslatest.FlowCollectorSpec) bool {
+		return helper.DeploymentChanged(old, new, constants.FLPName, spec.Processor.KafkaConsumerAutoscaler.Disabled(), spec.Processor.KafkaConsumerReplicas, &report)
+	}
+
+	assert.True(checkChanged(first, second, cfg))
+	assert.Contains(report.String(), "probe changed")
 
 	// Check log level change
 	cfg.Processor.LogLevel = "info"
@@ -298,7 +321,9 @@ func TestDeploymentChanged(t *testing.T) {
 	assert.NoError(err)
 	third := b.deployment(digest)
 
-	assert.True(ftr.deploymentNeedsUpdate(second, third, &cfg.Processor))
+	report = helper.NewChangeReport("")
+	assert.True(checkChanged(second, third, cfg))
+	assert.Contains(report.String(), "config-digest")
 
 	// Check resource change
 	cfg.Processor.Resources.Limits = map[corev1.ResourceName]resource.Quantity{
@@ -310,7 +335,9 @@ func TestDeploymentChanged(t *testing.T) {
 	assert.NoError(err)
 	fourth := b.deployment(digest)
 
-	assert.True(ftr.deploymentNeedsUpdate(third, fourth, &cfg.Processor))
+	report = helper.NewChangeReport("")
+	assert.True(checkChanged(third, fourth, cfg))
+	assert.Contains(report.String(), "req/limit changed")
 
 	// Check reverting limits
 	cfg.Processor.Resources.Limits = map[corev1.ResourceName]resource.Quantity{
@@ -322,8 +349,12 @@ func TestDeploymentChanged(t *testing.T) {
 	assert.NoError(err)
 	fifth := b.deployment(digest)
 
-	assert.True(ftr.deploymentNeedsUpdate(fourth, fifth, &cfg.Processor))
-	assert.False(ftr.deploymentNeedsUpdate(third, fifth, &cfg.Processor))
+	report = helper.NewChangeReport("")
+	assert.True(checkChanged(fourth, fifth, cfg))
+	assert.Contains(report.String(), "req/limit changed")
+	report = helper.NewChangeReport("")
+	assert.False(checkChanged(third, fifth, cfg))
+	assert.Contains(report.String(), "no change")
 
 	// Check replicas didn't change because HPA is used
 	cfg2 := cfg
@@ -333,7 +364,9 @@ func TestDeploymentChanged(t *testing.T) {
 	assert.NoError(err)
 	sixth := b.deployment(digest)
 
-	assert.False(ftr.deploymentNeedsUpdate(fifth, sixth, &cfg2.Processor))
+	report = helper.NewChangeReport("")
+	assert.False(checkChanged(fifth, sixth, cfg2))
+	assert.Contains(report.String(), "no change")
 }
 
 func TestDeploymentChangedReplicasNoHPA(t *testing.T) {
@@ -355,8 +388,9 @@ func TestDeploymentChangedReplicasNoHPA(t *testing.T) {
 	assert.NoError(err)
 	second := b.deployment(digest)
 
-	ftr := flpTransformerReconciler{reconcilersCommonInfo: reconcilersCommonInfo{image: image}}
-	assert.True(ftr.deploymentNeedsUpdate(first, second, &cfg2.Processor))
+	report := helper.NewChangeReport("")
+	assert.True(helper.DeploymentChanged(first, second, constants.FLPName, cfg2.Processor.KafkaConsumerAutoscaler.Disabled(), cfg2.Processor.KafkaConsumerReplicas, &report))
+	assert.Contains(report.String(), "Replicas changed")
 }
 
 func TestServiceNoChange(t *testing.T) {
@@ -371,7 +405,9 @@ func TestServiceNoChange(t *testing.T) {
 	// Check no change
 	newService := first.DeepCopy()
 
-	assert.False(helper.ServiceChanged(first, newService))
+	report := helper.NewChangeReport("")
+	assert.False(helper.ServiceChanged(first, newService, &report))
+	assert.Contains(report.String(), "no change")
 }
 
 func TestServiceChanged(t *testing.T) {
@@ -388,14 +424,18 @@ func TestServiceChanged(t *testing.T) {
 	b = newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
 	second := b.fromPromService(first)
 
-	assert.True(helper.ServiceChanged(first, second))
+	report := helper.NewChangeReport("")
+	assert.True(helper.ServiceChanged(first, second, &report))
+	assert.Contains(report.String(), "Service spec changed")
 
 	// Make sure non-service settings doesn't trigger service update
 	cfg.Processor.LogLevel = "error"
 	b = newMonolithBuilder(ns, image, &cfg, true, &certWatcher)
 	third := b.fromPromService(first)
 
-	assert.False(helper.ServiceChanged(second, third))
+	report = helper.NewChangeReport("")
+	assert.False(helper.ServiceChanged(second, third, &report))
+	assert.Contains(report.String(), "no change")
 }
 
 func TestServiceMonitorNoChange(t *testing.T) {
@@ -506,27 +546,30 @@ func TestAutoScalerUpdateCheck(t *testing.T) {
 
 	//equals specs
 	autoScalerSpec, hpa := getAutoScalerSpecs()
-	assert.Equal(autoScalerNeedsUpdate(&autoScalerSpec, hpa, testNamespace), false)
+	report := helper.NewChangeReport("")
+	assert.False(helper.AutoScalerChanged(&autoScalerSpec, hpa, &report))
+	assert.Contains(report.String(), "no change")
 
 	//wrong max replicas
 	autoScalerSpec, hpa = getAutoScalerSpecs()
 	autoScalerSpec.Spec.MaxReplicas = 10
-	assert.Equal(autoScalerNeedsUpdate(&autoScalerSpec, hpa, testNamespace), true, &certWatcher)
+	report = helper.NewChangeReport("")
+	assert.True(helper.AutoScalerChanged(&autoScalerSpec, hpa, &report))
+	assert.Contains(report.String(), "Max replicas changed")
 
 	//missing min replicas
 	autoScalerSpec, hpa = getAutoScalerSpecs()
 	autoScalerSpec.Spec.MinReplicas = nil
-	assert.Equal(autoScalerNeedsUpdate(&autoScalerSpec, hpa, testNamespace), true, &certWatcher)
+	report = helper.NewChangeReport("")
+	assert.True(helper.AutoScalerChanged(&autoScalerSpec, hpa, &report))
+	assert.Contains(report.String(), "Min replicas changed")
 
 	//missing metrics
 	autoScalerSpec, hpa = getAutoScalerSpecs()
 	autoScalerSpec.Spec.Metrics = []ascv2.MetricSpec{}
-	assert.Equal(autoScalerNeedsUpdate(&autoScalerSpec, hpa, testNamespace), true, &certWatcher)
-
-	//wrong namespace
-	autoScalerSpec, hpa = getAutoScalerSpecs()
-	autoScalerSpec.Namespace = "NewNamespace"
-	assert.Equal(autoScalerNeedsUpdate(&autoScalerSpec, hpa, testNamespace), true, &certWatcher)
+	report = helper.NewChangeReport("")
+	assert.True(helper.AutoScalerChanged(&autoScalerSpec, hpa, &report))
+	assert.Contains(report.String(), "Metrics changed")
 }
 
 func TestLabels(t *testing.T) {

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	flowslatest "github.com/netobserv/network-observability-operator/api/v1beta1"
 	"github.com/netobserv/network-observability-operator/controllers/constants"
@@ -185,6 +186,26 @@ func TestDaemonSetChanged(t *testing.T) {
 	report := helper.NewChangeReport("")
 	assert.True(helper.PodChanged(&first.Spec.Template, &second.Spec.Template, constants.FLPName, &report))
 	assert.Contains(report.String(), "probe changed")
+
+	// Check probes DON'T change infinitely (bc DeepEqual/Derivative checks won't work there)
+	assert.NoError(err)
+	secondBis := b.daemonSet(digest)
+	secondBis.Spec.Template.Spec.Containers[0].LivenessProbe = &corev1.Probe{
+		FailureThreshold: 3,
+		PeriodSeconds:    10,
+		SuccessThreshold: 1,
+		TimeoutSeconds:   5,
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   "/live",
+				Port:   intstr.FromString("health"),
+				Scheme: "http",
+			},
+		},
+	}
+	report = helper.NewChangeReport("")
+	assert.False(helper.PodChanged(&second.Spec.Template, &secondBis.Spec.Template, constants.FLPName, &report))
+	assert.Contains(report.String(), "no change")
 
 	// Check log level change
 	cfg.Processor.LogLevel = "info"

--- a/controllers/flowlogspipeline/flp_transfo_reconciler.go
+++ b/controllers/flowlogspipeline/flp_transfo_reconciler.go
@@ -123,7 +123,9 @@ func (r *flpTransformerReconciler) reconcile(ctx context.Context, desired *flows
 }
 
 func (r *flpTransformerReconciler) reconcileDeployment(ctx context.Context, desiredFLP *flpSpec, builder *transfoBuilder, configDigest string) error {
-	ns := r.nobjMngr.Namespace
+	report := helper.NewChangeReport("FLP Deployment")
+	defer report.LogIfNeeded(ctx)
+
 	new := builder.deployment(configDigest)
 
 	// Annotate pod with certificate reference so that it is reloaded if modified
@@ -135,7 +137,7 @@ func (r *flpTransformerReconciler) reconcileDeployment(ctx context.Context, desi
 		if err := r.CreateOwned(ctx, new); err != nil {
 			return err
 		}
-	} else if r.deploymentNeedsUpdate(r.owned.deployment, new, desiredFLP) {
+	} else if helper.DeploymentChanged(r.owned.deployment, new, constants.FLPName, desiredFLP.KafkaConsumerAutoscaler.Disabled(), desiredFLP.KafkaConsumerReplicas, &report) {
 		if err := r.UpdateOwned(ctx, r.owned.deployment, new); err != nil {
 			return err
 		}
@@ -153,7 +155,7 @@ func (r *flpTransformerReconciler) reconcileDeployment(ctx context.Context, desi
 			if err := r.CreateOwned(ctx, newASC); err != nil {
 				return err
 			}
-		} else if autoScalerNeedsUpdate(r.owned.hpa, desiredFLP.KafkaConsumerAutoscaler, ns) {
+		} else if helper.AutoScalerChanged(r.owned.hpa, desiredFLP.KafkaConsumerAutoscaler, &report) {
 			if err := r.UpdateOwned(ctx, r.owned.hpa, newASC); err != nil {
 				return err
 			}
@@ -163,6 +165,9 @@ func (r *flpTransformerReconciler) reconcileDeployment(ctx context.Context, desi
 }
 
 func (r *flpTransformerReconciler) reconcilePrometheusService(ctx context.Context, builder *transfoBuilder) error {
+	report := helper.NewChangeReport("FLP prometheus service")
+	defer report.LogIfNeeded(ctx)
+
 	if !r.nobjMngr.Exists(r.owned.promService) {
 		if err := r.CreateOwned(ctx, builder.newPromService()); err != nil {
 			return err
@@ -178,7 +183,7 @@ func (r *flpTransformerReconciler) reconcilePrometheusService(ctx context.Contex
 		return nil
 	}
 	newSVC := builder.fromPromService(r.owned.promService)
-	if helper.ServiceChanged(r.owned.promService, newSVC) {
+	if helper.ServiceChanged(r.owned.promService, newSVC, &report) {
 		if err := r.UpdateOwned(ctx, r.owned.promService, newSVC); err != nil {
 			return err
 		}
@@ -210,26 +215,4 @@ func (r *flpTransformerReconciler) reconcilePermissions(ctx context.Context, bui
 		return err
 	}
 	return nil
-}
-
-func (r *flpTransformerReconciler) deploymentNeedsUpdate(old, new *appsv1.Deployment, desired *flpSpec) bool {
-	return helper.PodChanged(&old.Spec.Template, &new.Spec.Template, constants.FLPName) ||
-		(desired.KafkaConsumerAutoscaler.Disabled() && *old.Spec.Replicas != desired.KafkaConsumerReplicas)
-}
-
-func autoScalerNeedsUpdate(asc *ascv2.HorizontalPodAutoscaler, desired flowslatest.FlowCollectorHPA, ns string) bool {
-	if asc.Namespace != ns {
-		return true
-	}
-	differentPointerValues := func(a, b *int32) bool {
-		return (a == nil && b != nil) || (a != nil && b == nil) || (a != nil && *a != *b)
-	}
-	if asc.Spec.MaxReplicas != desired.MaxReplicas ||
-		differentPointerValues(asc.Spec.MinReplicas, desired.MinReplicas) {
-		return true
-	}
-	if !equality.Semantic.DeepDerivative(desired.Metrics, asc.Spec.Metrics) {
-		return true
-	}
-	return false
 }

--- a/pkg/helper/change_report.go
+++ b/pkg/helper/change_report.go
@@ -1,0 +1,50 @@
+package helper
+
+import (
+	"context"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// ChangeReport is a logging utility for troubleshooting operator issues
+type ChangeReport struct {
+	title  string
+	report []string
+}
+
+func NewChangeReport(title string) ChangeReport {
+	return ChangeReport{title: title}
+}
+
+func (r *ChangeReport) Add(msg string) {
+	r.report = append(r.report, msg)
+}
+
+func (r *ChangeReport) Check(msg string, change bool) bool {
+	if change {
+		r.report = append(r.report, msg)
+	}
+	return change
+}
+
+func (r *ChangeReport) LogIfNeeded(ctx context.Context) {
+	if len(r.report) > 0 {
+		log.FromContext(ctx).Info(r.String())
+	}
+}
+
+func (r *ChangeReport) String() string {
+	sb := strings.Builder{}
+	sb.WriteString(r.title)
+	sb.WriteRune(':')
+	if len(r.report) > 0 {
+		for _, str := range r.report {
+			sb.WriteRune('<')
+			sb.WriteString(str)
+		}
+	} else {
+		sb.WriteString("no change")
+	}
+	return sb.String()
+}

--- a/pkg/helper/comparators.go
+++ b/pkg/helper/comparators.go
@@ -1,42 +1,55 @@
 package helper
 
 import (
+	"fmt"
 	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	ascv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 
+	flowslatest "github.com/netobserv/network-observability-operator/api/v1beta1"
 	"github.com/netobserv/network-observability-operator/controllers/constants"
 )
 
-func PodChanged(old, new *corev1.PodTemplateSpec, containerName string) bool {
-	if annotationsChanged(old, new) || volumesChanged(old, new) {
+func DeploymentChanged(old, new *appsv1.Deployment, contName string, checkReplicas bool, desiredReplicas int32, report *ChangeReport) bool {
+	return report.Check("Pod changed", PodChanged(&old.Spec.Template, &new.Spec.Template, contName, report)) ||
+		report.Check("Replicas changed", (checkReplicas && *old.Spec.Replicas != desiredReplicas))
+}
+
+func PodChanged(old, new *corev1.PodTemplateSpec, containerName string, report *ChangeReport) bool {
+	if annotationsChanged(old, new, report) || volumesChanged(old, new, report) {
 		return true
 	}
 	// Find containers
 	oldContainer := FindContainer(&old.Spec, containerName)
 	if oldContainer == nil {
+		report.Add("Old container not found")
 		return true
 	}
 	newContainer := FindContainer(&new.Spec, containerName)
 	if newContainer == nil {
+		report.Add("New container not found")
 		return true
 	}
-	return containerChanged(oldContainer, newContainer)
+	return report.Check("Container changed", containerChanged(oldContainer, newContainer, report))
 }
 
-func annotationsChanged(old, new *corev1.PodTemplateSpec) bool {
+func annotationsChanged(old, new *corev1.PodTemplateSpec, report *ChangeReport) bool {
 	if old.Annotations == nil && new.Annotations == nil {
 		return false
 	}
 	if old.Annotations == nil {
+		report.Add("New annotations, previously none")
 		return true
 	}
 	// Check domain annotations (config digest, certificate stamp...)
 	for k, v := range old.Annotations {
 		if strings.HasPrefix(k, constants.AnnotationDomain) {
 			if new.Annotations[k] != v {
+				report.Add(fmt.Sprintf("Annotation changed: '%s: %s'", k, v))
 				return true
 			}
 		}
@@ -44,22 +57,26 @@ func annotationsChanged(old, new *corev1.PodTemplateSpec) bool {
 	return false
 }
 
-func volumesChanged(old, new *corev1.PodTemplateSpec) bool {
-	return !equality.Semantic.DeepDerivative(new.Spec.Volumes, old.Spec.Volumes)
+func volumesChanged(old, new *corev1.PodTemplateSpec, report *ChangeReport) bool {
+	return report.Check("Volumes changed", !equality.Semantic.DeepDerivative(new.Spec.Volumes, old.Spec.Volumes))
 }
 
-func containerChanged(old, new *corev1.Container) bool {
-	return new.Image != old.Image ||
-		new.ImagePullPolicy != old.ImagePullPolicy ||
-		!equality.Semantic.DeepDerivative(new.Args, old.Args) ||
-		!equality.Semantic.DeepDerivative(new.Resources, old.Resources) ||
-		!equality.Semantic.DeepEqual(old.LivenessProbe, new.LivenessProbe) ||
-		!equality.Semantic.DeepEqual(old.StartupProbe, new.StartupProbe)
+func containerChanged(old, new *corev1.Container, report *ChangeReport) bool {
+	return report.Check("Image changed", new.Image != old.Image) ||
+		report.Check("Pull policy changed", new.ImagePullPolicy != old.ImagePullPolicy) ||
+		report.Check("Args changed", !equality.Semantic.DeepDerivative(new.Args, old.Args)) ||
+		report.Check("Resources req/limit changed", !equality.Semantic.DeepDerivative(new.Resources, old.Resources)) ||
+		report.Check("Liveness probe changed", probeChanged(new.LivenessProbe, old.LivenessProbe)) ||
+		report.Check("Startup probe changed", probeChanged(new.StartupProbe, old.StartupProbe))
 }
 
-func ServiceChanged(old, new *corev1.Service) bool {
-	return !equality.Semantic.DeepDerivative(new.ObjectMeta, old.ObjectMeta) ||
-		!equality.Semantic.DeepDerivative(new.Spec, old.Spec)
+func probeChanged(old, new *corev1.Probe) bool {
+	return (old == nil && new != nil) || (old != nil && new == nil)
+}
+
+func ServiceChanged(old, new *corev1.Service, report *ChangeReport) bool {
+	return report.Check("Service meta changed", !equality.Semantic.DeepDerivative(new.ObjectMeta, old.ObjectMeta)) ||
+		report.Check("Service spec changed", !equality.Semantic.DeepDerivative(new.Spec, old.Spec))
 }
 
 func ServiceMonitorChanged(old, new *monitoringv1.ServiceMonitor) bool {
@@ -80,4 +97,18 @@ func FindContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {
 		}
 	}
 	return nil
+}
+
+func AutoScalerChanged(asc *ascv2.HorizontalPodAutoscaler, desired flowslatest.FlowCollectorHPA, report *ChangeReport) bool {
+	differentPointerValues := func(a, b *int32) bool {
+		return (a == nil && b != nil) || (a != nil && b == nil) || (a != nil && *a != *b)
+	}
+	if report.Check("Max replicas changed", asc.Spec.MaxReplicas != desired.MaxReplicas) ||
+		report.Check("Min replicas changed", differentPointerValues(asc.Spec.MinReplicas, desired.MinReplicas)) {
+		return true
+	}
+	if report.Check("Metrics changed", !equality.Semantic.DeepDerivative(desired.Metrics, asc.Spec.Metrics)) {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
The infinite reconcile was due to a bad change comparison of liveness/readiness probes.

This commit is also adding better reconciliation change tracking utility for debugging.