### PR TITLE
NETOBSERV-155: Added sampling field to console frontend configuration

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -30,17 +30,6 @@ const (
 	DeploymentModelKafka  = "KAFKA"
 )
 
-func (spec *FlowCollectorSpec) UseEBPF() bool  { return spec.Agent.Type == AgentEBPF }
-func (spec *FlowCollectorSpec) UseIPFIX() bool { return spec.Agent.Type == AgentIPFIX }
-func (spec *FlowCollectorSpec) UseKafka() bool { return spec.DeploymentModel == DeploymentModelKafka }
-
-func (spec *FlowCollectorSpec) GetSampling() int {
-	if spec.UseEBPF() {
-		return int(*spec.Agent.EBPF.Sampling)
-	}
-	return int(spec.Agent.IPFIX.Sampling)
-}
-
 // Please notice that the FlowCollectorSpec's properties MUST redefine one of the default
 // values to force the definition of the section when it is not provided by the manifest.
 // This will cause that the remaining default fields will be set according to their definition.
@@ -401,31 +390,11 @@ type FlowCollectorHPA struct {
 	Metrics []ascv2.MetricSpec `json:"metrics"`
 }
 
-func (spec *FlowCollectorHPA) Disabled() bool {
-	return spec.Status == HPAStatusDisabled
-}
-
-func (spec *FlowCollectorHPA) Enabled() bool {
-	return spec.Status == HPAStatusEnabled
-}
-
 const (
 	LokiAuthDisabled         = "DISABLED"
 	LokiAuthUseHostToken     = "HOST"
 	LokiAuthForwardUserToken = "FORWARD"
 )
