### PR TITLE
NETOBSERV-123: Added infra health dashboard

### DIFF
--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -315,6 +315,12 @@ func (r *FlowCollectorReconciler) reconcileOperator(ctx context.Context, clientH
 			return err
 		}
 	}
+	if r.availableAPIs.HasSvcMonitor() {
+		desiredHealthDashboardCM := buildHealthDashboard()
+		if err := clientHelper.ReconcileConfigMap(ctx, desiredHealthDashboardCM); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -219,6 +219,15 @@ func flowCollectorControllerSpecs() {
 				}
 				return ofc.Data["netobserv-metrics.json"]
 			}, timeout, interval).Should(ContainSubstring(`"panels": [`))
+
+			By("Expecting the infra health dashboards configmap to be created")
+			Eventually(func() interface{} {
+				cm := v1.ConfigMap{}
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "grafana-dashboard-netobserv-health",
+					Namespace: "openshift-config-managed",
+				}, &cm)
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("Should update successfully", func() {

--- a/controllers/flowcollector_objects.go
+++ b/controllers/flowcollector_objects.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	_ "embed"
+
 	"github.com/netobserv/network-observability-operator/controllers/constants"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -64,4 +66,30 @@ func buildRoleBindingMonitoringReader(ns string) *rbacv1.ClusterRoleBinding {
 			Namespace: monitoringNamespace,
 		}},
 	}
+}
+
+//go:embed infra_health_dashboard.json
+var healthDashboardEmbed string
+
+const (
+	healthDashboardCMName       = "grafana-dashboard-netobserv-health"
+	healthDashboardCMNamespace  = "openshift-config-managed"
+	healthDashboardCMAnnotation = "console.openshift.io/dashboard"
+	healthDashboardCMFile       = "netobserv-health-metrics.json"
+)
+
+func buildHealthDashboard() *corev1.ConfigMap {
+	configMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      healthDashboardCMName,
+			Namespace: healthDashboardCMNamespace,
+			Labels: map[string]string{
+				healthDashboardCMAnnotation: "true",
+			},
+		},
+		Data: map[string]string{
+			healthDashboardCMFile: string(healthDashboardEmbed),
+		},
+	}
+	return &configMap
 }

--- a/controllers/flowcollector_objects.go
+++ b/controllers/flowcollector_objects.go
@@ -88,7 +88,7 @@ func buildHealthDashboard() *corev1.ConfigMap {
 			},
 		},
 		Data: map[string]string{
-			healthDashboardCMFile: string(healthDashboardEmbed),
+			healthDashboardCMFile: healthDashboardEmbed,
 		},
 	}
 	return &configMap

--- a/controllers/flowlogspipeline/flp_common_objects.go
+++ b/controllers/flowlogspipeline/flp_common_objects.go
@@ -739,6 +739,7 @@ func (b *builder) prometheusRule() *monitoringv1.PrometheusRule {
 			For:  "10m",
 			Labels: map[string]string{
 				"severity": "warning",
+				"app":      "netobserv",
 			},
 		})
 	}
@@ -755,6 +756,7 @@ func (b *builder) prometheusRule() *monitoringv1.PrometheusRule {
 			For:  "10m",
 			Labels: map[string]string{
 				"severity": "warning",
+				"app":      "netobserv",
 			},
 		})
 	}

--- a/controllers/infra_health_dashboard.json
+++ b/controllers/infra_health_dashboard.json
@@ -660,6 +660,6 @@
         ]
     },
     "timezone":"browser",
-    "title":"Netobserv / Health",
+    "title":"NetObserv / Health",
     "version":0
 }

