### PR TITLE
NETOBSERV-736: Added downstream deployment configuration for monitoring collection

### DIFF
--- a/.mk/development.mk
+++ b/.mk/development.mk
@@ -64,7 +64,7 @@ deploy-kafka-tls:
 	kubectl create namespace $(NAMESPACE)  --dry-run=client -o yaml | kubectl apply -f -
 	kubectl apply -f "https://strimzi.io/install/latest?namespace="$(NAMESPACE) -n $(NAMESPACE)
 	kubectl apply -f "https://raw.githubusercontent.com/netobserv/documents/main/examples/kafka/metrics-config.yaml" -n $(NAMESPACE)
-	curl -s -L "https://raw.githubusercontent.com/netobserv/documents/main/examples/kafka/tls.yaml" | envsubst | kubectl apply -n $(NAMESPACE) -f - 
+	curl -s -L "https://raw.githubusercontent.com/netobserv/documents/main/examples/kafka/tls.yaml" | envsubst | kubectl apply -n $(NAMESPACE) -f -
 	@echo -e "\n==>Using storage class ${DEFAULT_SC}"
 	kubectl apply -f "https://raw.githubusercontent.com/netobserv/documents/main/examples/kafka/topic.yaml" -n $(NAMESPACE)
 	kubectl apply -f "https://raw.githubusercontent.com/netobserv/documents/main/examples/kafka/user.yaml" -n $(NAMESPACE)
@@ -164,3 +164,10 @@ set-plugin-image:
 	kubectl wait -n $(NAMESPACE) --timeout=60s --for condition=Available=True deployment netobserv-controller-manager
 	kubectl rollout status -n $(NAMESPACE) --timeout=60s deployment netobserv-plugin
 	kubectl wait -n $(NAMESPACE) --timeout=60s --for condition=Available=True deployment netobserv-plugin
+
+.PHONY: set-release-kind-downstream
+set-release-kind-downstream:
+	kubectl  -n $(NAMESPACE) set env deployment netobserv-controller-manager -c "manager" DOWNSTREAM_DEPLOYMENT=true
+	@echo -e "\n==> Redeploying..."
+	kubectl rollout status -n $(NAMESPACE) --timeout=60s deployment netobserv-controller-manager
+	kubectl wait -n $(NAMESPACE) --timeout=60s --for condition=Available=True deployment netobserv-controller-manager

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -176,3 +176,13 @@ cd hack
 
 The metrics will be visible in the Openshift console under the tab `Observe -> Metrics.`
 Look for the metrics that begin with `netobserv_.`
+
+## Simulating a downstream deployment
+
+To configure the operator to run as a downstream deployment run this command:
+
+```
+make set-release-kind-downstream
+```
+
+Most notably change will concern the monitoring part which will use the platoform monitoring stack instead of the user workload monitoring stack.

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -509,9 +509,8 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - nodes
-          - pods
-          - services
+          - endpoints
+          - secrets
           verbs:
           - get
           - list
@@ -519,7 +518,9 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - secrets
+          - nodes
+          - pods
+          - services
           verbs:
           - get
           - list
@@ -576,6 +577,7 @@ spec:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings
+          - rolebindings
           verbs:
           - create
           - delete
@@ -587,6 +589,7 @@ spec:
           - rbac.authorization.k8s.io
           resources:
           - clusterroles
+          - roles
           verbs:
           - create
           - delete
@@ -649,6 +652,7 @@ spec:
                 - --ebpf-agent-image=$(RELATED_IMAGE_EBPF_AGENT)
                 - --flowlogs-pipeline-image=$(RELATED_IMAGE_FLOWLOGS_PIPELINE)
                 - --console-plugin-image=$(RELATED_IMAGE_CONSOLE_PLUGIN)
+                - --downstream-deployment=$(DOWNSTREAM_DEPLOYMENT)
                 command:
                 - /manager
                 env:
@@ -658,6 +662,8 @@ spec:
                   value: quay.io/netobserv/flowlogs-pipeline:v0.1.8
                 - name: RELATED_IMAGE_CONSOLE_PLUGIN
                   value: quay.io/netobserv/network-observability-console-plugin:v0.1.9
+                - name: DOWNSTREAM_DEPLOYMENT
+                  value: "false"
                 image: quay.io/netobserv/network-observability-operator:1.0.2
                 imagePullPolicy: Always
                 livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,7 @@ spec:
         - --ebpf-agent-image=$(RELATED_IMAGE_EBPF_AGENT)
         - --flowlogs-pipeline-image=$(RELATED_IMAGE_FLOWLOGS_PIPELINE)
         - --console-plugin-image=$(RELATED_IMAGE_CONSOLE_PLUGIN)
