### PR TITLE
Fix remaining Makefile issues + annoying bundle date

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,6 +40,6 @@ jobs:
     - name: checkout
       uses: actions/checkout@v3
     - name: generate bundle
-      run: make generate bundle
+      run: make update-bundle
     - name: check bundle clean state
-      run: git diff HEAD -I "createdAt" -I "operator-sdk-v" --exit-code
+      run: git diff HEAD -I "operator-sdk-v" --exit-code

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,20 +46,26 @@ You can refer to existing commits using their short-SHA as the image tag, or ref
 
 ```bash
 # By commit SHA
-OPERATOR_VERSION="960766c" make deploy
+VERSION="960766c" make deploy
 # By release
-OPERATOR_VERSION="0.1.2" make deploy
+VERSION="0.1.2" make deploy
 ```
 
 It is recommended to switch to the corresponding release Git tag before deploying an old version to make sure the underlying components refer to the correct versions.
 
-When `OPERATOR_VERSION` is not provided, it defaults to the latest released version.
+When `VERSION` is not provided, it defaults to the latest build on `main` branch.
 
-To deploy all components on their `main` image tag (which correspond to their `main` branches, ie. their latest builds), you can simply run:
+You can also provide any custom `IMG` to `make deploy`.
+
+## Before commiting, make sure bundle is correct
+
+The github CI will fail if it finds the bundle isn't in a clean state. To update the bundle, simply run:
 
 ```bash
-make deploy-latest
+make update-bundle
 ```
+
+This is necessary when the changes you did end up affecting the bundle manifests or metadata (e.g. adding new fields in the CRD, updating some documentation, etc.). When unsure, just run the command mentioned above.
 
 ## Installing Kafka
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -100,9 +100,8 @@ bundle for local testing, you should execute the following commands:
 
 ```bash
 export USER=<container-registry-username>
-export VERSION=0.0.1
-export IMG=quay.io/$USER/network-observability-operator:v$VERSION
-export BUNDLE_IMG=quay.io/$USER/network-observability-operator-bundle:v$VERSION
+export IMG=quay.io/$USER/network-observability-operator:v0.0.1
+export BUNDLE_IMG=quay.io/$USER/network-observability-operator-bundle:v0.0.1
 make image-build image-push
 make bundle bundle-build bundle-push
 ```
@@ -111,6 +110,8 @@ Optionally, you might validate the bundle:
 
 ```bash
 bin/operator-sdk bundle validate $BUNDLE_IMG
+# or for podman
+bin/operator-sdk bundle validate -b podman $BUNDLE_IMG
 ```
 
 > Note: the base64 logo can be generated with: `base64 -w 0 <image file>`, then manually pasted in the [CSV manifest file](./config/manifests/bases/netobserv-operator.clusterserviceversion.yaml) under `spec.icon`.
@@ -121,6 +122,12 @@ This mode is recommended to quickly test the operator during its development:
 
 ```bash
 bin/operator-sdk run bundle $BUNDLE_IMG
+```
+
+To cleanup:
+
+```bash
+bin/operator-sdk cleanup netobserv-operator
 ```
 
 ### Deploy as bundle from the Console's OperatorHub page

--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ update-bundle: bundle ## Prepare a clean bundle to be commited
 bundle-build: ## Build the bundle image.
 	cp ./bundle/manifests/netobserv-operator.clusterserviceversion.yaml tmp-bundle
 	$(SED) -i -r 's~:created-at:~$(DATE)~' ./bundle/manifests/netobserv-operator.clusterserviceversion.yaml
-	$(OCI_BIN) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	-$(OCI_BIN) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 	mv tmp-bundle ./bundle/manifests/netobserv-operator.clusterserviceversion.yaml
 
 .PHONY: bundle-push

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -332,7 +332,7 @@ metadata:
     categories: Monitoring
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: quay.io/netobserv/network-observability-operator:1.0.2
-    createdAt: "2023-02-28T08:36:03Z"
+    createdAt: ':created-at:'
     description: Network flows collector and monitoring solution
     operators.operatorframework.io/builder: operator-sdk-v1.25.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3


### PR DESCRIPTION
After the recent reworking on the Makefile, there were still some pending issues. E.g. we introduced a "deploy-latest" target but it did not allow to override the operator image.

This is rollbacking part of the last changes:
- deploy-latest is removed, we can run "make deploy" as we used to do before
- make deploy now uses again "main" images by default, as before
- keeping the behaviour that Mohamed introduced, "make bundle" keeps using the provided IMG
- UNLIKE before: running "make bundle" alone will NOT update the bundle so it is ready for commit; For that, a new target "make update-bundle" is introduced
- "make bundle" does not generate the creation date as it used to do. This is now done via "make bundle-build". It means that release scripts have to be updated so they generate the creation date.