### PR TITLE
NETOBSERV-993 Restore default metrics

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -279,7 +279,7 @@ type FLPMetrics struct {
 
 	// ignoreTags is a list of tags to specify which metrics to ignore. Each metric is associated with a list of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions .
 	// Available tags are: egress, ingress, flows, bytes, packets, namespaces, nodes, workloads
-	//+kubebuilder:default:={"flows","bytes","packets"}
+	//+kubebuilder:default:={"egress","packets"}
 	IgnoreTags []string `json:"ignoreTags,omitempty"`
 }
 

--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -291,7 +291,7 @@ type FLPMetrics struct {
 
 	// ignoreTags is a list of tags to specify which metrics to ignore. Each metric is associated with a list of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions .
 	// Available tags are: egress, ingress, flows, bytes, packets, namespaces, nodes, workloads
-	//+kubebuilder:default:={"flows","bytes","packets"}
+	//+kubebuilder:default:={"egress","packets"}
 	IgnoreTags []string `json:"ignoreTags,omitempty"`
 
 	// disableAlerts is a list of alerts that should be disabled.

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -1951,8 +1951,7 @@ spec:
                     properties:
                       ignoreTags:
                         default:
-                        - flows
-                        - bytes
+                        - egress
                         - packets
                         description: 'ignoreTags is a list of tags to specify which
                           metrics to ignore. Each metric is associated with a list
@@ -4184,8 +4183,7 @@ spec:
                         type: array
                       ignoreTags:
                         default:
-                        - flows
-                        - bytes
+                        - egress
                         - packets
                         description: 'ignoreTags is a list of tags to specify which
                           metrics to ignore. Each metric is associated with a list

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -143,8 +143,7 @@ metadata:
               "logLevel": "info",
               "metrics": {
                 "ignoreTags": [
-                  "flows",
-                  "bytes",
+                  "egress",
                   "packets"
                 ],
                 "server": {
@@ -323,8 +322,7 @@ metadata:
               "metrics": {
                 "disableAlerts": [],
                 "ignoreTags": [
-                  "flows",
-                  "bytes",
+                  "egress",
                   "packets"
                 ],
                 "server": {

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -1938,8 +1938,7 @@ spec:
                     properties:
                       ignoreTags:
                         default:
-                        - flows
-                        - bytes
+                        - egress
                         - packets
                         description: 'ignoreTags is a list of tags to specify which
                           metrics to ignore. Each metric is associated with a list
@@ -4171,8 +4170,7 @@ spec:
                         type: array
                       ignoreTags:
                         default:
-                        - flows
-                        - bytes
+                        - egress
                         - packets
                         description: 'ignoreTags is a list of tags to specify which
                           metrics to ignore. Each metric is associated with a list

--- a/config/samples/flows_v1alpha1_flowcollector.yaml
+++ b/config/samples/flows_v1alpha1_flowcollector.yaml
@@ -31,8 +31,7 @@ spec:
       server:
         port: 9102
       ignoreTags:
-        - flows
-        - bytes
+        - egress
         - packets
     dropUnusedFields: true
     resources:

--- a/config/samples/flows_v1beta1_flowcollector.yaml
+++ b/config/samples/flows_v1beta1_flowcollector.yaml
@@ -31,8 +31,7 @@ spec:
       server:
         port: 9102
       ignoreTags:
-        - flows
-        - bytes
+        - egress
         - packets
       disableAlerts: []
     dropUnusedFields: true

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -3499,7 +3499,7 @@ Metrics define the processor configuration regarding metrics
         <td>
           ignoreTags is a list of tags to specify which metrics to ignore. Each metric is associated with a list of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions . Available tags are: egress, ingress, flows, bytes, packets, namespaces, nodes, workloads<br/>
           <br/>
-            <i>Default</i>: [flows bytes packets]<br/>
+            <i>Default</i>: [egress packets]<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7464,7 +7464,7 @@ Metrics define the processor configuration regarding metrics
         <td>
           ignoreTags is a list of tags to specify which metrics to ignore. Each metric is associated with a list of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions . Available tags are: egress, ingress, flows, bytes, packets, namespaces, nodes, workloads<br/>
           <br/>
-            <i>Default</i>: [flows bytes packets]<br/>
+            <i>Default</i>: [egress packets]<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
Re-enabling the defaults, so that the related dashboard is visible by default