### PR TITLE
NETOBSERV-765 Add CA/Secret config to ServiceMonitor

### DIFF
--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -540,7 +540,7 @@ type FlowCollectorConsolePlugin struct {
 	//+kubebuilder:validation:Minimum=1
 	//+kubebuilder:validation:Maximum=65535
 	//+kubebuilder:default:=9001
-	// port is the plugin service port
+	// port is the plugin service port. Do not use 9002, which is reserved for metrics.
 	Port int32 `json:"port,omitempty"`
 
 	//+kubebuilder:validation:Enum=IfNotPresent;Always;Never

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -2978,7 +2978,8 @@ spec:
                     type: string
                   port:
                     default: 9001
-                    description: port is the plugin service port
+                    description: port is the plugin service port. Do not use 9002,
+                      which is reserved for metrics.
                     format: int32
                     maximum: 65535
                     minimum: 1

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -2965,7 +2965,8 @@ spec:
                     type: string
                   port:
                     default: 9001
-                    description: port is the plugin service port
+                    description: port is the plugin service port. Do not use 9002,
+                      which is reserved for metrics.
                     format: int32
                     maximum: 65535
                     minimum: 1

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -1,6 +1,7 @@
 package consoleplugin
 
 import (
+	"fmt"
 	"hash/fnv"
 	"path/filepath"
 	"strconv"
@@ -84,6 +85,7 @@ func (b *builder) consolePlugin() *osv1alpha1.ConsolePlugin {
 }
 
 func (b *builder) serviceMonitor() *monitoringv1.ServiceMonitor {
+	serverName := fmt.Sprintf("%s.%s.svc", constants.PluginName, b.namespace)
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.PluginName,
@@ -97,6 +99,15 @@ func (b *builder) serviceMonitor() *monitoringv1.ServiceMonitor {
 					Scheme:   "https",
 					TLSConfig: &monitoringv1.TLSConfig{
 						SafeTLSConfig: monitoringv1.SafeTLSConfig{
+							ServerName: serverName,
+							CA: monitoringv1.SecretOrConfigMap{
+								ConfigMap: &corev1.ConfigMapKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "openshift-service-ca.crt",
+									},
+									Key: "service-ca.crt",
+								},
+							},
 							Cert: monitoringv1.SecretOrConfigMap{
 								Secret: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
@@ -104,6 +115,12 @@ func (b *builder) serviceMonitor() *monitoringv1.ServiceMonitor {
 									},
 									Key: "tls.crt",
 								},
+							},
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: secretName,
+								},
+								Key: "tls.key",
 							},
 						},
 					},

--- a/controllers/flowlogspipeline/flp_ingest_objects.go
+++ b/controllers/flowlogspipeline/flp_ingest_objects.go
@@ -68,12 +68,8 @@ func (b *ingestBuilder) buildPipelineConfig() ([]config.Stage, []config.StagePar
 	return pipeline.GetStages(), pipeline.GetStageParams(), nil
 }
 
