### PR TITLE
Fix deployment on non-ovnk (e.g. kind)

### DIFF
--- a/controllers/ovs/flowsconfig_ovnk_reconciler.go
+++ b/controllers/ovs/flowsconfig_ovnk_reconciler.go
@@ -56,7 +56,7 @@ func (c *FlowsConfigOVNKController) updateEnv(ctx context.Context, target *flows
 		Name:      c.config.DaemonSetName,
 		Namespace: c.config.Namespace,
 	}, ds); err != nil {
-		if kerr.IsNotFound(err) && !target.Spec.UseIPFIX() {
+		if kerr.IsNotFound(err) && !helper.UseIPFIX(&target.Spec) {
 			// If we don't want IPFIX and ovn-k daemonset is not found, assume there no ovn-k, just succeed
 			rlog.Info("Skip reconciling OVN: OVN DaemonSet not found")
 			return nil

--- a/controllers/ovs/flowsconfig_ovnk_reconciler.go
+++ b/controllers/ovs/flowsconfig_ovnk_reconciler.go
@@ -57,7 +57,8 @@ func (c *FlowsConfigOVNKController) updateEnv(ctx context.Context, target *flows
 		Namespace: c.config.Namespace,
 	}, ds); err != nil {
 		if kerr.IsNotFound(err) && !target.Spec.UseIPFIX() {
-			// If we don't want IPFIX and ovn-k daemonset is not found, assume there no ovn-k, just succeed silently
+			// If we don't want IPFIX and ovn-k daemonset is not found, assume there no ovn-k, just succeed
+			rlog.Info("Skip reconciling OVN: OVN DaemonSet not found")
 			return nil
 		}
 		return fmt.Errorf("retrieving %s/%s daemonset: %w", c.config.Namespace, c.config.DaemonSetName, err)


### PR DESCRIPTION
Exit silently when ovn-k workloads aren't found, when they are not required