### PR TITLE
NETOBSERV-933: make sure flows collector CRD has the right namespace for OCP

### DIFF
--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -12,7 +12,7 @@ spec:
       clientConfig:
         service:
           name: netobserv-webhook-service
-          namespace: netobserv
+          namespace: openshift-netobserv-operator
           path: /convert
       conversionReviewVersions:
       - v1alpha1

--- a/bundle/manifests/netobserv-webhook-service_v1_service.yaml
+++ b/bundle/manifests/netobserv-webhook-service_v1_service.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: webhook

--- a/config/openshift-olm/kustomization.yaml
+++ b/config/openshift-olm/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: netobserv
+namespace: openshift-netobserv-operator
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/openshift-olm/patch.yaml
+++ b/config/openshift-olm/patch.yaml
@@ -3,15 +3,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
-  annotations:
-    # functionality only works on openshift
-    service.beta.openshift.io/inject-cabundle: "true"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: webhook-service
   namespace: system
-  annotations:
-    # functionality only works on openshift
-    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert


### PR DESCRIPTION
flowcollectors namespace in the bundle need to point to the new namespace `openshift-netobserv-operator`