### PR TITLE
NETOBSERV-928 Connection tracking renaming

### DIFF
--- a/api/v1alpha1/flowcollector_webhook.go
+++ b/api/v1alpha1/flowcollector_webhook.go
@@ -43,14 +43,14 @@ func (r *FlowCollector) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 
-	dst.Spec.Processor.OutputRecordTypes = restored.Spec.Processor.OutputRecordTypes
+	dst.Spec.Processor.LogTypes = restored.Spec.Processor.LogTypes
 
-	if restored.Spec.Processor.ConnectionHeartbeatInterval != nil {
-		dst.Spec.Processor.ConnectionHeartbeatInterval = restored.Spec.Processor.ConnectionHeartbeatInterval
+	if restored.Spec.Processor.ConversationHeartbeatInterval != nil {
+		dst.Spec.Processor.ConversationHeartbeatInterval = restored.Spec.Processor.ConversationHeartbeatInterval
 	}
 
-	if restored.Spec.Processor.ConnectionEndTimeout != nil {
-		dst.Spec.Processor.ConnectionEndTimeout = restored.Spec.Processor.ConnectionEndTimeout
+	if restored.Spec.Processor.ConversationEndTimeout != nil {
+		dst.Spec.Processor.ConversationEndTimeout = restored.Spec.Processor.ConversationEndTimeout
 	}
 
 	if restored.Spec.Processor.Metrics.DisableAlerts != nil {

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -640,9 +640,9 @@ func autoConvert_v1beta1_FlowCollectorFLP_To_v1alpha1_FlowCollectorFLP(in *v1bet
 	}
 	out.KafkaConsumerQueueCapacity = in.KafkaConsumerQueueCapacity
 	out.KafkaConsumerBatchSize = in.KafkaConsumerBatchSize
-	// WARNING: in.OutputRecordTypes requires manual conversion: does not exist in peer-type
-	// WARNING: in.ConnectionHeartbeatInterval requires manual conversion: does not exist in peer-type
-	// WARNING: in.ConnectionEndTimeout requires manual conversion: does not exist in peer-type
+	// WARNING: in.LogTypes requires manual conversion: does not exist in peer-type
+	// WARNING: in.ConversationHeartbeatInterval requires manual conversion: does not exist in peer-type
+	// WARNING: in.ConversationEndTimeout requires manual conversion: does not exist in peer-type
 	if err := Convert_v1beta1_DebugConfig_To_v1alpha1_DebugConfig(&in.Debug, &out.Debug, s); err != nil {
 		return err
 	}

--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -299,10 +299,10 @@ type FLPMetrics struct {
 }
 
 const (
-	OutputRecordFlows            = "FLOWS"
-	OutputRecordConnections      = "CONNECTIONS"
-	OutputRecordEndedConnections = "ENDED_CONNECTIONS"
-	OutputRecordAll              = "ALL"
+	LogTypeFlows              = "FLOWS"
+	LogTypeConversations      = "CONVERSATIONS"
+	LogTypeEndedConversations = "ENDED_CONVERSATIONS"
+	LogTypeAll                = "ALL"
 )
 
 // FlowCollectorFLP defines the desired flowlogs-pipeline state of FlowCollector
@@ -377,23 +377,23 @@ type FlowCollectorFLP struct {
 	// kafkaConsumerBatchSize indicates to the broker the maximum batch size, in bytes, that the consumer will accept. Ignored when not using Kafka. Default: 10MB.
 	KafkaConsumerBatchSize int `json:"kafkaConsumerBatchSize"`
 
-	// outputRecordTypes defines the desired record types to generate. Possible values are "FLOWS" (default) to export
-	// flowLogs, "CONNECTIONS" to generate newConnection, heartbeat, endConnection events, "ENDED_CONNECTIONS" to generate
-	// only endConnection events or "ALL" to generate both flowLogs and connection events
+	// logTypes defines the desired record types to generate. Possible values are "FLOWS" (default) to export
+	// flowLogs, "CONVERSATIONS" to generate newConnection, heartbeat, endConnection events, "ENDED_CONVERSATIONS" to generate
+	// only endConnection events or "ALL" to generate both flow logs and conversations events
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Enum:="FLOWS";"CONNECTIONS";"ENDED_CONNECTIONS";"ALL"
+	// +kubebuilder:validation:Enum:="FLOWS";"CONVERSATIONS";"ENDED_CONVERSATIONS";"ALL"
 	// +kubebuilder:default:=FLOWS
-	OutputRecordTypes *string `json:"outputRecordTypes,omitempty"`
+	LogTypes *string `json:"logTypes,omitempty"`
 
 	//+kubebuilder:default:="30s"
 	// +optional
-	// connection heartbeat interval is the duration of time to wait between heartbeat reports of a connection
-	ConnectionHeartbeatInterval *metav1.Duration `json:"connectionHeartbeatInterval,omitempty"`
+	// conversation heartbeat interval is the duration of time to wait between heartbeat reports of a conversation
+	ConversationHeartbeatInterval *metav1.Duration `json:"conversationHeartbeatInterval,omitempty"`
 
 	//+kubebuilder:default:="10s"
 	// +optional
-	// connection end timeout is the duration of time to wait from the last flow log to end a connection
-	ConnectionEndTimeout *metav1.Duration `json:"connectionEndTimeout,omitempty"`
+	// conversation end timeout is the duration of time to wait from the last flow log to end a conversation
+	ConversationEndTimeout *metav1.Duration `json:"conversationEndTimeout,omitempty"`
 
 	// Debug allows setting some aspects of the internal configuration of the flow processor.
 	// This section is aimed exclusively for debugging and fine-grained performance optimizations

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -267,18 +267,18 @@ func (in *FlowCollectorFLP) DeepCopyInto(out *FlowCollectorFLP) {
 	in.Metrics.DeepCopyInto(&out.Metrics)
 	in.Resources.DeepCopyInto(&out.Resources)
 	in.KafkaConsumerAutoscaler.DeepCopyInto(&out.KafkaConsumerAutoscaler)
-	if in.OutputRecordTypes != nil {
-		in, out := &in.OutputRecordTypes, &out.OutputRecordTypes
+	if in.LogTypes != nil {
+		in, out := &in.LogTypes, &out.LogTypes
 		*out = new(string)
 		**out = **in
 	}
-	if in.ConnectionHeartbeatInterval != nil {
-		in, out := &in.ConnectionHeartbeatInterval, &out.ConnectionHeartbeatInterval
+	if in.ConversationHeartbeatInterval != nil {
+		in, out := &in.ConversationHeartbeatInterval, &out.ConversationHeartbeatInterval
 		*out = new(v1.Duration)
 		**out = **in
 	}
-	if in.ConnectionEndTimeout != nil {
-		in, out := &in.ConnectionEndTimeout, &out.ConnectionEndTimeout
+	if in.ConversationEndTimeout != nil {
+		in, out := &in.ConversationEndTimeout, &out.ConversationEndTimeout
 		*out = new(v1.Duration)
 		**out = **in
 	}

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -3460,15 +3460,15 @@ spec:
                   receives the flows from the agent, enriches them, and forwards them
                   to the Loki persistence layer.
                 properties:
-                  connectionEndTimeout:
+                  conversationEndTimeout:
                     default: 10s
-                    description: connection end timeout is the duration of time to
-                      wait from the last flow log to end a connection
+                    description: conversation end timeout is the duration of time
+                      to wait from the last flow log to end a conversation
                     type: string
-                  connectionHeartbeatInterval:
+                  conversationHeartbeatInterval:
                     default: 30s
-                    description: connection heartbeat interval is the duration of
-                      time to wait between heartbeat reports of a connection
+                    description: conversation heartbeat interval is the duration of
+                      time to wait between heartbeat reports of a conversation
                     type: string
                   debug:
                     description: Debug allows setting some aspects of the internal
@@ -4078,6 +4078,19 @@ spec:
                     - fatal
                     - panic
                     type: string
+                  logTypes:
+                    default: FLOWS
+                    description: logTypes defines the desired record types to generate.
+                      Possible values are "FLOWS" (default) to export flowLogs, "CONVERSATIONS"
+                      to generate newConnection, heartbeat, endConnection events,
+                      "ENDED_CONVERSATIONS" to generate only endConnection events
+                      or "ALL" to generate both flow logs and conversations events
+                    enum:
+                    - FLOWS
+                    - CONVERSATIONS
+                    - ENDED_CONVERSATIONS
+                    - ALL
+                    type: string
                   metrics:
                     description: Metrics define the processor configuration regarding
                       metrics
@@ -4159,19 +4172,6 @@ spec:
                             type: object
                         type: object
                     type: object
-                  outputRecordTypes:
-                    default: FLOWS
-                    description: outputRecordTypes defines the desired record types
-                      to generate. Possible values are "FLOWS" (default) to export
-                      flowLogs, "CONNECTIONS" to generate newConnection, heartbeat,
-                      endConnection events, "ENDED_CONNECTIONS" to generate only endConnection
-                      events or "ALL" to generate both flowLogs and connection events
-                    enum:
-                    - FLOWS
-                    - CONNECTIONS
-                    - ENDED_CONNECTIONS
-                    - ALL
-                    type: string
                   port:
                     default: 2055
                     description: 'port of the flow collector (host port) By conventions,

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -294,8 +294,8 @@ metadata:
             },
             "namespace": "netobserv",
             "processor": {
-              "connectionEndTimeout": "10s",
-              "connectionHeartbeatInterval": "30s",
+              "conversationEndTimeout": "10s",
+              "conversationHeartbeatInterval": "30s",
               "dropUnusedFields": true,
               "imagePullPolicy": "IfNotPresent",
               "kafkaConsumerAutoscaler": null,
@@ -303,6 +303,7 @@ metadata:
               "kafkaConsumerQueueCapacity": 1000,
               "kafkaConsumerReplicas": 3,
               "logLevel": "info",
+              "logTypes": "FLOWS",
               "metrics": {
                 "disableAlerts": [],
                 "ignoreTags": [
@@ -313,7 +314,6 @@ metadata:
                   "port": 9102
                 }
               },
-              "outputRecordTypes": "FLOWS",
               "port": 2055,
               "profilePort": 6060,
               "resources": {

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -3447,15 +3447,15 @@ spec:
                   receives the flows from the agent, enriches them, and forwards them
                   to the Loki persistence layer.
                 properties:
-                  connectionEndTimeout:
+                  conversationEndTimeout:
                     default: 10s
-                    description: connection end timeout is the duration of time to
-                      wait from the last flow log to end a connection
+                    description: conversation end timeout is the duration of time
+                      to wait from the last flow log to end a conversation
                     type: string
-                  connectionHeartbeatInterval:
+                  conversationHeartbeatInterval:
                     default: 30s
-                    description: connection heartbeat interval is the duration of
-                      time to wait between heartbeat reports of a connection
+                    description: conversation heartbeat interval is the duration of
+                      time to wait between heartbeat reports of a conversation
                     type: string
                   debug:
                     description: Debug allows setting some aspects of the internal
@@ -4065,6 +4065,19 @@ spec:
                     - fatal
                     - panic
                     type: string
+                  logTypes:
+                    default: FLOWS
+                    description: logTypes defines the desired record types to generate.
+                      Possible values are "FLOWS" (default) to export flowLogs, "CONVERSATIONS"
+                      to generate newConnection, heartbeat, endConnection events,
+                      "ENDED_CONVERSATIONS" to generate only endConnection events
+                      or "ALL" to generate both flow logs and conversations events
+                    enum:
+                    - FLOWS
+                    - CONVERSATIONS
+                    - ENDED_CONVERSATIONS
+                    - ALL
+                    type: string
                   metrics:
                     description: Metrics define the processor configuration regarding
                       metrics
@@ -4146,19 +4159,6 @@ spec:
                             type: object
                         type: object
                     type: object
-                  outputRecordTypes:
-                    default: FLOWS
-                    description: outputRecordTypes defines the desired record types
-                      to generate. Possible values are "FLOWS" (default) to export
-                      flowLogs, "CONNECTIONS" to generate newConnection, heartbeat,
-                      endConnection events, "ENDED_CONNECTIONS" to generate only endConnection
-                      events or "ALL" to generate both flowLogs and connection events
-                    enum:
-                    - FLOWS
-                    - CONNECTIONS
-                    - ENDED_CONNECTIONS
-                    - ALL
-                    type: string
                   port:
                     default: 2055
                     description: 'port of the flow collector (host port) By conventions,

--- a/config/samples/flows_v1beta1_flowcollector.yaml
+++ b/config/samples/flows_v1beta1_flowcollector.yaml
@@ -45,9 +45,9 @@ spec:
     kafkaConsumerAutoscaler: null
     kafkaConsumerQueueCapacity: 1000
     kafkaConsumerBatchSize: 10485760
-    outputRecordTypes: FLOWS
-    connectionHeartbeatInterval: 30s
-    connectionEndTimeout: 10s
+    logTypes: FLOWS
+    conversationHeartbeatInterval: 30s
+    conversationEndTimeout: 10s
   kafka:
     address: "kafka-cluster-kafka-bootstrap.netobserv"
     topic: network-flows

--- a/config/samples/flows_v1beta1_flowcollector_versioned.yaml
+++ b/config/samples/flows_v1beta1_flowcollector_versioned.yaml
@@ -45,9 +45,9 @@ spec:
     kafkaConsumerAutoscaler: null
     kafkaConsumerQueueCapacity: 1000
     kafkaConsumerBatchSize: 10485760
-    outputRecordTypes: FLOWS
-    connectionHeartbeatInterval: 30s
-    connectionEndTimeout: 10s
+    logTypes: FLOWS
+    conversationHeartbeatInterval: 30s
+    conversationEndTimeout: 10s
   kafka:
     address: "kafka-cluster-kafka-bootstrap.netobserv"
     topic: network-flows

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -155,7 +155,7 @@ func buildArgs(desired *flowslatest.FlowCollectorSpec) []string {
 
 	// check for connection traking to list indexes
 	indexFields := constants.LokiIndexFields
-	if desired.Processor.OutputRecordTypes != nil && *desired.Processor.OutputRecordTypes != flowslatest.OutputRecordFlows {
+	if desired.Processor.LogTypes != nil && *desired.Processor.LogTypes != flowslatest.LogTypeFlows {
 		indexFields = append(indexFields, constants.LokiConnectionIndexFields...)
 	}
 

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -27,10 +27,10 @@ const (
 	CertCASuffix           = "ca"
 	CertUserSuffix         = "user"
 
-	FlowLogRecordType       = "flowLog"
-	NewConnectionRecordType = "newConnection"
-	HeartbeatRecordType     = "heartbeat"
-	EndConnectionRecordType = "endConnection"
+	FlowLogType       = "flowLog"
+	NewConnectionType = "newConnection"
+	HeartbeatType     = "heartbeat"
+	EndConnectionType = "endConnection"
 )
 
 var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "DstK8S_Namespace", "DstK8S_OwnerName", "FlowDirection"}

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -32,7 +32,7 @@ const (
 	conntrackHeartbeatInterval = 30 * time.Second
 )
 
-var outputRecordTypes = flowslatest.OutputRecordAll
+var outputRecordTypes = flowslatest.LogTypeAll
 
 // nolint:cyclop
 func flowCollectorControllerSpecs() {
@@ -102,11 +102,11 @@ func flowCollectorControllerSpecs() {
 								"GOGC": "200",
 							},
 						},
-						OutputRecordTypes: &outputRecordTypes,
-						ConnectionHeartbeatInterval: &metav1.Duration{
+						LogTypes: &outputRecordTypes,
+						ConversationHeartbeatInterval: &metav1.Duration{
 							Duration: conntrackHeartbeatInterval,
 						},
-						ConnectionEndTimeout: &metav1.Duration{
+						ConversationEndTimeout: &metav1.Duration{
 							Duration: conntrackEndTimeout,
 						},
 					},
@@ -219,11 +219,11 @@ func flowCollectorControllerSpecs() {
 							"GOGC":       "400",
 						},
 					},
-					OutputRecordTypes: &outputRecordTypes,
-					ConnectionHeartbeatInterval: &metav1.Duration{
+					LogTypes: &outputRecordTypes,
+					ConversationHeartbeatInterval: &metav1.Duration{
 						Duration: conntrackHeartbeatInterval,
 					},
-					ConnectionEndTimeout: &metav1.Duration{
+					ConversationEndTimeout: &metav1.Duration{
 						Duration: conntrackEndTimeout,
 					},
 				}

--- a/controllers/flowlogspipeline/flp_common_objects.go
+++ b/controllers/flowlogspipeline/flp_common_objects.go
@@ -339,19 +339,19 @@ func (b *builder) addTransformStages(stage *config.PipelineBuilderStage) (*corev
 		// Else: nothing for eBPF at the moment
 	}
 
-	// Connection tracking stage (only if OutputRecordTypes is not FLOWS)
-	if b.desired.Processor.OutputRecordTypes != nil && *b.desired.Processor.OutputRecordTypes != flowslatest.OutputRecordFlows {
+	// Connection tracking stage (only if LogTypes is not FLOWS)
+	if b.desired.Processor.LogTypes != nil && *b.desired.Processor.LogTypes != flowslatest.LogTypeFlows {
 		indexFields = append(indexFields, constants.LokiConnectionIndexFields...)
 		outputRecordTypes := helper.GetRecordTypes(&b.desired.Processor)
 
 		endTimeout := conntrackEndTimeout
-		if b.desired.Processor.ConnectionEndTimeout != nil {
-			endTimeout = b.desired.Processor.ConnectionEndTimeout.Duration
+		if b.desired.Processor.ConversationEndTimeout != nil {
+			endTimeout = b.desired.Processor.ConversationEndTimeout.Duration
 		}
 
 		heartbeatInterval := conntrackHeartbeatInterval
-		if b.desired.Processor.ConnectionHeartbeatInterval != nil {
-			heartbeatInterval = b.desired.Processor.ConnectionHeartbeatInterval.Duration
+		if b.desired.Processor.ConversationHeartbeatInterval != nil {
+			heartbeatInterval = b.desired.Processor.ConversationHeartbeatInterval.Duration
 		}
 
 		lastStage = lastStage.ConnTrack("extract_conntrack", api.ConnTrack{

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -48,7 +48,7 @@ var minReplicas = int32(1)
 var maxReplicas = int32(5)
 var targetCPU = int32(75)
 var certWatcher = watchers.NewCertificatesWatcher()
-var outputRecordTypes = flowslatest.OutputRecordAll
+var outputRecordTypes = flowslatest.LogTypeAll
 
 const testNamespace = "flp"
 
@@ -86,11 +86,11 @@ func getConfig() flowslatest.FlowCollectorSpec {
 					},
 				}},
 			},
-			OutputRecordTypes: &outputRecordTypes,
-			ConnectionHeartbeatInterval: &metav1.Duration{
+			LogTypes: &outputRecordTypes,
+			ConversationHeartbeatInterval: &metav1.Duration{
 				Duration: conntrackHeartbeatInterval,
 			},
-			ConnectionEndTimeout: &metav1.Duration{
+			ConversationEndTimeout: &metav1.Duration{
 				Duration: conntrackEndTimeout,
 			},
 		},

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -6166,19 +6166,19 @@ processor defines the settings of the component that receives the flows from the
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>connectionEndTimeout</b></td>
+        <td><b>conversationEndTimeout</b></td>
         <td>string</td>
         <td>
-          connection end timeout is the duration of time to wait from the last flow log to end a connection<br/>
+          conversation end timeout is the duration of time to wait from the last flow log to end a conversation<br/>
           <br/>
             <i>Default</i>: 10s<br/>
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>connectionHeartbeatInterval</b></td>
+        <td><b>conversationHeartbeatInterval</b></td>
         <td>string</td>
         <td>
-          connection heartbeat interval is the duration of time to wait between heartbeat reports of a connection<br/>
+          conversation heartbeat interval is the duration of time to wait between heartbeat reports of a conversation<br/>
           <br/>
             <i>Default</i>: 30s<br/>
         </td>
@@ -6277,20 +6277,20 @@ processor defines the settings of the component that receives the flows from the
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>logTypes</b></td>
+        <td>enum</td>
+        <td>
+          logTypes defines the desired record types to generate. Possible values are "FLOWS" (default) to export flowLogs, "CONVERSATIONS" to generate newConnection, heartbeat, endConnection events, "ENDED_CONVERSATIONS" to generate only endConnection events or "ALL" to generate both flow logs and conversations events<br/>
+          <br/>
+            <i>Enum</i>: FLOWS, CONVERSATIONS, ENDED_CONVERSATIONS, ALL<br/>
+            <i>Default</i>: FLOWS<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#flowcollectorspecprocessormetrics-1">metrics</a></b></td>
         <td>object</td>
         <td>
           Metrics define the processor configuration regarding metrics<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>outputRecordTypes</b></td>
-        <td>enum</td>
-        <td>
-          outputRecordTypes defines the desired record types to generate. Possible values are "FLOWS" (default) to export flowLogs, "CONNECTIONS" to generate newConnection, heartbeat, endConnection events, "ENDED_CONNECTIONS" to generate only endConnection events or "ALL" to generate both flowLogs and connection events<br/>
-          <br/>
-            <i>Enum</i>: FLOWS, CONNECTIONS, ENDED_CONNECTIONS, ALL<br/>
-            <i>Default</i>: FLOWS<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/helper/flowcollector.go
+++ b/pkg/helper/flowcollector.go
@@ -43,29 +43,29 @@ func LokiForwardUserToken(spec *flowslatest.FlowCollectorLoki) bool {
 }
 
 func GetRecordTypes(processor *flowslatest.FlowCollectorFLP) []string {
-	outputRecordTypes := []string{constants.FlowLogRecordType}
-	if processor.OutputRecordTypes != nil {
-		switch *processor.OutputRecordTypes {
-		case flowslatest.OutputRecordFlows:
+	outputRecordTypes := []string{constants.FlowLogType}
+	if processor.LogTypes != nil {
+		switch *processor.LogTypes {
+		case flowslatest.LogTypeFlows:
 			outputRecordTypes = []string{
-				constants.FlowLogRecordType,
+				constants.FlowLogType,
 			}
-		case flowslatest.OutputRecordConnections:
+		case flowslatest.LogTypeConversations:
 			outputRecordTypes = []string{
-				constants.NewConnectionRecordType,
-				constants.HeartbeatRecordType,
-				constants.EndConnectionRecordType,
+				constants.NewConnectionType,
+				constants.HeartbeatType,
+				constants.EndConnectionType,
 			}
-		case flowslatest.OutputRecordEndedConnections:
+		case flowslatest.LogTypeEndedConversations:
 			outputRecordTypes = []string{
-				constants.EndConnectionRecordType,
+				constants.EndConnectionType,
 			}
-		case flowslatest.OutputRecordAll:
+		case flowslatest.LogTypeAll:
 			outputRecordTypes = []string{
-				constants.FlowLogRecordType,
-				constants.NewConnectionRecordType,
-				constants.HeartbeatRecordType,
-				constants.EndConnectionRecordType,
+				constants.FlowLogType,
+				constants.NewConnectionType,
+				constants.HeartbeatType,
+				constants.EndConnectionType,
 			}
 		}
 	}


### PR DESCRIPTION
`outputRecordTypes` -> `logTypes`
`connection` -> `conversation`

```yaml
spec:
...
  processor:
...
    logTypes: FLOWS
    conversationHeartbeatInterval: 30s
    conversationEndTimeout: 10s
```

Let's merge this first for consistency (at user level) and see if we do the renaming in FLP component in a followup since there are lots of changes