### PR TITLE
Update CRD documentation

### DIFF
--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -289,11 +289,15 @@ type FLPMetrics struct {
 	// +optional
 	Server MetricsServerConfig `json:"server,omitempty"`
 
-	// ignoreTags is a list of tags to specify which metrics to ignore
-	//+kubebuilder:default:={"egress","packets"}
+	// ignoreTags is a list of tags to specify which metrics to ignore. Each metric is associated with a list of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions .
+	// Available tags are: egress, ingress, flows, bytes, packets, namespaces, nodes, workloads
+	//+kubebuilder:default:={"flows","bytes","packets"}
 	IgnoreTags []string `json:"ignoreTags,omitempty"`
 
 	// disableAlerts is a list of alerts that should be disabled.
+	// Possible values are:
+	// `NetObservNoFlows`, which is triggered when no flows are being observed for a certain period.
+	// `NetObservLokiError`, which is triggered when flows are being dropped due to Loki errors.
 	// +optional
 	DisableAlerts []FLPAlert `json:"disableAlerts,omitempty"`
 }

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -4100,8 +4100,11 @@ spec:
                       metrics
                     properties:
                       disableAlerts:
-                        description: disableAlerts is a list of alerts that should
-                          be disabled.
+                        description: 'disableAlerts is a list of alerts that should
+                          be disabled. Possible values are: `NetObservNoFlows`, which
+                          is triggered when no flows are being observed for a certain
+                          period. `NetObservLokiError`, which is triggered when flows
+                          are being dropped due to Loki errors.'
                         items:
                           description: 'Name of a processor alert. Possible values
                             are: `NetObservNoFlows`, which is triggered when no flows
@@ -4115,10 +4118,14 @@ spec:
                         type: array
                       ignoreTags:
                         default:
-                        - egress
+                        - flows
+                        - bytes
                         - packets
-                        description: ignoreTags is a list of tags to specify which
-                          metrics to ignore
+                        description: 'ignoreTags is a list of tags to specify which
+                          metrics to ignore. Each metric is associated with a list
+                          of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions
+                          . Available tags are: egress, ingress, flows, bytes, packets,
+                          namespaces, nodes, workloads'
                         items:
                           type: string
                         type: array

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -4087,8 +4087,11 @@ spec:
                       metrics
                     properties:
                       disableAlerts:
-                        description: disableAlerts is a list of alerts that should
-                          be disabled.
+                        description: 'disableAlerts is a list of alerts that should
+                          be disabled. Possible values are: `NetObservNoFlows`, which
+                          is triggered when no flows are being observed for a certain
+                          period. `NetObservLokiError`, which is triggered when flows
+                          are being dropped due to Loki errors.'
                         items:
                           description: 'Name of a processor alert. Possible values
                             are: `NetObservNoFlows`, which is triggered when no flows
@@ -4102,10 +4105,14 @@ spec:
                         type: array
                       ignoreTags:
                         default:
-                        - egress
+                        - flows
+                        - bytes
                         - packets
-                        description: ignoreTags is a list of tags to specify which
-                          metrics to ignore
+                        description: 'ignoreTags is a list of tags to specify which
+                          metrics to ignore. Each metric is associated with a list
+                          of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions
+                          . Available tags are: egress, ingress, flows, bytes, packets,
+                          namespaces, nodes, workloads'
                         items:
                           type: string
                         type: array

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -7296,16 +7296,16 @@ Metrics define the processor configuration regarding metrics
         <td><b>disableAlerts</b></td>
         <td>[]enum</td>
         <td>
-          disableAlerts is a list of alerts that should be disabled.<br/>
+          disableAlerts is a list of alerts that should be disabled. Possible values are: `NetObservNoFlows`, which is triggered when no flows are being observed for a certain period. `NetObservLokiError`, which is triggered when flows are being dropped due to Loki errors.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>ignoreTags</b></td>
         <td>[]string</td>
         <td>
-          ignoreTags is a list of tags to specify which metrics to ignore<br/>
+          ignoreTags is a list of tags to specify which metrics to ignore. Each metric is associated with a list of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions . Available tags are: egress, ingress, flows, bytes, packets, namespaces, nodes, workloads<br/>
           <br/>
-            <i>Default</i>: [egress packets]<br/>
+            <i>Default</i>: [flows bytes packets]<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/flowcollector-flows-netobserv-io-v1beta1.adoc
+++ b/docs/flowcollector-flows-netobserv-io-v1beta1.adoc
@@ -1015,6 +1015,14 @@ Type::
 |===
 | Property | Type | Description
 
+| `conversationEndTimeout`
+| `string`
+| conversation end timeout is the duration of time to wait from the last flow log to end a conversation
+
+| `conversationHeartbeatInterval`
+| `string`
+| conversation heartbeat interval is the duration of time to wait between heartbeat reports of a conversation
+
 | `debug`
 | `object`
 | Debug allows setting some aspects of the internal configuration of the flow processor. This section is aimed exclusively for debugging and fine-grained performance optimizations (for example GOGC, GOMAXPROCS env vars). Users setting its values do it at their own risk.
