### PR TITLE
Fix regression on deploying latest

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,12 +46,20 @@ You can refer to existing commits using their short-SHA as the image tag, or ref
 
 ```bash
 # By commit SHA
-VERSION="960766c" make deploy
+OPERATOR_VERSION="960766c" make deploy
 # By release
-VERSION="0.1.2" make deploy
+OPERATOR_VERSION="0.1.2" make deploy
 ```
 
 It is recommended to switch to the corresponding release Git tag before deploying an old version to make sure the underlying components refer to the correct versions.
+
+When `OPERATOR_VERSION` is not provided, it defaults to the latest released version.
+
+To deploy all components on their `main` image tag (which correspond to their `main` branches, ie. their latest builds), you can simply run:
+
+```bash
+make deploy-latest
+```
 
 ## Installing Kafka
 

--- a/Makefile
+++ b/Makefile
@@ -276,6 +276,10 @@ uninstall: kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube
 
 deploy: kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/openshift | kubectl apply -f -
+
+deploy-latest: kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMAGE_TAG_BASE):main
 	$(SED) -i -r 's~ebpf-agent:.+~ebpf-agent:main~' ./config/manager/manager.yaml
 	$(SED) -i -r 's~flowlogs-pipeline:.+~flowlogs-pipeline:main~' ./config/manager/manager.yaml
 	$(SED) -i -r 's~console-plugin:.+~console-plugin:main~' ./config/manager/manager.yaml

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,11 @@ export FLP_VERSION ?= v0.1.8
 export BPF_VERSION ?= v0.3.0
 
 # Allows building bundles in Mac replacing BSD 'sed' command by GNU-compatible 'gsed'
+ifeq (,$(shell which gsed 2>/dev/null))
 SED ?= sed
+else
+SED ?= gsed
+endif
 
 # Port-forward (for loki/grafana deployments)
 PORT_FWD ?= true
@@ -278,7 +282,7 @@ deploy: kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/c
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/openshift | kubectl apply -f -
 
-deploy-latest: kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy-latest: kustomize ## Deploy latest controller, configured with all latest related images using "main" tag
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMAGE_TAG_BASE):main
 	$(SED) -i -r 's~ebpf-agent:.+~ebpf-agent:main~' ./config/manager/manager.yaml
 	$(SED) -i -r 's~flowlogs-pipeline:.+~flowlogs-pipeline:main~' ./config/manager/manager.yaml


### PR DESCRIPTION
In https://github.com/netobserv/network-observability-operator/pull/274 the way IMG is used is changed, which broke deploying all latest components

This patch introduces a new "deploy-latest" target to explicitly deploy all components on their `main` branches