### PR TITLE
NETOBSERV-933: make sure flows collector CRD has the right namespace for OCP (backport 1.2)

### DIFF
--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -12,7 +12,7 @@ spec:
       clientConfig:
         service:
           name: netobserv-webhook-service
-          namespace: netobserv
+          namespace: openshift-netobserv-operator
           path: /convert
       conversionReviewVersions:
       - v1alpha1

--- a/config/openshift-olm/kustomization.yaml
+++ b/config/openshift-olm/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: netobserv
+namespace: openshift-netobserv-operator
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named


### PR DESCRIPTION
Signed-off-by: msherif1234 <mmahmoud@redhat.com>
(cherry picked from commit 32f7ad37b1838978b2eebf0d8e6d36d5aab38253)