### PR TITLE
NETOBSERV-1033: Lock down Network Observability

### DIFF
--- a/config/policy/lockdown-netobserv.yaml
+++ b/config/policy/lockdown-netobserv.yaml
@@ -1,0 +1,21 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: lockdown-netobserv
+  namespace: netobserv
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - podSelector: {}  # without namespaceSelecor, it defaults to 'same namespace'
+        - podSelector: {}
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-console
+        - podSelector: {}
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+  policyTypes:
+    - Ingress
+status: {}


### PR DESCRIPTION
Network policy to lock down ingress traffic to 'netobserv' namespace