--- a/controllers/infra_health_dashboard.json
+++ b/controllers/infra_health_dashboard.json
@@ -1,0 +1,665 @@
+{
+    "__inputs":[
+    ],
+    "__requires":[
+    ],
+    "annotations":{
+        "list":[
+        ]
+    },
+    "editable":false,
+    "gnetId":null,
+    "graphTooltip":0,
+    "hideControls":false,
+    "id":null,
+    "links":[
+    ],
+    "panels":[],
+    "refresh":"",
+    "rows":[
+        {
+            "collapse":false,
+            "height":"250px",
+            "panels":[
+                {
+                    "aliasColors":{
+                    },
+                    "bars":false,
+                    "dashLength":10,
+                    "dashes":false,
+                    "datasource":"prometheus",
+                    "fill":1,
+                    "fillGradient":0,
+                    "gridPos":{
+                        "h":20,
+                        "w":25,
+                        "x":0,
+                        "y":0
+                    },
+                    "id":3,
+                    "legend":{
+                        "alignAsTable":false,
+                        "avg":false,
+                        "current":false,
+                        "max":false,
+                        "min":false,
+                        "rightSide":false,
+                        "show":true,
+                        "sideWidth":null,
+                        "total":false,
+                        "values":false
+                    },
+                    "lines":true,
+                    "linewidth":1,
+                    "links":[
+                    ],
+                    "nullPointMode":"null",
+                    "percentage":false,
+                    "pointradius":5,
+                    "points":false,
+                    "renderer":"flot",
+                    "repeat":null,
+                    "seriesOverrides":[
+                    ],
+                    "spaceLength":10,
+                    "stack":false,
+                    "steppedLine":false,
+                    "targets":[
+                        {
+                            "expr":"sum(rate(netobserv_ingest_flows_processed[5m]))",
+                            "format":"time_series",
+                            "intervalFactor":2,
+                            "legendFormat":"Flows ingested",
+                            "refId":"A"
+                        },
+                        {
+                            "expr":"sum(rate(netobserv_loki_sent_entries_total[5m]))",
+                            "format":"time_series",
+                            "intervalFactor":2,
+                            "legendFormat":"Flows sent to loki",
+                            "refId":"A"
+                        },
+			{
+                            "expr":"sum(rate(netobserv_loki_dropped_entries_total[5m]))",
+                            "format":"time_series",
+                            "intervalFactor":2,
+                            "legendFormat":"Flows dropped due to loki error",
+                            "refId":"A"
+                        }
+
+                    ],
+                    "thresholds":[
+                    ],
+                    "timeFrom":null,
+                    "timeShift":null,
+                    "title":"Rates",
+                    "tooltip":{
+                        "shared":true,
+                        "sort":0,
+                        "value_type":"individual"
+                    },
+                    "type":"graph",
+                    "xaxis":{
+                        "buckets":null,
+                        "mode":"time",
+                        "name":null,
+                        "show":true,
+                        "values":[
+                        ]
+                    },
+                    "yaxes":[
+                        {
+                            "format":"short",
+                            "label":null,
+                            "logBase":1,
+                            "max":null,
+                            "min":null,
+                            "show":true
+                        },
+                        {
+                            "format":"short",
+                            "label":null,
+                            "logBase":1,
+                            "max":null,
+                            "min":null,
+                            "show":true
+                        }
+                    ]
+                }
+            ],
+            "repeat":null,
+            "repeatIteration":null,
+            "repeatRowId":null,
+            "showTitle":true,
+            "title":"Flows",
+            "titleSize":"h6"
+        },
+        {
+            "collapse":false,
+            "height":"250px",
+            "panels":[
+                {
+                    "aliasColors":{
+                    },
+                    "bars":false,
+                    "dashLength":10,
+                    "dashes":false,
+                    "datasource":"prometheus",
+                    "fill":1,
+                    "fillGradient":0,
+                    "gridPos":{
+                        "h":20,
+                        "w":25,
+                        "x":0,
+                        "y":0
+                    },
+                    "id":4,
+                    "legend":{
+                        "alignAsTable":false,
+                        "avg":false,
+                        "current":false,
+                        "max":false,
+                        "min":false,
+                        "rightSide":false,
+                        "show":true,
+                        "sideWidth":null,
+                        "total":false,
+                        "values":false
+                    },
+                    "lines":true,
+                    "linewidth":1,
+                    "links":[
+                    ],
+                    "nullPointMode":"null",
+                    "percentage":false,
+                    "pointradius":5,
+                    "points":false,
+                    "renderer":"flot",
+                    "repeat":null,
+                    "seriesOverrides":[
+                    ],
+                    "spaceLength":10,
+		    "span": 6,
+                    "stack":false,
+                    "steppedLine":false,
+                    "targets":[
+                        {
+                            "expr":"node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container=\"netobserv-ebpf-agent\"}",
+                            "format":"time_series",
+                            "intervalFactor":2,
+                            "legendFormat":"{{pod}}",
+                            "refId":"A"
+                        }
+                    ],
+                    "thresholds":[
+                    ],
+                    "timeFrom":null,
+                    "timeShift":null,
+                    "title":"CPU usage",
+                    "tooltip":{
+                        "shared":true,
+                        "sort":0,
+                        "value_type":"individual"
+                    },
+                    "type":"graph",
+                    "xaxis":{
+                        "buckets":null,
+                        "mode":"time",
+                        "name":null,
+                        "show":true,
+                        "values":[
+                        ]
+                    },
+                    "yaxes":[
+                        {
+                            "format":"short",
+                            "label":null,
+                            "logBase":1,
+                            "max":null,
+                            "min":null,
+                            "show":true
+                        },
+                        {
+                            "format":"short",
+                            "label":null,
+                            "logBase":1,
+                            "max":null,
+                            "min":null,
+                            "show":true
+                        }
+                    ]
+                },
+                {
+                    "aliasColors":{
+                    },
+                    "bars":false,
+                    "dashLength":10,
+                    "dashes":false,
+                    "datasource":"prometheus",
+                    "fill":1,
+                    "fillGradient":0,
+                    "gridPos":{
+                        "h":20,
+                        "w":25,
+                        "x":0,
+                        "y":0
+                    },
+                    "id":4,
+                    "legend":{
+                        "alignAsTable":false,
+                        "avg":false,
+                        "current":false,
+                        "max":false,
+                        "min":false,
+                        "rightSide":false,
+                        "show":true,
+                        "sideWidth":null,
+                        "total":false,
+                        "values":false
+                    },
+                    "lines":true,
+                    "linewidth":1,
+                    "links":[
+                    ],
+                    "nullPointMode":"null",
+                    "percentage":false,
+                    "pointradius":5,
+                    "points":false,
+                    "renderer":"flot",
+                    "repeat":null,
+                    "seriesOverrides":[
+                    ],
+                    "spaceLength":10,
+		    "span": 6,
+                    "stack":false,
+                    "steppedLine":false,
+                    "targets":[
+                        {
+                            "expr":"container_memory_rss{container=\"netobserv-ebpf-agent\"}",
+                            "format":"time_series",
+                            "intervalFactor":2,
+                            "legendFormat":"{{pod}}",
+                            "refId":"A"
+                        }
+                    ],
+                    "thresholds":[
+                    ],
+                    "timeFrom":null,
+                    "timeShift":null,
+                    "title":"Memory Usage",
+                    "tooltip":{
+                        "shared":true,
+                        "sort":0,
+                        "value_type":"individual"
+                    },
+                    "type":"graph",
+                    "xaxis":{
+                        "buckets":null,
+                        "mode":"time",
+                        "name":null,
+                        "show":true,
+                        "values":[
+                        ]
+                    },
+                    "yaxes":[
+                        {
+                            "format":"short",
+                            "label":null,
+                            "logBase":1,
+                            "max":null,
+                            "min":null,
+                            "show":true
+                        },
+                        {
+                            "format":"short",
+                            "label":null,
+                            "logBase":1,
+                            "max":null,
+                            "min":null,
+                            "show":true
+                        }
+                    ]
+                }
+            ],
+            "repeat":null,
+            "repeatIteration":null,
+            "repeatRowId":null,
+            "showTitle":true,
+            "title":"Agents",
+            "titleSize":"h6"
+        },
+{
+
+    "collapse":false,
+    "height":"250px",
+    "panels":[
+{
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "prometheus",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+         },
+         "id": 4,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "span": 6,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container=\"flowlogs-pipeline\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{pod}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "CPU usage",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+},
+	{
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "prometheus",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+         },
+         "id": 4,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+            "spaceLength": 10,
+	             "span": 6,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "container_memory_rss{container=\"flowlogs-pipeline\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{pod}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Memory Usage",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      }
+
+
+
+    ],
+    "repeat":null,
+    "repeatIteration":null,
+    "repeatRowId":null,
+    "showTitle":true,
+    "title":"Processor",
+    "titleSize":"h6"
+
+},
+
+        {
+            "collapse":false,
+            "height":"250px",
+            "panels":[
+                {
+                    "aliasColors":{
+                    },
+                    "bars":false,
+                    "dashLength":10,
+                    "dashes":false,
+                    "datasource":"prometheus",
+                    "fill":1,
+                    "fillGradient":0,
+                    "gridPos":{
+                        "h":20,
+                        "w":25,
+                        "x":0,
+                        "y":0
+                    },
+                    "id":4,
+                    "legend":{
+                        "alignAsTable":false,
+                        "avg":false,
+                        "current":false,
+                        "max":false,
+                        "min":false,
+                        "rightSide":false,
+                        "show":true,
+                        "sideWidth":null,
+                        "total":false,
+                        "values":false
+                    },
+                    "lines":true,
+                    "linewidth":1,
+                    "links":[
+                    ],
+                    "nullPointMode":"null",
+                    "percentage":false,
+                    "pointradius":5,
+                    "points":false,
+                    "renderer":"flot",
+                    "repeat":null,
+                    "seriesOverrides":[
+                    ],
+                    "spaceLength":10,
+                    "stack":false,
+                    "steppedLine":false,
+                    "targets":[
+                        {
+                            "expr":"(sum(rate(controller_runtime_reconcile_total{controller=\"flowcollector\"}[1m])) by (result))",
+                            "format":"time_series",
+                            "intervalFactor":2,
+                            "legendFormat":"{{result}}",
+                            "refId":"A"
+                        }
+                    ],
+                    "thresholds":[
+                    ],
+                    "timeFrom":null,
+                    "timeShift":null,
+                    "title":"Operator reconciliation rate",
+                    "tooltip":{
+                        "shared":true,
+                        "sort":0,
+                        "value_type":"individual"
+                    },
+                    "type":"graph",
+                    "xaxis":{
+                        "buckets":null,
+                        "mode":"time",
+                        "name":null,
+                        "show":true,
+                        "values":[
+                        ]
+                    },
+                    "yaxes":[
+                        {
+                            "format":"short",
+                            "label":null,
+                            "logBase":1,
+                            "max":null,
+                            "min":null,
+                            "show":true
+                        },
+                        {
+                            "format":"short",
+                            "label":null,
+                            "logBase":1,
+                            "max":null,
+                            "min":null,
+                            "show":true
+                        }
+                    ]
+                }
+            ],
+            "repeat":null,
+            "repeatIteration":null,
+            "repeatRowId":null,
+            "showTitle":true,
+            "title":"Operator",
+            "titleSize":"h6"
+        }
+    ],
+    "schemaVersion":16,
+    "style":"dark",
+    "tags":[
+        "netobserv-mixin"
+    ],
+    "templating":{
+        "list":[
+        ]
+    },
+    "time":{
+        "from":"now",
+        "to":"now"
+    },
+    "timepicker":{
+        "refresh_intervals":[
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ],
+        "time_options":[
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+        ]
+    },
+    "timezone":"browser",
+    "title":"Netobserv / Health",
+    "version":0
+}


### PR DESCRIPTION
This PR add infra health dashboard.

I first try to generate the dashboard using FLP confgen but I faced multiple limitations:
- Not possible to use `rows` definitions to have multiple foldable subsections
- Not possible to have multiple query on the same graph. Here I wanted to have ingested flows and sent to loki flows in the same graph
- Not possible to manage graph width so we can have mulitple graphs on the same row. Here for CPU and memory utilization.

You can check [this branch](https://github.com/OlivierCazade/network-observability-operator/tree/health-dashboard-flp-api) which is working on how it was using FLP confgen.

If at some point we have to update this dashboard too often. We may want to implement this limitations in FLP confgen and use it.