### PR TITLE
NETOBSERV-674: Added alertNamespaces field in console plugin frontend configuration

### DIFF
--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -313,8 +313,9 @@ func buildServiceAccount(ns string) *corev1.ServiceAccount {
 // detect any configuration change
 func (b *builder) configMap() (*corev1.ConfigMap, string) {
 	config := map[string]interface{}{
-		"portNaming":   b.desired.PortNaming,
-		"quickFilters": b.desired.QuickFilters,
+		"portNaming":      b.desired.PortNaming,
+		"quickFilters":    b.desired.QuickFilters,
+		"alertNamespaces": []string{b.namespace},
 	}
 
 	configStr := "{}"


### PR DESCRIPTION
I just realized that I forgot to push the last commit on my previous PR.

This was linked to PR comments to make namespace configuration.