### PR TITLE
NETOBSERV-773 Copy certificates across namespaces

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -608,6 +608,11 @@ type CertificateReference struct {
 	// name of the config map or secret containing certificates
 	Name string `json:"name,omitempty"`
 
+	// namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed.
+	// If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
+
 	// certFile defines the path to the certificate file name within the config map or secret
 	CertFile string `json:"certFile,omitempty"`
 

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -1014,6 +1014,14 @@ spec:
                                   description: name of the config map or secret containing
                                     certificates
                                   type: string
+                                namespace:
+                                  description: namespace of the config map or secret
+                                    containing certificates. If omitted, assumes same
+                                    namespace as where NetObserv is deployed. If the
+                                    namespace is different, the config map or the
+                                    secret will be copied so that it can be mounted
+                                    as required.
+                                  type: string
                                 type:
                                   description: 'type for the certificate reference:
                                     "configmap" or "secret"'
@@ -1049,6 +1057,14 @@ spec:
                                 name:
                                   description: name of the config map or secret containing
                                     certificates
+                                  type: string
+                                namespace:
+                                  description: namespace of the config map or secret
+                                    containing certificates. If omitted, assumes same
+                                    namespace as where NetObserv is deployed. If the
+                                    namespace is different, the config map or the
+                                    secret will be copied so that it can be mounted
+                                    as required.
                                   type: string
                                 type:
                                   description: 'type for the certificate reference:
@@ -1110,6 +1126,13 @@ spec:
                             description: name of the config map or secret containing
                               certificates
                             type: string
+                          namespace:
+                            description: namespace of the config map or secret containing
+                              certificates. If omitted, assumes same namespace as
+                              where NetObserv is deployed. If the namespace is different,
+                              the config map or the secret will be copied so that
+                              it can be mounted as required.
+                            type: string
                           type:
                             description: 'type for the certificate reference: "configmap"
                               or "secret"'
@@ -1145,6 +1168,13 @@ spec:
                           name:
                             description: name of the config map or secret containing
                               certificates
+                            type: string
+                          namespace:
+                            description: namespace of the config map or secret containing
+                              certificates. If omitted, assumes same namespace as
+                              where NetObserv is deployed. If the namespace is different,
+                              the config map or the secret will be copied so that
+                              it can be mounted as required.
                             type: string
                           type:
                             description: 'type for the certificate reference: "configmap"
@@ -1264,6 +1294,13 @@ spec:
                             description: name of the config map or secret containing
                               certificates
                             type: string
+                          namespace:
+                            description: namespace of the config map or secret containing
+                              certificates. If omitted, assumes same namespace as
+                              where NetObserv is deployed. If the namespace is different,
+                              the config map or the secret will be copied so that
+                              it can be mounted as required.
+                            type: string
                           type:
                             description: 'type for the certificate reference: "configmap"
                               or "secret"'
@@ -1299,6 +1336,13 @@ spec:
                           name:
                             description: name of the config map or secret containing
                               certificates
+                            type: string
+                          namespace:
+                            description: namespace of the config map or secret containing
+                              certificates. If omitted, assumes same namespace as
+                              where NetObserv is deployed. If the namespace is different,
+                              the config map or the secret will be copied so that
+                              it can be mounted as required.
                             type: string
                           type:
                             description: 'type for the certificate reference: "configmap"
@@ -1977,6 +2021,14 @@ spec:
                                   name:
                                     description: name of the config map or secret
                                       containing certificates
+                                    type: string
+                                  namespace:
+                                    description: namespace of the config map or secret
+                                      containing certificates. If omitted, assumes
+                                      same namespace as where NetObserv is deployed.
+                                      If the namespace is different, the config map
+                                      or the secret will be copied so that it can
+                                      be mounted as required.
                                     type: string
                                   type:
                                     description: 'type for the certificate reference:

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -1012,6 +1012,14 @@ spec:
                                   description: name of the config map or secret containing
                                     certificates
                                   type: string
+                                namespace:
+                                  description: namespace of the config map or secret
+                                    containing certificates. If omitted, assumes same
+                                    namespace as where NetObserv is deployed. If the
+                                    namespace is different, the config map or the
+                                    secret will be copied so that it can be mounted
+                                    as required.
+                                  type: string
                                 type:
                                   description: 'type for the certificate reference:
                                     "configmap" or "secret"'
@@ -1047,6 +1055,14 @@ spec:
                                 name:
                                   description: name of the config map or secret containing
                                     certificates
+                                  type: string
+                                namespace:
+                                  description: namespace of the config map or secret
+                                    containing certificates. If omitted, assumes same
+                                    namespace as where NetObserv is deployed. If the
+                                    namespace is different, the config map or the
+                                    secret will be copied so that it can be mounted
+                                    as required.
                                   type: string
                                 type:
                                   description: 'type for the certificate reference:
@@ -1108,6 +1124,13 @@ spec:
                             description: name of the config map or secret containing
                               certificates
                             type: string
+                          namespace:
+                            description: namespace of the config map or secret containing
+                              certificates. If omitted, assumes same namespace as
+                              where NetObserv is deployed. If the namespace is different,
+                              the config map or the secret will be copied so that
+                              it can be mounted as required.
+                            type: string
                           type:
                             description: 'type for the certificate reference: "configmap"
                               or "secret"'
@@ -1143,6 +1166,13 @@ spec:
                           name:
                             description: name of the config map or secret containing
                               certificates
+                            type: string
+                          namespace:
+                            description: namespace of the config map or secret containing
+                              certificates. If omitted, assumes same namespace as
+                              where NetObserv is deployed. If the namespace is different,
+                              the config map or the secret will be copied so that
+                              it can be mounted as required.
                             type: string
                           type:
                             description: 'type for the certificate reference: "configmap"
@@ -1262,6 +1292,13 @@ spec:
                             description: name of the config map or secret containing
                               certificates
                             type: string
+                          namespace:
+                            description: namespace of the config map or secret containing
+                              certificates. If omitted, assumes same namespace as
+                              where NetObserv is deployed. If the namespace is different,
+                              the config map or the secret will be copied so that
+                              it can be mounted as required.
+                            type: string
                           type:
                             description: 'type for the certificate reference: "configmap"
                               or "secret"'
@@ -1297,6 +1334,13 @@ spec:
                           name:
                             description: name of the config map or secret containing
                               certificates
+                            type: string
+                          namespace:
+                            description: namespace of the config map or secret containing
+                              certificates. If omitted, assumes same namespace as
+                              where NetObserv is deployed. If the namespace is different,
+                              the config map or the secret will be copied so that
+                              it can be mounted as required.
                             type: string
                           type:
                             description: 'type for the certificate reference: "configmap"
@@ -1975,6 +2019,14 @@ spec:
                                   name:
                                     description: name of the config map or secret
                                       containing certificates
+                                    type: string
+                                  namespace:
+                                    description: namespace of the config map or secret
+                                      containing certificates. If omitted, assumes
+                                      same namespace as where NetObserv is deployed.
+                                      If the namespace is different, the config map
+                                      or the secret will be copied so that it can
+                                      be mounted as required.
                                     type: string
                                   type:
                                     description: 'type for the certificate reference:

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -218,7 +218,7 @@ func (b *builder) podTemplate(cmDigest string) *corev1.PodTemplateSpec {
 
 	args := buildArgs(b.desired, b.desiredLoki)
 	if b.desiredLoki != nil && b.desiredLoki.TLS.Enable && !b.desiredLoki.TLS.InsecureSkipVerify {
-		volumes, volumeMounts = helper.AppendCertVolumes(volumes, volumeMounts, &b.desiredLoki.TLS, lokiCerts, b.cWatcher)
+		volumes, volumeMounts = helper.AppendCertVolumes(volumes, volumeMounts, &b.desiredLoki.TLS, lokiCerts, b.cWatcher.SetWatchedCertificate)
 	}
 
 	if b.desiredLoki.UseHostToken() {

--- a/controllers/ebpf/internal/permissions/permissions.go
+++ b/controllers/ebpf/internal/permissions/permissions.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/netobserv/network-observability-operator/api/v1alpha1"
 	"github.com/netobserv/network-observability-operator/controllers/constants"
-	"github.com/netobserv/network-observability-operator/controllers/reconcilers"
 	"github.com/netobserv/network-observability-operator/pkg/discover"
 	"github.com/netobserv/network-observability-operator/pkg/helper"
 	osv1 "github.com/openshift/api/security/v1"
@@ -27,14 +26,14 @@ var AllowedCapabilities = []v1.Capability{"BPF", "PERFMON", "NET_ADMIN", "SYS_RE
 // - Create netobserv-ebpf-agent service account in the privileged namespace
 // - For Openshift, apply the required SecurityContextConstraints for privileged Pod operation
 type Reconciler struct {
-	client                      reconcilers.ClientHelper
+	client                      helper.ClientHelper
 	privilegedNamespace         string
 	previousPrivilegedNamespace string
 	vendor                      *discover.Permissions
 }
 
 func NewReconciler(
-	client reconcilers.ClientHelper,
+	client helper.ClientHelper,
 	privilegedNamespace string,
 	previousPrivilegedNamespace string,
 	permissionsVendor *discover.Permissions,

--- a/controllers/flowlogspipeline/flp_common_objects.go
+++ b/controllers/flowlogspipeline/flp_common_objects.go
@@ -170,12 +170,12 @@ func (b *builder) podTemplate(hasHostPort, hasLokiInterface, hostNetwork bool, c
 	}}
 
 	if b.desired.UseKafka() && b.desired.Kafka.TLS.Enable {
-		volumes, volumeMounts = helper.AppendCertVolumes(volumes, volumeMounts, &b.desired.Kafka.TLS, kafkaCerts, b.cWatcher)
+		volumes, volumeMounts = helper.AppendCertVolumes(volumes, volumeMounts, &b.desired.Kafka.TLS, kafkaCerts, b.cWatcher.SetWatchedCertificate)
 	}
 
 	if hasLokiInterface {
 		if b.desired.Loki.TLS.Enable && !b.desired.Loki.TLS.InsecureSkipVerify {
-			volumes, volumeMounts = helper.AppendCertVolumes(volumes, volumeMounts, &b.desired.Loki.TLS, lokiCerts, b.cWatcher)
+			volumes, volumeMounts = helper.AppendCertVolumes(volumes, volumeMounts, &b.desired.Loki.TLS, lokiCerts, b.cWatcher.SetWatchedCertificate)
 		}
 		if b.desired.Loki.UseHostToken() || b.desired.Loki.ForwardUserToken() {
 			volumes, volumeMounts = helper.AppendTokenVolume(volumes, volumeMounts, lokiToken, constants.FLPName)
@@ -183,7 +183,7 @@ func (b *builder) podTemplate(hasHostPort, hasLokiInterface, hostNetwork bool, c
 	}
 
 	if b.desired.Processor.Metrics.Server.TLS.Type != flowsv1alpha1.ServerTLSDisabled {
-		volumes, volumeMounts = helper.AppendSingleCertVolumes(volumes, volumeMounts, b.promTLS, promCerts, b.cWatcher)
+		volumes, volumeMounts = helper.AppendSingleCertVolumes(volumes, volumeMounts, b.promTLS, promCerts, b.cWatcher.SetWatchedCertificate)
 	}
 
 	var envs []corev1.EnvVar

--- a/controllers/flowlogspipeline/flp_ingest_reconciler.go
+++ b/controllers/flowlogspipeline/flp_ingest_reconciler.go
@@ -138,7 +138,7 @@ func (r *flpIngesterReconciler) reconcilePrometheusService(ctx context.Context, 
 
 func (r *flpIngesterReconciler) reconcileDaemonSet(ctx context.Context, desiredDS *appsv1.DaemonSet) error {
 	// Annotate pod with certificate reference so that it is reloaded if modified
-	if err := r.CertWatcher.AnnotatePod(ctx, r.Client, &desiredDS.Spec.Template, lokiCerts, kafkaCerts); err != nil {
+	if err := r.CertWatcher.PrepareForPod(ctx, r.ClientHelper, &desiredDS.Spec.Template, r.nobjMngr.Namespace, lokiCerts, kafkaCerts); err != nil {
 		return err
 	}
 	if !r.nobjMngr.Exists(r.owned.daemonSet) {

--- a/controllers/flowlogspipeline/flp_monolith_reconciler.go
+++ b/controllers/flowlogspipeline/flp_monolith_reconciler.go
@@ -140,7 +140,7 @@ func (r *flpMonolithReconciler) reconcilePrometheusService(ctx context.Context, 
 
 func (r *flpMonolithReconciler) reconcileDaemonSet(ctx context.Context, desiredDS *appsv1.DaemonSet) error {
 	// Annotate pod with certificate reference so that it is reloaded if modified
-	if err := r.CertWatcher.AnnotatePod(ctx, r.Client, &desiredDS.Spec.Template, lokiCerts, kafkaCerts); err != nil {
+	if err := r.CertWatcher.PrepareForPod(ctx, r.ClientHelper, &desiredDS.Spec.Template, r.nobjMngr.Namespace, lokiCerts, kafkaCerts); err != nil {
 		return err
 	}
 	if !r.nobjMngr.Exists(r.owned.daemonSet) {

--- a/controllers/flowlogspipeline/flp_reconciler.go
+++ b/controllers/flowlogspipeline/flp_reconciler.go
@@ -27,18 +27,18 @@ type singleReconciler interface {
 }
 
 type reconcilersCommonInfo struct {
-	reconcilers.ClientHelper
+	reconcilers.Common
 	nobjMngr        *reconcilers.NamespacedObjectManager
 	useOpenShiftSCC bool
 	image           string
 	availableAPIs   *discover.AvailableAPIs
 }
 
-func createCommonInfo(ctx context.Context, cl reconcilers.ClientHelper, ns, prevNS, image string, permissionsVendor *discover.Permissions, availableAPIs *discover.AvailableAPIs) *reconcilersCommonInfo {
-	nobjMngr := reconcilers.NewNamespacedObjectManager(cl, ns, prevNS)
+func createCommonInfo(ctx context.Context, cmn reconcilers.Common, ns, prevNS, image string, permissionsVendor *discover.Permissions, availableAPIs *discover.AvailableAPIs) *reconcilersCommonInfo {
+	nobjMngr := reconcilers.NewNamespacedObjectManager(cmn, ns, prevNS)
 	openshift := permissionsVendor.Vendor(ctx) == discover.VendorOpenShift
 	return &reconcilersCommonInfo{
-		ClientHelper:    cl,
+		Common:          cmn,
 		nobjMngr:        nobjMngr,
 		useOpenShiftSCC: openshift,
 		image:           image,
@@ -46,12 +46,12 @@ func createCommonInfo(ctx context.Context, cl reconcilers.ClientHelper, ns, prev
 	}
 }
 
-func NewReconciler(ctx context.Context, cl reconcilers.ClientHelper, ns, prevNS, image string, permissionsVendor *discover.Permissions, availableAPIs *discover.AvailableAPIs) FLPReconciler {
+func NewReconciler(ctx context.Context, cmn reconcilers.Common, ns, prevNS, image string, permissionsVendor *discover.Permissions, availableAPIs *discover.AvailableAPIs) FLPReconciler {
 	return FLPReconciler{
 		reconcilers: []singleReconciler{
-			newMonolithReconciler(createCommonInfo(ctx, cl, ns, prevNS, image, permissionsVendor, availableAPIs)),
-			newTransformerReconciler(createCommonInfo(ctx, cl, ns, prevNS, image, permissionsVendor, availableAPIs)),
-			newIngesterReconciler(createCommonInfo(ctx, cl, ns, prevNS, image, permissionsVendor, availableAPIs)),
+			newMonolithReconciler(createCommonInfo(ctx, cmn, ns, prevNS, image, permissionsVendor, availableAPIs)),
+			newTransformerReconciler(createCommonInfo(ctx, cmn, ns, prevNS, image, permissionsVendor, availableAPIs)),
+			newIngesterReconciler(createCommonInfo(ctx, cmn, ns, prevNS, image, permissionsVendor, availableAPIs)),
 		},
 	}
 }

--- a/controllers/flowlogspipeline/flp_transfo_reconciler.go
+++ b/controllers/flowlogspipeline/flp_transfo_reconciler.go
@@ -124,7 +124,7 @@ func (r *flpTransformerReconciler) reconcileDeployment(ctx context.Context, desi
 	new := builder.deployment(configDigest)
 
 	// Annotate pod with certificate reference so that it is reloaded if modified
-	if err := r.CertWatcher.AnnotatePod(ctx, r.Client, &new.Spec.Template, lokiCerts, kafkaCerts); err != nil {
+	if err := r.CertWatcher.PrepareForPod(ctx, r.ClientHelper, &new.Spec.Template, r.nobjMngr.Namespace, lokiCerts, kafkaCerts); err != nil {
 		return err
 	}
 

--- a/controllers/ovs/flowsconfig_ovnk_reconciler.go
+++ b/controllers/ovs/flowsconfig_ovnk_reconciler.go
@@ -19,15 +19,15 @@ import (
 )
 
 type FlowsConfigOVNKController struct {
+	reconcilers.Common
 	namespace string
 	config    flowsv1alpha1.OVNKubernetesConfig
-	client    reconcilers.ClientHelper
 	lookupIP  func(string) ([]net.IP, error)
 }
 
-func NewFlowsConfigOVNKController(client reconcilers.ClientHelper, namespace string, config flowsv1alpha1.OVNKubernetesConfig, lookupIP func(string) ([]net.IP, error)) *FlowsConfigOVNKController {
+func NewFlowsConfigOVNKController(cmn reconcilers.Common, namespace string, config flowsv1alpha1.OVNKubernetesConfig, lookupIP func(string) ([]net.IP, error)) *FlowsConfigOVNKController {
 	return &FlowsConfigOVNKController{
-		client:    client,
+		Common:    cmn,
 		namespace: namespace,
 		config:    config,
 		lookupIP:  lookupIP,
@@ -68,7 +68,7 @@ func (c *FlowsConfigOVNKController) updateEnv(ctx context.Context, target *flows
 	}
 	if anyUpdate {
 		rlog.Info("Provided IPFIX configuration differs current configuration. Updating")
-		return c.client.Update(ctx, ds)
+		return c.Client.Update(ctx, ds)
 	}
 
 	rlog.Info("No changes needed")
@@ -77,7 +77,7 @@ func (c *FlowsConfigOVNKController) updateEnv(ctx context.Context, target *flows
 
 func (c *FlowsConfigOVNKController) getDaemonSet(ctx context.Context) (*appsv1.DaemonSet, error) {
 	curr := &appsv1.DaemonSet{}
-	if err := c.client.Get(ctx, types.NamespacedName{
+	if err := c.Client.Get(ctx, types.NamespacedName{
 		Name:      c.config.DaemonSetName,
 		Namespace: c.config.Namespace,
 	}, curr); err != nil {

--- a/controllers/reconcilers/common.go
+++ b/controllers/reconcilers/common.go
@@ -1,0 +1,11 @@
+package reconcilers
+
+import (
+	"github.com/netobserv/network-observability-operator/pkg/helper"
+	"github.com/netobserv/network-observability-operator/pkg/watchers"
+)
+
+type Common struct {
+	helper.ClientHelper
+	CertWatcher *watchers.CertificatesWatcher
+}

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -1830,6 +1830,13 @@ caCert defines the reference of the certificate for the Certificate Authority
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>namespace</b></td>
+        <td>string</td>
+        <td>
+          namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
         <td>
@@ -1877,6 +1884,13 @@ userCert defines the user certificate reference, used for mTLS (you can ignore i
         <td>string</td>
         <td>
           name of the config map or secret containing certificates<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>namespace</b></td>
+        <td>string</td>
+        <td>
+          namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2027,6 +2041,13 @@ caCert defines the reference of the certificate for the Certificate Authority
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>namespace</b></td>
+        <td>string</td>
+        <td>
+          namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
         <td>
@@ -2074,6 +2095,13 @@ userCert defines the user certificate reference, used for mTLS (you can ignore i
         <td>string</td>
         <td>
           name of the config map or secret containing certificates<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>namespace</b></td>
+        <td>string</td>
+        <td>
+          namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2315,6 +2343,13 @@ caCert defines the reference of the certificate for the Certificate Authority
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>namespace</b></td>
+        <td>string</td>
+        <td>
+          namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
         <td>
@@ -2362,6 +2397,13 @@ userCert defines the user certificate reference, used for mTLS (you can ignore i
         <td>string</td>
         <td>
           name of the config map or secret containing certificates<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>namespace</b></td>
+        <td>string</td>
+        <td>
+          namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -3623,6 +3665,13 @@ TLS configuration.
         <td>string</td>
         <td>
           name of the config map or secret containing certificates<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>namespace</b></td>
+        <td>string</td>
+        <td>
+          namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/helper/client_helper.go
+++ b/pkg/helper/client_helper.go
@@ -1,12 +1,10 @@
-package reconcilers
+package helper
 
 import (
 	"context"
 	"fmt"
 	"reflect"
 
-	"github.com/netobserv/network-observability-operator/pkg/helper"
-	"github.com/netobserv/network-observability-operator/pkg/watchers"
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -21,7 +19,6 @@ type ClientHelper struct {
 	SetControllerReference func(client.Object) error
 	changed                bool
 	deplInProgress         bool
-	CertWatcher            *watchers.CertificatesWatcher
 }
 
 // CreateOwned is an helper function that creates an object, sets owner reference and writes info & errors logs
@@ -93,7 +90,7 @@ func (c *ClientHelper) ReconcileClusterRoleBinding(ctx context.Context, desired 
 		}
 		return fmt.Errorf("can't reconcile ClusterRoleBinding %s: %w", desired.Name, err)
 	}
-	if helper.IsSubSet(actual.Labels, desired.Labels) &&
+	if IsSubSet(actual.Labels, desired.Labels) &&
 		actual.RoleRef == desired.RoleRef &&
 		reflect.DeepEqual(actual.Subjects, desired.Subjects) {
 		if actual.RoleRef != desired.RoleRef {
@@ -121,7 +118,7 @@ func (c *ClientHelper) ReconcileClusterRole(ctx context.Context, desired *rbacv1
 		return fmt.Errorf("can't reconcile ClusterRole %s: %w", desired.Name, err)
 	}
 
-	if helper.IsSubSet(actual.Labels, desired.Labels) &&
+	if IsSubSet(actual.Labels, desired.Labels) &&
 		reflect.DeepEqual(actual.Rules, desired.Rules) {
 		// cluster role already reconciled. Exiting
 		return nil

--- a/pkg/watchers/certificates_watcher.go
+++ b/pkg/watchers/certificates_watcher.go
@@ -2,23 +2,27 @@ package watchers
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/netobserv/network-observability-operator/api/v1alpha1"
 	"github.com/netobserv/network-observability-operator/controllers/constants"
+	"github.com/netobserv/network-observability-operator/pkg/helper"
 )
 
 type CertificatesWatcher struct {
-	watched   map[string]watchedObject
-	namespace string
+	watched          map[string]watchedObject
+	defaultNamespace string
 }
 
 func NewCertificatesWatcher() CertificatesWatcher {
@@ -56,15 +60,19 @@ func RegisterCertificatesWatcher(builder *builder.Builder) *CertificatesWatcher 
 }
 
 func (w *CertificatesWatcher) Reset(namespace string) {
-	w.namespace = namespace
+	w.defaultNamespace = namespace
 	w.watched = make(map[string]watchedObject)
 }
 
 func (w *CertificatesWatcher) SetWatchedCertificate(key string, ref *v1alpha1.CertificateReference) {
+	ns := ref.Namespace
+	if ns == "" {
+		ns = w.defaultNamespace
+	}
 	w.watched[key] = watchedObject{
 		nsName: types.NamespacedName{
 			Name:      ref.Name,
-			Namespace: w.namespace,
+			Namespace: ns,
 		},
 		kind: ref.Type,
 	}
@@ -79,39 +87,111 @@ func (w *CertificatesWatcher) isWatched(kind string, o client.Object) bool {
 	return false
 }
 
-func (w *CertificatesWatcher) AnnotatePod(ctx context.Context, cl client.Client, pod *corev1.PodTemplateSpec, keyPrefixes ...string) error {
+func (w *CertificatesWatcher) PrepareForPod(ctx context.Context, cl helper.ClientHelper, pod *corev1.PodTemplateSpec, namespace string, keyPrefixes ...string) error {
 	for _, keyPrefix := range keyPrefixes {
 		caName := constants.CertCAName(keyPrefix)
-		if err := w.AnnotatePodSingleVolume(ctx, cl, pod, caName); err != nil {
+		if err := w.PrepareForPodSingleVolume(ctx, cl, pod, namespace, caName); err != nil {
 			return err
 		}
 		userName := constants.CertUserName(keyPrefix)
-		if err := w.AnnotatePodSingleVolume(ctx, cl, pod, userName); err != nil {
+		if err := w.PrepareForPodSingleVolume(ctx, cl, pod, namespace, userName); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (w *CertificatesWatcher) AnnotatePodSingleVolume(ctx context.Context, cl client.Client, pod *corev1.PodTemplateSpec, key string) error {
+func (w *CertificatesWatcher) PrepareForPodSingleVolume(ctx context.Context, cl helper.ClientHelper, pod *corev1.PodTemplateSpec, namespace string, key string) error {
 	if watched, ok := w.watched[key]; ok {
-		var sourceMeta *metav1.ObjectMeta
+		var idRev string
+		var err error
 		if watched.kind == v1alpha1.CertRefTypeConfigMap {
-			var cm corev1.ConfigMap
-			err := cl.Get(ctx, watched.nsName, &cm)
-			if err != nil {
-				return err
-			}
-			sourceMeta = &cm.ObjectMeta
+			idRev, err = reconcileConfigMap(ctx, cl, watched.nsName.Name, watched.nsName.Namespace, namespace)
 		} else {
-			var s corev1.Secret
-			err := cl.Get(ctx, watched.nsName, &s)
-			if err != nil {
-				return err
-			}
-			sourceMeta = &s.ObjectMeta
+			idRev, err = reconcileSecret(ctx, cl, watched.nsName.Name, watched.nsName.Namespace, namespace)
 		}
-		pod.Annotations[constants.PodCertIDSuffix+key] = string(sourceMeta.GetUID()) + "/" + sourceMeta.GetResourceVersion()
+		if err != nil {
+			return err
+		}
+		pod.Annotations[constants.PodCertIDSuffix+key] = idRev
 	}
 	return nil
+}
+
+func reconcileConfigMap(ctx context.Context, cl helper.ClientHelper, name, sourceNamespace, destNamespace string) (string, error) {
+	rlog := log.FromContext(ctx, "Name", name, "Source namespace", sourceNamespace, "Target namespace", destNamespace)
+
+	var cm corev1.ConfigMap
+	err := cl.Get(ctx, types.NamespacedName{Name: name, Namespace: sourceNamespace}, &cm)
+	if err != nil {
+		return "", err
+	}
+	idRev := getIDRev(&cm.ObjectMeta)
+	if sourceNamespace != destNamespace {
+		// copy to namespace
+		var cmTarget corev1.ConfigMap
+		err := cl.Get(ctx, types.NamespacedName{Name: name, Namespace: destNamespace}, &cmTarget)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return "", err
+			}
+			rlog.Info(fmt.Sprintf("creating configmap %s in namespace %s", name, destNamespace))
+			cm.ObjectMeta = metav1.ObjectMeta{
+				Name:      name,
+				Namespace: destNamespace,
+			}
+			if err := cl.CreateOwned(ctx, &cm); err != nil {
+				return "", err
+			}
+		} else {
+			// Update existing
+			rlog.Info(fmt.Sprintf("updating configmap %s in namespace %s", name, destNamespace))
+			cmTarget.Data = cm.Data
+			if err := cl.UpdateOwned(ctx, &cmTarget, &cmTarget); err != nil {
+				return "", err
+			}
+		}
+	}
+	return idRev, nil
+}
+
+func reconcileSecret(ctx context.Context, cl helper.ClientHelper, name, sourceNamespace, destNamespace string) (string, error) {
+	rlog := log.FromContext(ctx, "Name", name, "Source namespace", sourceNamespace, "Target namespace", destNamespace)
+
+	var s corev1.Secret
+	err := cl.Get(ctx, types.NamespacedName{Name: name, Namespace: sourceNamespace}, &s)
+	if err != nil {
+		return "", err
+	}
+	idRev := getIDRev(&s.ObjectMeta)
+	if sourceNamespace != destNamespace {
+		// copy to namespace
+		var sTarget corev1.Secret
+		err := cl.Get(ctx, types.NamespacedName{Name: name, Namespace: destNamespace}, &sTarget)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return "", err
+			}
+			rlog.Info(fmt.Sprintf("creating secret %s in namespace %s", name, destNamespace))
+			s.ObjectMeta = metav1.ObjectMeta{
+				Name:      name,
+				Namespace: destNamespace,
+			}
+			if err := cl.CreateOwned(ctx, &s); err != nil {
+				return "", err
+			}
+		} else {
+			// Update existing
+			rlog.Info(fmt.Sprintf("updating secret %s in namespace %s", name, destNamespace))
+			sTarget.Data = s.Data
+			if err := cl.UpdateOwned(ctx, &sTarget, &sTarget); err != nil {
+				return "", err
+			}
+		}
+	}
+	return idRev, nil
+}
+
+func getIDRev(m *metav1.ObjectMeta) string {
+	return string(m.GetUID()) + "/" + m.GetResourceVersion()
 }

--- a/pkg/watchers/certificates_watcher_test.go
+++ b/pkg/watchers/certificates_watcher_test.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 
 	"github.com/netobserv/network-observability-operator/api/v1alpha1"
+	"github.com/netobserv/network-observability-operator/pkg/helper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,6 +20,8 @@ import (
 type ClientMock struct {
 	mock.Mock
 	client.Client
+	lastCreated client.Object
+	lastUpdated client.Object
 }
 
 func (o *ClientMock) Get(ctx context.Context, nsname types.NamespacedName, obj client.Object) error {
@@ -24,12 +29,46 @@ func (o *ClientMock) Get(ctx context.Context, nsname types.NamespacedName, obj c
 	return args.Error(0)
 }
 
-func (o *ClientMock) mockObject(name, ns string, meta *v1.ObjectMeta) {
+func (o *ClientMock) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	args := o.Called(ctx, obj, opts)
+	o.lastCreated = obj
+	return args.Error(0)
+}
+
+func (o *ClientMock) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	args := o.Called(ctx, obj, opts)
+	o.lastUpdated = obj
+	return args.Error(0)
+}
+
+func (o *ClientMock) mockConfigMap(name, ns string, cm *corev1.ConfigMap) {
 	o.On("Get", mock.Anything, types.NamespacedName{Namespace: ns, Name: name}, mock.Anything).Run(func(args mock.Arguments) {
-		arg := args.Get(2).(client.Object)
-		arg.SetUID(meta.GetUID())
-		arg.SetResourceVersion(meta.GetResourceVersion())
+		arg := args.Get(2).(*corev1.ConfigMap)
+		arg.SetUID(cm.GetUID())
+		arg.SetResourceVersion(cm.GetResourceVersion())
+		arg.Data = cm.Data
 	}).Return(nil)
+}
+
+func (o *ClientMock) mockSecret(name, ns string, s *corev1.Secret) {
+	o.On("Get", mock.Anything, types.NamespacedName{Namespace: ns, Name: name}, mock.Anything).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*corev1.Secret)
+		arg.SetUID(s.GetUID())
+		arg.SetResourceVersion(s.GetResourceVersion())
+		arg.Data = s.Data
+	}).Return(nil)
+}
+
+func (o *ClientMock) mockNotFound(name, ns string) {
+	o.On("Get", mock.Anything, types.NamespacedName{Namespace: ns, Name: name}, mock.Anything).Return(errors.NewNotFound(schema.GroupResource{}, name))
+}
+
+func newClientMock() (helper.ClientHelper, *ClientMock) {
+	cm := ClientMock{}
+	cm.On("Create", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	cm.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	ch := helper.ClientHelper{Client: &cm, SetControllerReference: func(o client.Object) error { return nil }}
+	return ch, &cm
 }
 
 var lokiCA = corev1.ConfigMap{
@@ -37,26 +76,29 @@ var lokiCA = corev1.ConfigMap{
 		UID:             "abcd",
 		ResourceVersion: "1234",
 	},
+	Data: map[string]string{"loki-ca": "--cert--"},
 }
 var kafkaCA = corev1.ConfigMap{
 	ObjectMeta: v1.ObjectMeta{
 		UID:             "efg",
 		ResourceVersion: "567",
 	},
+	Data: map[string]string{"kafka-ca": "--cert--"},
 }
 var kafkaUser = corev1.Secret{
 	ObjectMeta: v1.ObjectMeta{
 		UID:             "hij",
 		ResourceVersion: "890",
 	},
+	Data: map[string][]byte{"kafka-user": []byte("--cert--")},
 }
 
 func TestWatchingCertificates(t *testing.T) {
 	assert := assert.New(t)
-	clientMock := ClientMock{}
-	clientMock.mockObject("loki-ca", "ns", &lokiCA.ObjectMeta)
-	clientMock.mockObject("kafka-ca", "ns", &kafkaCA.ObjectMeta)
-	clientMock.mockObject("kafka-user", "ns", &kafkaUser.ObjectMeta)
+	cl, clientMock := newClientMock()
+	clientMock.mockConfigMap("loki-ca", "ns", &lokiCA)
+	clientMock.mockConfigMap("kafka-ca", "ns", &kafkaCA)
+	clientMock.mockSecret("kafka-user", "ns", &kafkaUser)
 
 	builder := builder.Builder{}
 	watcher := RegisterCertificatesWatcher(&builder)
@@ -80,7 +122,7 @@ func TestWatchingCertificates(t *testing.T) {
 			Annotations: map[string]string{},
 		},
 	}
-	err := watcher.AnnotatePod(context.Background(), &clientMock, &pod, "loki-certificate", "kafka-certificate")
+	err := watcher.PrepareForPod(context.Background(), cl, &pod, "ns", "loki-certificate", "kafka-certificate")
 	assert.NoError(err)
 
 	// Pod annotated with info from the loki-ca configmap
@@ -99,7 +141,7 @@ func TestWatchingCertificates(t *testing.T) {
 		CertKey:  "user.key",
 	})
 
-	err = watcher.AnnotatePod(context.Background(), &clientMock, &pod, "loki-certificate", "kafka-certificate")
+	err = watcher.PrepareForPod(context.Background(), cl, &pod, "ns", "loki-certificate", "kafka-certificate")
 	assert.NoError(err)
 
 	// Pod annotated with info from the kafka-ca configmap and kafka-user secret
@@ -110,7 +152,7 @@ func TestWatchingCertificates(t *testing.T) {
 	}, pod.Annotations)
 
 	kafkaUser.SetResourceVersion("xxx")
-	err = watcher.AnnotatePod(context.Background(), &clientMock, &pod, "loki-certificate", "kafka-certificate")
+	err = watcher.PrepareForPod(context.Background(), cl, &pod, "ns", "loki-certificate", "kafka-certificate")
 	assert.NoError(err)
 
 	// kafka-user secret updated with the new annotation
@@ -119,5 +161,59 @@ func TestWatchingCertificates(t *testing.T) {
 		"flows.netobserv.io/cert-kafka-certificate-ca":   "efg/567",
 		"flows.netobserv.io/cert-kafka-certificate-user": "hij/xxx",
 	}, pod.Annotations)
+}
 
+func TestWatchingCertificatesCopyAcrossNamespaces(t *testing.T) {
+	assert := assert.New(t)
+	cl, clientMock := newClientMock()
+	clientMock.mockConfigMap("loki-ca", "ns-source", &lokiCA)
+	clientMock.mockNotFound("loki-ca", "ns-dest")
+
+	builder := builder.Builder{}
+	watcher := RegisterCertificatesWatcher(&builder)
+	assert.NotNil(watcher)
+
+	watcher.Reset("ns")
+	watcher.SetWatchedCertificate("loki-certificate-ca", &v1alpha1.CertificateReference{
+		Type:      v1alpha1.CertRefTypeConfigMap,
+		Name:      "loki-ca",
+		Namespace: "ns-source",
+		CertFile:  "ca.crt",
+	})
+
+	pod := corev1.PodTemplateSpec{
+		ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+	}
+	err := watcher.PrepareForPod(context.Background(), cl, &pod, "ns-dest", "loki-certificate", "kafka-certificate")
+	assert.NoError(err)
+
+	clientMock.AssertNumberOfCalls(t, "Create", 1)
+	clientMock.AssertNotCalled(t, "Update")
+	created := clientMock.lastCreated.(*corev1.ConfigMap)
+	assert.Equal(map[string]string{"loki-ca": "--cert--"}, created.Data)
+
+	// Pod annotated with info from the loki-ca configmap
+	assert.Equal(map[string]string{"flows.netobserv.io/cert-loki-certificate-ca": "abcd/1234"}, pod.Annotations)
+
+	// Reset mock to test update
+	cl, clientMock = newClientMock()
+	clientMock.mockConfigMap("loki-ca", "ns-source", &lokiCA)
+	clientMock.mockConfigMap("loki-ca", "ns-dest", created)
+
+	// Updating source certificate
+	lokiCA.SetResourceVersion("xxx")
+	lokiCA.Data["loki-ca"] = "--other-cert--"
+	err = watcher.PrepareForPod(context.Background(), cl, &pod, "ns-dest", "loki-certificate", "kafka-certificate")
+	assert.NoError(err)
+
+	// kafka-user secret updated with the new annotation
+	assert.Equal(map[string]string{
+		"flows.netobserv.io/cert-loki-certificate-ca": "abcd/xxx",
+	}, pod.Annotations)
+
+	clientMock.AssertNumberOfCalls(t, "Create", 0)
+	clientMock.AssertNumberOfCalls(t, "Update", 1)
+	assert.Equal(map[string]string{"loki-ca": "--other-cert--"}, clientMock.lastUpdated.(*corev1.ConfigMap).Data)
 }


### PR DESCRIPTION
Certificates (configmaps or secrets) can now be referred to with their source namespace; when that namespace doesn't match their target namespace (e.g. netobserv or netobserv-privileged), they are copied.

Had to refactor a little bit to break an import cycle between cert watchers and helper

Add tests