### PR TITLE
NETOBSERV-933: make sure flows collector CRD has the right namespace for OCP (backport 1.2)

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -654,14 +654,13 @@ type FlowCollectorStatus struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
-//+kubebuilder:printcolumn:name="Agent",type="string",JSONPath=`.spec.agent.type`
-//+kubebuilder:printcolumn:name="Sampling (EBPF)",type="string",JSONPath=`.spec.agent.ebpf.sampling`
-//+kubebuilder:printcolumn:name="Deployment Model",type="string",JSONPath=`.spec.deploymentModel`
-//+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[*].reason"
-// +kubebuilder:storageversion
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="Agent",type="string",JSONPath=`.spec.agent.type`
+// +kubebuilder:printcolumn:name="Sampling (EBPF)",type="string",JSONPath=`.spec.agent.ebpf.sampling`
+// +kubebuilder:printcolumn:name="Deployment Model",type="string",JSONPath=`.spec.deploymentModel`
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[*].reason"
 
 // FlowCollector is the Schema for the flowcollectors API, which pilots and configures netflow collection.
 type FlowCollector struct {

--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -710,6 +710,8 @@ type FlowCollectorStatus struct {
 // +kubebuilder:printcolumn:name="Sampling (EBPF)",type="string",JSONPath=`.spec.agent.ebpf.sampling`
 // +kubebuilder:printcolumn:name="Deployment Model",type="string",JSONPath=`.spec.deploymentModel`
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[*].reason"
+// +kubebuilder:storageversion
+
 // FlowCollector is the Schema for the flowcollectors API, which pilots and configures netflow collection.
 type FlowCollector struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -12,7 +12,7 @@ spec:
       clientConfig:
         service:
           name: netobserv-webhook-service
-          namespace: netobserv
+          namespace: openshift-netobserv-operator
           path: /convert
       conversionReviewVersions:
       - v1alpha1

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -2153,7 +2153,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -4386,7 +4386,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
 status:

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -2140,7 +2140,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -4373,7 +4373,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
 status:

--- a/config/openshift-olm/kustomization.yaml
+++ b/config/openshift-olm/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: netobserv
+namespace: openshift-netobserv-operator
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/controllers/flowcollector_controller_console_test.go
+++ b/controllers/flowcollector_controller_console_test.go
@@ -194,7 +194,7 @@ func flowCollectorConsolePluginSpecs() {
 
 			// Do a dummy change that will trigger reconcile, and make sure SM is created again
 			UpdateCR(crKey, func(fc *flowslatest.FlowCollector) {
-				fc.Spec.Processor.LogLevel = "info"
+				fc.Spec.Processor.LogLevel = "trace"
 			})
 			By("Expecting ServiceMonitor to exist")
 			Eventually(func() interface{} {


### PR DESCRIPTION
Signed-off-by: msherif1234 <mmahmoud@redhat.com>
(cherry picked from commit 32f7ad37b1838978b2eebf0d8e6d36d5aab38253)