@@ -1054,6 +1062,10 @@ Type::
 | `logLevel`
 | `string`
 | logLevel of the collector runtime
+
+| `logTypes`
+| `string`
+| logTypes defines the desired record types to generate. Possible values are "FLOWS" (default) to export flowLogs, "CONVERSATIONS" to generate newConnection, heartbeat, endConnection events, "ENDED_CONVERSATIONS" to generate only endConnection events or "ALL" to generate both flow logs and conversations events
 
 | `metrics`
 | `object`
@@ -1123,6 +1135,10 @@ Type::
 [cols="1,1,1",options="header"]
 |===
 | Property | Type | Description
+
+| `disableAlerts`
+| `array (string)`
+| disableAlerts is a list of alerts that should be disabled. Possible values are: `NetObservNoFlows`, which is triggered when no flows are being observed for a certain period. `NetObservLokiError`, which is triggered when flows are being dropped due to Loki errors.
 
 | `ignoreTags`
 | `array (string)`

--- a/hack/asciidoc-gen-config.yaml
+++ b/hack/asciidoc-gen-config.yaml
@@ -6,4 +6,4 @@ apiMap:
   resources:
   - kind: FlowCollector
     group: flows.netobserv.io
-    version: v1alpha1
+    version: v1beta1

--- a/hack/asciidoc-gen.sh
+++ b/hack/asciidoc-gen.sh
@@ -5,21 +5,21 @@ set -e
 mkdir -p _tmp
 oc get --raw /openapi/v2 | jq . > _tmp/openapi.json
 
-jq '.definitions |= ({"io.netobserv.flows.v1alpha1.FlowCollector"})
-  | del(.definitions."io.netobserv.flows.v1alpha1.FlowCollector".properties.status)
-  | del(.definitions."io.netobserv.flows.v1alpha1.FlowCollector".properties.metadata."$ref")
-  | .definitions."io.netobserv.flows.v1alpha1.FlowCollector".properties.metadata += {type:"object"}
-  | del(.definitions."io.netobserv.flows.v1alpha1.FlowCollector".properties.spec.properties.consolePlugin.properties.autoscaler.properties)
-  | del(.definitions."io.netobserv.flows.v1alpha1.FlowCollector".properties.spec.properties.processor.properties.kafkaConsumerAutoscaler.properties)
-  | .definitions."io.netobserv.flows.v1alpha1.FlowCollector".properties.spec.properties.consolePlugin.properties.autoscaler.description |= . + " Please refer to HorizontalPodAutoscaler documentation (autoscaling/v2)."
-  | .definitions."io.netobserv.flows.v1alpha1.FlowCollector".properties.spec.properties.processor.properties.kafkaConsumerAutoscaler.description |= . + " Please refer to HorizontalPodAutoscaler documentation (autoscaling/v2)."' \
+jq '.definitions |= ({"io.netobserv.flows.v1beta1.FlowCollector"})
+  | del(.definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.status)
+  | del(.definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.metadata."$ref")
+  | .definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.metadata += {type:"object"}
+  | del(.definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.spec.properties.consolePlugin.properties.autoscaler.properties)
+  | del(.definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.spec.properties.processor.properties.kafkaConsumerAutoscaler.properties)
+  | .definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.spec.properties.consolePlugin.properties.autoscaler.description |= . + " Please refer to HorizontalPodAutoscaler documentation (autoscaling/v2)."
+  | .definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.spec.properties.processor.properties.kafkaConsumerAutoscaler.description |= . + " Please refer to HorizontalPodAutoscaler documentation (autoscaling/v2)."' \
   _tmp/openapi.json > _tmp/openapi-amended.json
 
 openshift-apidocs-gen build -c hack/asciidoc-gen-config.yaml _tmp/openapi-amended.json
 
-ADOC=docs/flowcollector-flows-netobserv-io-v1alpha1.adoc
+ADOC=docs/flowcollector-flows-netobserv-io-v1beta1.adoc
 
-mv _tmp/flows_netobserv_io/flowcollector-flows-netobserv-io-v1alpha1.adoc $ADOC
+mv _tmp/flows_netobserv_io/flowcollector-flows-netobserv-io-v1beta1.adoc $ADOC
 
 sed -i -r 's/^:_content-type: ASSEMBLY$/:_content-type: REFERENCE/' $ADOC
 sed -i -r 's/^\[id="flowcollector-flows-netobserv-io-v.+"\]$/[id="network-observability-flowcollector-api-specifications_{context}"]/' $ADOC


### PR DESCRIPTION
- switch asciidoc gen to referencing v1beta1
- improve doc & default for ignored metrics (those changes were previously done on v1alpha1 instead of v1beta1, mistakenly)
- add enum info on disableAlerts doc (unfortunately the enum doc, while being correctly picked up for openapi, is not picked up for doc generation; so I am duplicating it)
- regenerate bundle & doc