+        - --downstream-deployment=$(DOWNSTREAM_DEPLOYMENT)
         env:
           - name: RELATED_IMAGE_EBPF_AGENT
             value: quay.io/netobserv/netobserv-ebpf-agent:v0.3.0
@@ -34,6 +35,8 @@ spec:
             value: quay.io/netobserv/flowlogs-pipeline:v0.1.8
           - name: RELATED_IMAGE_CONSOLE_PLUGIN
             value: quay.io/netobserv/network-observability-console-plugin:v0.1.9
+          - name: DOWNSTREAM_DEPLOYMENT
+            value: "false"
         image: controller:latest
         name: manager
         imagePullPolicy: Always

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -83,9 +83,8 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
-  - pods
-  - services
+  - endpoints
+  - secrets
   verbs:
   - get
   - list
@@ -93,7 +92,9 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
+  - nodes
+  - pods
+  - services
   verbs:
   - get
   - list
@@ -150,6 +151,7 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
+  - rolebindings
   verbs:
   - create
   - delete
@@ -161,6 +163,7 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterroles
+  - roles
   verbs:
   - create
   - delete

--- a/controllers/flowcollector_objects.go
+++ b/controllers/flowcollector_objects.go
@@ -1,14 +1,63 @@
 package controllers
 
 import (
+	"github.com/netobserv/network-observability-operator/controllers/constants"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func buildNamespace(ns string) *corev1.Namespace {
+const (
+	downstreamLabelKey       = "openshift.io/cluster-monitoring"
+	downstreamLabelValue     = "true"
+	roleSuffix               = "-metrics-reader"
+	monitoringServiceAccount = "prometheus-k8s"
+	monitoringNamespace      = "openshift-monitoring"
+)
+
+func buildNamespace(ns string, isDownstream bool) *corev1.Namespace {
+	labels := map[string]string{}
+	if isDownstream {
+		labels[downstreamLabelKey] = downstreamLabelValue
+	}
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: ns,
+			Name:   ns,
+			Labels: labels,
 		},
+	}
+}
+
+func buildRoleMonitoringReader(ns string) *rbacv1.Role {
+	cr := rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.OperatorName + roleSuffix,
+			Namespace: ns,
+		},
+		Rules: []rbacv1.PolicyRule{{APIGroups: []string{""},
+			Verbs:     []string{"get", "list", "watch"},
+			Resources: []string{"pods", "services", "endpoints"},
+		},
+		},
+	}
+	return &cr
+}
+
+func buildRoleBindingMonitoringReader(ns string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.OperatorName + roleSuffix,
+			Namespace: ns,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     constants.OperatorName + roleSuffix,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      monitoringServiceAccount,
+			Namespace: monitoringNamespace,
+		}},
 	}
 }

--- a/controllers/operator/config.go
+++ b/controllers/operator/config.go
@@ -10,6 +10,8 @@ type Config struct {
 	FlowlogsPipelineImage string
 	// ConsolePluginImage is the image of the Console Plugin that is managed by the operator
 	ConsolePluginImage string
+	// Release kind is either upstream or downstream
+	DownstreamDeployment bool
 }
 
 func (cfg *Config) Validate() error {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -167,6 +167,7 @@ func NewTestFlowCollectorReconciler(client client.Client, scheme *runtime.Scheme
 			EBPFAgentImage:        "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-ebpf-agent@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
 			FlowlogsPipelineImage: "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-flowlogs-pipeline@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
 			ConsolePluginImage:    "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-console-plugin@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
+			DownstreamDeployment:  false,
 		},
 	}
 }

--- a/main.go
+++ b/main.go
@@ -91,6 +91,7 @@ func main() {
 	flag.StringVar(&config.EBPFAgentImage, "ebpf-agent-image", "quay.io/netobserv/netobserv-ebpf-agent:main", "The image of the eBPF agent")
 	flag.StringVar(&config.FlowlogsPipelineImage, "flowlogs-pipeline-image", "quay.io/netobserv/flowlogs-pipeline:main", "The image of Flowlogs Pipeline")
 	flag.StringVar(&config.ConsolePluginImage, "console-plugin-image", "quay.io/netobserv/network-observability-console-plugin:main", "The image of the Console Plugin")
+	flag.BoolVar(&config.DownstreamDeployment, "downstream-deployment", false, "Either this deployment is a downstream deployment ot not")
 	flag.BoolVar(&versionFlag, "v", false, "print version")
 	opts := zap.Options{
 		Development: true,


### PR DESCRIPTION
Add downstream configuration boolean.

To override this boolean run: `make set-release-kind-downstream`

This PR does not change the HTTPS config for the operator metrics endpoint but I did not want to overload the PR, I will do another PR about it.