-
-func (spec *FlowCollectorLoki) NoAuthToken() bool {
-	return spec.AuthToken == LokiAuthDisabled
-}
-
-func (spec *FlowCollectorLoki) UseHostToken() bool {
-	return spec.AuthToken == LokiAuthUseHostToken
-}
-
-func (spec *FlowCollectorLoki) ForwardUserToken() bool {
-	return spec.AuthToken == LokiAuthForwardUserToken
-}
 
 // FlowCollectorLoki defines the desired state for FlowCollector's Loki client.
 type FlowCollectorLoki struct {

--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -34,6 +34,13 @@ func (spec *FlowCollectorSpec) UseEBPF() bool  { return spec.Agent.Type == Agent
 func (spec *FlowCollectorSpec) UseIPFIX() bool { return spec.Agent.Type == AgentIPFIX }
 func (spec *FlowCollectorSpec) UseKafka() bool { return spec.DeploymentModel == DeploymentModelKafka }
 
+func (spec *FlowCollectorSpec) GetSampling() int {
+	if spec.UseEBPF() {
+		return int(*spec.Agent.EBPF.Sampling)
+	}
+	return int(spec.Agent.IPFIX.Sampling)
+}
+
 // Please notice that the FlowCollectorSpec's properties MUST redefine one of the default
 // values to force the definition of the section when it is not provided by the manifest.
 // This will cause that the remaining default fields will be set according to their definition.

--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -30,17 +30,6 @@ const (
 	DeploymentModelKafka  = "KAFKA"
 )
 
-func (spec *FlowCollectorSpec) UseEBPF() bool  { return spec.Agent.Type == AgentEBPF }
-func (spec *FlowCollectorSpec) UseIPFIX() bool { return spec.Agent.Type == AgentIPFIX }
-func (spec *FlowCollectorSpec) UseKafka() bool { return spec.DeploymentModel == DeploymentModelKafka }
-
-func (spec *FlowCollectorSpec) GetSampling() int {
-	if spec.UseEBPF() {
-		return int(*spec.Agent.EBPF.Sampling)
-	}
-	return int(spec.Agent.IPFIX.Sampling)
-}
-
 // Please notice that the FlowCollectorSpec's properties MUST redefine one of the default
 // values to force the definition of the section when it is not provided by the manifest.
 // This will cause that the remaining default fields will be set according to their definition.
@@ -401,31 +390,11 @@ type FlowCollectorHPA struct {
 	Metrics []ascv2.MetricSpec `json:"metrics"`
 }
 
-func (spec *FlowCollectorHPA) Disabled() bool {
-	return spec.Status == HPAStatusDisabled
-}
-
-func (spec *FlowCollectorHPA) Enabled() bool {
-	return spec.Status == HPAStatusEnabled
-}
-
 const (
 	LokiAuthDisabled         = "DISABLED"
 	LokiAuthUseHostToken     = "HOST"
 	LokiAuthForwardUserToken = "FORWARD"
 )
-
-func (spec *FlowCollectorLoki) NoAuthToken() bool {
-	return spec.AuthToken == LokiAuthDisabled
-}
-
-func (spec *FlowCollectorLoki) UseHostToken() bool {
-	return spec.AuthToken == LokiAuthUseHostToken
-}
-
-func (spec *FlowCollectorLoki) ForwardUserToken() bool {
-	return spec.AuthToken == LokiAuthForwardUserToken
-}
 
 // FlowCollectorLoki defines the desired state for FlowCollector's Loki client.
 type FlowCollectorLoki struct {

--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -34,6 +34,13 @@ func (spec *FlowCollectorSpec) UseEBPF() bool  { return spec.Agent.Type == Agent
 func (spec *FlowCollectorSpec) UseIPFIX() bool { return spec.Agent.Type == AgentIPFIX }
 func (spec *FlowCollectorSpec) UseKafka() bool { return spec.DeploymentModel == DeploymentModelKafka }
 
+func (spec *FlowCollectorSpec) GetSampling() int {
+	if spec.UseEBPF() {
+		return int(*spec.Agent.EBPF.Sampling)
+	}
+	return int(spec.Agent.IPFIX.Sampling)
+}
+
 // Please notice that the FlowCollectorSpec's properties MUST redefine one of the default
 // values to force the definition of the section when it is not provided by the manifest.
 // This will cause that the remaining default fields will be set according to their definition.

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -142,7 +142,7 @@ func (b *builder) deployment(cmDigest string) *appsv1.Deployment {
 }
 
 func tokenPath(desiredLoki *flowslatest.FlowCollectorLoki) string {
-	if desiredLoki.UseHostToken() {
+	if helper.LokiUseHostToken(desiredLoki) {
 		return tokensPath + constants.PluginName
 	}
 	return ""
@@ -162,7 +162,7 @@ func buildArgs(desired *flowslatest.FlowCollectorConsolePlugin, desiredLoki *flo
 		"-frontend-config", filepath.Join(configPath, configFile),
 	}
 
-	if desiredLoki.ForwardUserToken() {
+	if helper.LokiForwardUserToken(desiredLoki) {
 		args = append(args, "-loki-forward-user-token")
 	}
 
@@ -177,7 +177,7 @@ func buildArgs(desired *flowslatest.FlowCollectorConsolePlugin, desiredLoki *flo
 			args = append(args, "--loki-ca-path", helper.GetCACertPath(&desiredLoki.TLS, lokiCerts))
 		}
 	}
-	if desiredLoki.UseHostToken() {
+	if helper.LokiUseHostToken(desiredLoki) {
 		args = append(args, "-loki-token-path", tokenPath(desiredLoki))
 	}
 	return args
@@ -219,7 +219,7 @@ func (b *builder) podTemplate(cmDigest string) *corev1.PodTemplateSpec {
 		volumes, volumeMounts = helper.AppendCertVolumes(volumes, volumeMounts, &b.desired.Loki.TLS, lokiCerts, b.cWatcher)
 	}
 
-	if b.desired.Loki.UseHostToken() {
+	if helper.LokiUseHostToken(&b.desired.Loki) {
 		volumes, volumeMounts = helper.AppendTokenVolume(volumes, volumeMounts, constants.PluginName, constants.PluginName)
 	}
 
@@ -314,7 +314,7 @@ func (b *builder) configMap() (*corev1.ConfigMap, string) {
 		"portNaming":      b.desired.ConsolePlugin.PortNaming,
 		"quickFilters":    b.desired.ConsolePlugin.QuickFilters,
 		"alertNamespaces": []string{b.namespace},
-		"sampling":        b.desired.GetSampling(),
+		"sampling":        helper.GetSampling(b.desired),
 	}
 
 	configStr := "{}"

--- a/controllers/consoleplugin/consoleplugin_reconciler.go
+++ b/controllers/consoleplugin/consoleplugin_reconciler.go
@@ -90,7 +90,7 @@ func (r *CPReconciler) Reconcile(ctx context.Context, desired *flowslatest.FlowC
 	}
 
 	// Create object builder
-	builder := newBuilder(ns, r.image, &desired.Spec.ConsolePlugin, &desired.Spec.Loki, r.CertWatcher)
+	builder := newBuilder(ns, r.image, &desired.Spec, r.CertWatcher)
 
 	if err = r.reconcilePlugin(ctx, builder, &desired.Spec); err != nil {
 		return err

--- a/controllers/consoleplugin/consoleplugin_reconciler.go
+++ b/controllers/consoleplugin/consoleplugin_reconciler.go
@@ -190,7 +190,7 @@ func (r *CPReconciler) reconcileDeployment(ctx context.Context, builder builder,
 		if err := r.CreateOwned(ctx, newDepl); err != nil {
 			return err
 		}
-	} else if helper.DeploymentChanged(r.owned.deployment, newDepl, constants.PluginName, desired.ConsolePlugin.Autoscaler.Disabled(), desired.ConsolePlugin.Replicas, &report) {
+	} else if helper.DeploymentChanged(r.owned.deployment, newDepl, constants.PluginName, helper.HPADisabled(&desired.ConsolePlugin.Autoscaler), desired.ConsolePlugin.Replicas, &report) {
 		if err := r.UpdateOwned(ctx, r.owned.deployment, newDepl); err != nil {
 			return err
 		}
@@ -229,7 +229,7 @@ func (r *CPReconciler) reconcileHPA(ctx context.Context, builder builder, desire
 	defer report.LogIfNeeded(ctx)
 
 	// Delete or Create / Update Autoscaler according to HPA option
-	if desired.ConsolePlugin.Autoscaler.Disabled() {
+	if helper.HPADisabled(&desired.ConsolePlugin.Autoscaler) {
 		r.nobjMngr.TryDelete(ctx, r.owned.hpa)
 	} else {
 		newASC := builder.autoScaler()

--- a/controllers/consoleplugin/consoleplugin_test.go
+++ b/controllers/consoleplugin/consoleplugin_test.go
@@ -109,9 +109,9 @@ func TestContainerUpdateCheck(t *testing.T) {
 
 	//equals specs
 	plugin := getPluginConfig()
-	loki := &flowslatest.FlowCollectorLoki{URL: "http://loki:3100/", TenantID: "netobserv"}
-	spec := &flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: *loki}
-	builder := newBuilder(testNamespace, testImage, spec, &certWatcher)
+	loki := flowslatest.FlowCollectorLoki{URL: "http://loki:3100/", TenantID: "netobserv"}
+	spec := flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: loki}
+	builder := newBuilder(testNamespace, testImage, &spec, &certWatcher)
 	old := builder.deployment("digest")
 	new := builder.deployment("digest")
 	report := helper.NewChangeReport("")
@@ -154,7 +154,7 @@ func TestContainerUpdateCheck(t *testing.T) {
 	old = new
 
 	//new loki config
-	loki = &flowslatest.FlowCollectorLoki{URL: "http://loki:3100/", TenantID: "netobserv", TLS: flowslatest.ClientTLS{
+	loki = flowslatest.FlowCollectorLoki{URL: "http://loki:3100/", TenantID: "netobserv", TLS: flowslatest.ClientTLS{
 		Enable: true,
 		CACert: flowslatest.CertificateReference{
 			Type:     "configmap",
@@ -162,8 +162,8 @@ func TestContainerUpdateCheck(t *testing.T) {
 			CertFile: "ca.crt",
 		},
 	}}
-	spec = &flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: *loki}
-	builder = newBuilder(testNamespace, testImage, spec, &certWatcher)
+	spec = flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: loki}
+	builder = newBuilder(testNamespace, testImage, &spec, &certWatcher)
 	new = builder.deployment("digest")
 	report = helper.NewChangeReport("")
 	assert.True(helper.PodChanged(&old.Spec.Template, &new.Spec.Template, constants.PluginName, &report))
@@ -172,8 +172,8 @@ func TestContainerUpdateCheck(t *testing.T) {
 
 	//new loki cert name
 	loki.TLS.CACert.Name = "cm-name-2"
-	spec = &flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: *loki}
-	builder = newBuilder(testNamespace, testImage, spec, &certWatcher)
+	spec = flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: loki}
+	builder = newBuilder(testNamespace, testImage, &spec, &certWatcher)
 	new = builder.deployment("digest")
 	report = helper.NewChangeReport("")
 	assert.True(helper.PodChanged(&old.Spec.Template, &new.Spec.Template, constants.PluginName, &report))
@@ -182,8 +182,8 @@ func TestContainerUpdateCheck(t *testing.T) {
 
 	//test again no change
 	loki.TLS.CACert.Name = "cm-name-2"
-	spec = &flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: *loki}
-	builder = newBuilder(testNamespace, testImage, spec, &certWatcher)
+	spec = flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: loki}
+	builder = newBuilder(testNamespace, testImage, &spec, &certWatcher)
 	new = builder.deployment("digest")
 	report = helper.NewChangeReport("")
 	assert.False(helper.PodChanged(&old.Spec.Template, &new.Spec.Template, constants.PluginName, &report))
@@ -219,9 +219,9 @@ func TestBuiltService(t *testing.T) {
 
 	//newly created service should not need update
 	plugin := getPluginConfig()
-	loki := &flowslatest.FlowCollectorLoki{URL: "http://foo:1234"}
-	spec := &flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: *loki}
-	builder := newBuilder(testNamespace, testImage, spec, &certWatcher)
+	loki := flowslatest.FlowCollectorLoki{URL: "http://foo:1234"}
+	spec := flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: loki}
+	builder := newBuilder(testNamespace, testImage, &spec, &certWatcher)
 	newService := builder.service(nil)
 	report := helper.NewChangeReport("")
 	assert.Equal(serviceNeedsUpdate(newService, &plugin, &report), false)
@@ -232,9 +232,9 @@ func TestLabels(t *testing.T) {
 	assert := assert.New(t)
 
 	plugin := getPluginConfig()
-	loki := &flowslatest.FlowCollectorLoki{URL: "http://foo:1234"}
-	spec := &flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: *loki}
-	builder := newBuilder(testNamespace, testImage, spec, &certWatcher)
+	loki := flowslatest.FlowCollectorLoki{URL: "http://foo:1234"}
+	spec := flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: loki}
+	builder := newBuilder(testNamespace, testImage, &spec, &certWatcher)
 
 	// Deployment
 	depl := builder.deployment("digest")

--- a/controllers/flowlogspipeline/flp_ingest_objects.go
+++ b/controllers/flowlogspipeline/flp_ingest_objects.go
@@ -9,6 +9,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	flowslatest "github.com/netobserv/network-observability-operator/api/v1beta1"
+	"github.com/netobserv/network-observability-operator/pkg/helper"
 	"github.com/netobserv/network-observability-operator/pkg/watchers"
 )
 
@@ -50,7 +51,7 @@ func (b *ingestBuilder) configMap() (*corev1.ConfigMap, string, error) {
 
 func (b *ingestBuilder) buildPipelineConfig() ([]config.Stage, []config.StageParam, error) {
 	var pipeline config.PipelineBuilderStage
-	if b.generic.desired.UseIPFIX() {
+	if helper.UseIPFIX(b.generic.desired) {
 		// IPFIX collector
 		pipeline = config.NewCollectorPipeline("ipfix", api.IngestCollector{
 			Port:     int(b.generic.desired.Processor.Port),

--- a/controllers/flowlogspipeline/flp_ingest_reconciler.go
+++ b/controllers/flowlogspipeline/flp_ingest_reconciler.go
@@ -86,7 +86,7 @@ func (r *flpIngesterReconciler) reconcile(ctx context.Context, desired *flowslat
 	}
 
 	// Ingester only used with Kafka and without eBPF
-	if !desired.Spec.UseKafka() || desired.Spec.UseEBPF() {
+	if !helper.UseKafka(&desired.Spec) || helper.UseEBPF(&desired.Spec) {
 		r.nobjMngr.TryDeleteAll(ctx)
 		return nil
 	}

--- a/controllers/flowlogspipeline/flp_monolith_objects.go
+++ b/controllers/flowlogspipeline/flp_monolith_objects.go
@@ -9,6 +9,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	flowslatest "github.com/netobserv/network-observability-operator/api/v1beta1"
+	"github.com/netobserv/network-observability-operator/pkg/helper"
 	"github.com/netobserv/network-observability-operator/pkg/watchers"
 )
 
@@ -50,7 +51,7 @@ func (b *monolithBuilder) configMap() (*corev1.ConfigMap, string, error) {
 
 func (b *monolithBuilder) buildPipelineConfig() ([]config.Stage, []config.StageParam, error) {
 	var pipeline config.PipelineBuilderStage
-	if b.generic.desired.UseIPFIX() {
+	if helper.UseIPFIX(b.generic.desired) {
 		// IPFIX collector
 		pipeline = config.NewCollectorPipeline("ipfix", api.IngestCollector{
 			Port:     int(b.generic.desired.Processor.Port),

--- a/controllers/flowlogspipeline/flp_monolith_reconciler.go
+++ b/controllers/flowlogspipeline/flp_monolith_reconciler.go
@@ -88,7 +88,7 @@ func (r *flpMonolithReconciler) reconcile(ctx context.Context, desired *flowslat
 	}
 
 	// Monolith only used without Kafka
-	if desired.Spec.UseKafka() {
+	if helper.UseKafka(&desired.Spec) {
 		r.nobjMngr.TryDeleteAll(ctx)
 		return nil
 	}

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -305,7 +305,7 @@ func TestDeploymentNoChange(t *testing.T) {
 	second := b.deployment(digest)
 
 	report := helper.NewChangeReport("")
-	assert.False(helper.DeploymentChanged(first, second, constants.FLPName, cfg.Processor.KafkaConsumerAutoscaler.Disabled(), cfg.Processor.KafkaConsumerReplicas, &report))
+	assert.False(helper.DeploymentChanged(first, second, constants.FLPName, helper.HPADisabled(&cfg.Processor.KafkaConsumerAutoscaler), cfg.Processor.KafkaConsumerReplicas, &report))
 	assert.Contains(report.String(), "no change")
 }
 
@@ -329,7 +329,7 @@ func TestDeploymentChanged(t *testing.T) {
 
 	report := helper.NewChangeReport("")
 	checkChanged := func(old, new *appsv1.Deployment, spec flowslatest.FlowCollectorSpec) bool {
-		return helper.DeploymentChanged(old, new, constants.FLPName, spec.Processor.KafkaConsumerAutoscaler.Disabled(), spec.Processor.KafkaConsumerReplicas, &report)
+		return helper.DeploymentChanged(old, new, constants.FLPName, helper.HPADisabled(&spec.Processor.KafkaConsumerAutoscaler), spec.Processor.KafkaConsumerReplicas, &report)
 	}
 
 	assert.True(checkChanged(first, second, cfg))
@@ -410,7 +410,7 @@ func TestDeploymentChangedReplicasNoHPA(t *testing.T) {
 	second := b.deployment(digest)
 
 	report := helper.NewChangeReport("")
-	assert.True(helper.DeploymentChanged(first, second, constants.FLPName, cfg2.Processor.KafkaConsumerAutoscaler.Disabled(), cfg2.Processor.KafkaConsumerReplicas, &report))
+	assert.True(helper.DeploymentChanged(first, second, constants.FLPName, helper.HPADisabled(&cfg2.Processor.KafkaConsumerAutoscaler), cfg2.Processor.KafkaConsumerReplicas, &report))
 	assert.Contains(report.String(), "Replicas changed")
 }
 

--- a/controllers/flowlogspipeline/flp_transfo_objects.go
+++ b/controllers/flowlogspipeline/flp_transfo_objects.go
@@ -10,6 +10,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	flowslatest "github.com/netobserv/network-observability-operator/api/v1beta1"
+	"github.com/netobserv/network-observability-operator/pkg/helper"
 	"github.com/netobserv/network-observability-operator/pkg/watchers"
 )
 
@@ -55,7 +56,7 @@ func (b *transfoBuilder) buildPipelineConfig() ([]config.Stage, []config.StagePa
 	// For now, we leave this communication via JSON and just setup protobuf ingestion when
 	// the transformer is communicating directly via eBPF agent
 	decoder := api.Decoder{Type: "protobuf"}
-	if b.generic.desired.UseIPFIX() {
+	if helper.UseIPFIX(b.generic.desired) {
 		decoder = api.Decoder{Type: "json"}
 	}
 	pipeline := config.NewKafkaPipeline("kafka-read", api.IngestKafka{

--- a/controllers/flowlogspipeline/flp_transfo_reconciler.go
+++ b/controllers/flowlogspipeline/flp_transfo_reconciler.go
@@ -90,7 +90,7 @@ func (r *flpTransformerReconciler) reconcile(ctx context.Context, desired *flows
 	}
 
 	// Transformer only used with Kafka
-	if !desired.Spec.UseKafka() {
+	if !helper.UseKafka(&desired.Spec) {
 		r.nobjMngr.TryDeleteAll(ctx)
 		return nil
 	}
@@ -137,7 +137,7 @@ func (r *flpTransformerReconciler) reconcileDeployment(ctx context.Context, desi
 		if err := r.CreateOwned(ctx, new); err != nil {
 			return err
 		}
-	} else if helper.DeploymentChanged(r.owned.deployment, new, constants.FLPName, desiredFLP.KafkaConsumerAutoscaler.Disabled(), desiredFLP.KafkaConsumerReplicas, &report) {
+	} else if helper.DeploymentChanged(r.owned.deployment, new, constants.FLPName, helper.HPADisabled(&desiredFLP.KafkaConsumerAutoscaler), desiredFLP.KafkaConsumerReplicas, &report) {
 		if err := r.UpdateOwned(ctx, r.owned.deployment, new); err != nil {
 			return err
 		}
@@ -147,7 +147,7 @@ func (r *flpTransformerReconciler) reconcileDeployment(ctx context.Context, desi
 	}
 
 	// Delete or Create / Update Autoscaler according to HPA option
-	if desiredFLP.KafkaConsumerAutoscaler.Disabled() {
+	if helper.HPADisabled(&desiredFLP.KafkaConsumerAutoscaler) {
 		r.nobjMngr.TryDelete(ctx, r.owned.hpa)
 	} else {
 		newASC := builder.autoScaler()

--- a/controllers/ovs/flowsconfig_cno_reconciler.go
+++ b/controllers/ovs/flowsconfig_cno_reconciler.go
@@ -13,6 +13,7 @@ import (
 
 	flowslatest "github.com/netobserv/network-observability-operator/api/v1beta1"
 	"github.com/netobserv/network-observability-operator/controllers/reconcilers"
+	"github.com/netobserv/network-observability-operator/pkg/helper"
 )
 
 type FlowsConfigCNOController struct {
@@ -44,7 +45,7 @@ func (c *FlowsConfigCNOController) Reconcile(ctx context.Context, target *flowsl
 	if err != nil {
 		return err
 	}
-	if !target.Spec.UseIPFIX() {
+	if !helper.UseIPFIX(&target.Spec) {
 		if current == nil {
 			return nil
 		}

--- a/controllers/ovs/flowsconfig_ovnk_reconciler.go
+++ b/controllers/ovs/flowsconfig_ovnk_reconciler.go
@@ -100,7 +100,7 @@ func (c *FlowsConfigOVNKController) desiredEnv(ctx context.Context, coll *flowsl
 		"OVN_IPFIX_SAMPLING":             strconv.Itoa(int(sampling)),
 	}
 
-	if !coll.Spec.UseIPFIX() {
+	if !helper.UseIPFIX(&coll.Spec) {
 		// No IPFIX => leave target empty and return
 		return envs, nil
 	}

--- a/pkg/helper/flowcollector.go
+++ b/pkg/helper/flowcollector.go
@@ -1,0 +1,42 @@
+package helper
+
+import (
+	flowslatest "github.com/netobserv/network-observability-operator/api/v1beta1"
+)
+
+func GetSampling(spec *flowslatest.FlowCollectorSpec) int {
+	if UseEBPF(spec) {
+		return int(*spec.Agent.EBPF.Sampling)
+	}
+	return int(spec.Agent.IPFIX.Sampling)
+}
+
+func UseEBPF(spec *flowslatest.FlowCollectorSpec) bool {
+	return spec.Agent.Type == flowslatest.AgentEBPF
+}
+func UseIPFIX(spec *flowslatest.FlowCollectorSpec) bool {
+	return spec.Agent.Type == flowslatest.AgentIPFIX
+}
+func UseKafka(spec *flowslatest.FlowCollectorSpec) bool {
+	return spec.DeploymentModel == flowslatest.DeploymentModelKafka
+}
+
+func HPADisabled(spec *flowslatest.FlowCollectorHPA) bool {
+	return spec.Status == flowslatest.HPAStatusDisabled
+}
+
+func HPAEnabled(spec *flowslatest.FlowCollectorHPA) bool {
+	return spec.Status == flowslatest.HPAStatusEnabled
+}
+
+func LokiNoAuthToken(spec *flowslatest.FlowCollectorLoki) bool {
+	return spec.AuthToken == flowslatest.LokiAuthDisabled
+}
+
+func LokiUseHostToken(spec *flowslatest.FlowCollectorLoki) bool {
+	return spec.AuthToken == flowslatest.LokiAuthUseHostToken
+}
+
+func LokiForwardUserToken(spec *flowslatest.FlowCollectorLoki) bool {
+	return spec.AuthToken == flowslatest.LokiAuthForwardUserToken
+}


### PR DESCRIPTION
Added sampling field to configuration.

To do that I needed to keep a reference to the FlowCollectorSpec object in the console object builder so I added a bit of refactoring to only keep this object and remove ConsolePlugin and Loki reference which are not needed anymore.