-func (b *ingestBuilder) newPromService() *corev1.Service {
-	return b.generic.newPromService()
-}
-
-func (b *ingestBuilder) fromPromService(old *corev1.Service) *corev1.Service {
-	return b.generic.fromPromService(old)
+func (b *ingestBuilder) promService() *corev1.Service {
+	return b.generic.promService()
 }
 
 func buildClusterRoleIngester(useOpenShiftSCC bool) *rbacv1.ClusterRole {

--- a/controllers/flowlogspipeline/flp_ingest_reconciler.go
+++ b/controllers/flowlogspipeline/flp_ingest_reconciler.go
@@ -116,17 +116,8 @@ func (r *flpIngesterReconciler) reconcilePrometheusService(ctx context.Context, 
 	report := helper.NewChangeReport("FLP prometheus service")
 	defer report.LogIfNeeded(ctx)
 
-	if !r.nobjMngr.Exists(r.owned.promService) {
-		if err := r.CreateOwned(ctx, builder.newPromService()); err != nil {
-			return err
-		}
-	} else {
-		newSVC := builder.fromPromService(r.owned.promService)
-		if helper.ServiceChanged(r.owned.promService, newSVC, &report) {
-			if err := r.UpdateOwned(ctx, r.owned.promService, newSVC); err != nil {
-				return err
-			}
-		}
+	if err := reconcilers.ReconcileService(ctx, r.nobjMngr, &r.ClientHelper, r.owned.promService, builder.promService(), &report); err != nil {
+		return err
 	}
 	if r.availableAPIs.HasSvcMonitor() {
 		serviceMonitor := builder.generic.serviceMonitor()

--- a/controllers/flowlogspipeline/flp_monolith_objects.go
+++ b/controllers/flowlogspipeline/flp_monolith_objects.go
@@ -71,12 +71,8 @@ func (b *monolithBuilder) buildPipelineConfig() ([]config.Stage, []config.StageP
 	return pipeline.GetStages(), pipeline.GetStageParams(), dashboardConfigMap, nil
 }
 
-func (b *monolithBuilder) newPromService() *corev1.Service {
-	return b.generic.newPromService()
-}
-
-func (b *monolithBuilder) fromPromService(old *corev1.Service) *corev1.Service {
-	return b.generic.fromPromService(old)
+func (b *monolithBuilder) promService() *corev1.Service {
+	return b.generic.promService()
 }
 
 func (b *monolithBuilder) serviceAccount() *corev1.ServiceAccount {

--- a/controllers/flowlogspipeline/flp_monolith_reconciler.go
+++ b/controllers/flowlogspipeline/flp_monolith_reconciler.go
@@ -124,17 +124,8 @@ func (r *flpMonolithReconciler) reconcilePrometheusService(ctx context.Context, 
 	report := helper.NewChangeReport("FLP prometheus service")
 	defer report.LogIfNeeded(ctx)
 
-	if !r.nobjMngr.Exists(r.owned.promService) {
-		if err := r.CreateOwned(ctx, builder.newPromService()); err != nil {
-			return err
-		}
-	} else {
-		newSVC := builder.fromPromService(r.owned.promService)
-		if helper.ServiceChanged(r.owned.promService, newSVC, &report) {
-			if err := r.UpdateOwned(ctx, r.owned.promService, newSVC); err != nil {
-				return err
-			}
-		}
+	if err := reconcilers.ReconcileService(ctx, r.nobjMngr, &r.ClientHelper, r.owned.promService, builder.promService(), &report); err != nil {
+		return err
 	}
 	if r.availableAPIs.HasSvcMonitor() {
 		serviceMonitor := builder.generic.serviceMonitor()

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -429,7 +429,7 @@ func TestServiceNoChange(t *testing.T) {
 	ns := "namespace"
 	cfg := getConfig()
 	b := newMonolithBuilder(ns, image, &cfg, true)
-	first := b.newPromService()
+	first := b.promService()
 
 	// Check no change
 	newService := first.DeepCopy()
@@ -446,12 +446,12 @@ func TestServiceChanged(t *testing.T) {
 	ns := "namespace"
 	cfg := getConfig()
 	b := newMonolithBuilder(ns, image, &cfg, true)
-	first := b.newPromService()
+	first := b.promService()
 
 	// Check port changed
 	cfg.Processor.Metrics.Server.Port = 9999
 	b = newMonolithBuilder(ns, image, &cfg, true)
-	second := b.fromPromService(first)
+	second := b.promService()
 
 	report := helper.NewChangeReport("")
 	assert.True(helper.ServiceChanged(first, second, &report))
@@ -460,7 +460,7 @@ func TestServiceChanged(t *testing.T) {
 	// Make sure non-service settings doesn't trigger service update
 	cfg.Processor.LogLevel = "error"
 	b = newMonolithBuilder(ns, image, &cfg, true)
-	third := b.fromPromService(first)
+	third := b.promService()
 
 	report = helper.NewChangeReport("")
 	assert.False(helper.ServiceChanged(second, third, &report))
@@ -653,7 +653,7 @@ func TestLabels(t *testing.T) {
 	assert.Equal("dev", ds2.Spec.Template.Labels["version"])
 
 	// Service
-	svc := builder.newPromService()
+	svc := builder.promService()
 	assert.Equal("flowlogs-pipeline", svc.Labels["app"])
 	assert.Equal("flowlogs-pipeline", svc.Spec.Selector["app"])
 	assert.Equal("dev", svc.Labels["version"])

--- a/controllers/flowlogspipeline/flp_transfo_objects.go
+++ b/controllers/flowlogspipeline/flp_transfo_objects.go
@@ -76,12 +76,8 @@ func (b *transfoBuilder) buildPipelineConfig() ([]config.Stage, []config.StagePa
 	return pipeline.GetStages(), pipeline.GetStageParams(), dashboardConfigMap, nil
 }
 
-func (b *transfoBuilder) newPromService() *corev1.Service {
-	return b.generic.newPromService()
-}
-
-func (b *transfoBuilder) fromPromService(old *corev1.Service) *corev1.Service {
-	return b.generic.fromPromService(old)
+func (b *transfoBuilder) promService() *corev1.Service {
+	return b.generic.promService()
 }
 
 func (b *transfoBuilder) autoScaler() *ascv2.HorizontalPodAutoscaler {

--- a/controllers/flowlogspipeline/flp_transfo_reconciler.go
+++ b/controllers/flowlogspipeline/flp_transfo_reconciler.go
@@ -161,17 +161,8 @@ func (r *flpTransformerReconciler) reconcilePrometheusService(ctx context.Contex
 	report := helper.NewChangeReport("FLP prometheus service")
 	defer report.LogIfNeeded(ctx)
 
-	if !r.nobjMngr.Exists(r.owned.promService) {
-		if err := r.CreateOwned(ctx, builder.newPromService()); err != nil {
-			return err
-		}
-	} else {
-		newSVC := builder.fromPromService(r.owned.promService)
-		if helper.ServiceChanged(r.owned.promService, newSVC, &report) {
-			if err := r.UpdateOwned(ctx, r.owned.promService, newSVC); err != nil {
-				return err
-			}
-		}
+	if err := reconcilers.ReconcileService(ctx, r.nobjMngr, &r.ClientHelper, r.owned.promService, builder.promService(), &report); err != nil {
+		return err
 	}
 	if r.availableAPIs.HasSvcMonitor() {
 		serviceMonitor := builder.generic.serviceMonitor()

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -4341,7 +4341,7 @@ consolePlugin defines the settings related to the OpenShift Console plugin, when
         <td><b>port</b></td>
         <td>integer</td>
         <td>
-          port is the plugin service port<br/>
+          port is the plugin service port. Do not use 9002, which is reserved for metrics.<br/>
           <br/>
             <i>Format</i>: int32<br/>
             <i>Default</i>: 9001<br/>


### PR DESCRIPTION
Add missing CA/Secret to the console plugin service monitor

Cf https://github.com/netobserv/network-observability-console-plugin/pull/315

We might also want to add a bearer token config