### PR TITLE
Attempt to fix multiarch workflow

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -8,6 +8,7 @@ env:
   REGISTRY: quay.io/netobserv
   IMAGE: network-observability-operator
   ORG: netobserv
+  MULTIARCH_TARGETS: amd64 arm64 ppc64le
   VERSION: main
 
 jobs:
@@ -35,13 +36,17 @@ jobs:
       - name: get short sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build images
-        run: IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.VERSION }} make image-build
+        run: |
+          MULTIARCH_TARGETS=${{ env.MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.VERSION }} make image-build
+          MULTIARCH_TARGETS=${{ env.MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} OCI_BUILD_OPTS="--label quay.expires-after=2w" make image-build
       - name: push images
-        run: IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.VERSION }} make image-push
+        run: |
+          MULTIARCH_TARGETS=${{ env.MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.VERSION }} make image-push
+          MULTIARCH_TARGETS=${{ env.MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make image-push
       - name: build and push manifest
-        run: IMAGE_ORG=${{ env.ORG }} VERSION=${{ env.VERSION }} make ci-manifest
-      - name: print image url
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        run: |
+          IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.VERSION }} make manifest-build manifest-push
+          IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make manifest-build manifest-push
       - name: build bundle
         run: IMAGE_ORG=${{ env.ORG }} VERSION=${{ env.VERSION }} PLG_VERSION=${{ env.VERSION }} FLP_VERSION=${{ env.VERSION }} BPF_VERSION=${{ env.VERSION }} BUNDLE_VERSION=0.0.0-${{ env.VERSION }} make bundle bundle-build
       - name: push bundle to quay.io
@@ -60,9 +65,6 @@ jobs:
           image: ${{ env.IMAGE }}-catalog
           tags: v0.0.0-${{ env.VERSION }}
           registry: ${{ env.REGISTRY }}
-      - name: print images reference
-        run: |
-          echo "Images: ${{ steps.push-to-quay.outputs.registry-paths }}, ${{ steps.push-bundle.outputs.registry-paths }}, ${{ steps.push-catalog.outputs.registry-paths }}"
 
   codecov:
     name: Codecov upload

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -8,7 +8,7 @@ env:
   WF_REGISTRY: quay.io/netobserv
   WF_IMAGE: network-observability-operator
   WF_ORG: netobserv
-  WF_MULTIARCH_TARGETS: "amd64 arm64 ppc64le"
+  WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le
   WF_VERSION: main
 
 jobs:
@@ -37,12 +37,12 @@ jobs:
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build images
         run: |
-          MULTIARCH_TARGETS=${{ env.WF_MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.WF_VERSION }} make image-build
-          MULTIARCH_TARGETS=${{ env.WF_MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} OCI_BUILD_OPTS="--label quay.expires-after=2w" make image-build
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.WF_VERSION }} make image-build
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} OCI_BUILD_OPTS="--label quay.expires-after=2w" make image-build
       - name: push images
         run: |
-          MULTIARCH_TARGETS=${{ env.WF_MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.WF_VERSION }} make image-push
-          MULTIARCH_TARGETS=${{ env.WF_MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make image-push
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.WF_VERSION }} make image-push
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make image-push
       - name: build and push manifest
         run: |
           IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.WF_VERSION }} make manifest-build manifest-push

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -1,7 +1,7 @@
 name: Build and push to quay.io
 on:
   push:
-    branches: [ main ]
+    branches: [ main, workflow-test ]
 
 env:
   WF_REGISTRY_USER: netobserv+github_ci
@@ -9,7 +9,7 @@ env:
   WF_IMAGE: network-observability-operator
   WF_ORG: netobserv
   WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le
-  WF_VERSION: main
+  WF_VERSION: ${{ github.ref_name }}
 
 jobs:
   push-image:

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -4,12 +4,12 @@ on:
     branches: [ main ]
 
 env:
-  REGISTRY_USER: netobserv+github_ci
-  REGISTRY: quay.io/netobserv
-  IMAGE: network-observability-operator
-  ORG: netobserv
-  MULTIARCH_TARGETS: amd64 arm64 ppc64le
-  VERSION: main
+  WF_REGISTRY_USER: netobserv+github_ci
+  WF_REGISTRY: quay.io/netobserv
+  WF_IMAGE: network-observability-operator
+  WF_ORG: netobserv
+  WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le
+  WF_VERSION: main
 
 jobs:
   push-image:
@@ -30,41 +30,41 @@ jobs:
       - name: docker login to quay.io
         uses: docker/login-action@v2
         with:
-          username: ${{ env.REGISTRY_USER }}
+          username: ${{ env.WF_REGISTRY_USER }}
           password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
       - name: get short sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build images
         run: |
-          MULTIARCH_TARGETS=${{ env.MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.VERSION }} make image-build
-          MULTIARCH_TARGETS=${{ env.MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} OCI_BUILD_OPTS="--label quay.expires-after=2w" make image-build
+          MULTIARCH_TARGETS=${{ env.WF_MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.WF_VERSION }} make image-build
+          MULTIARCH_TARGETS=${{ env.WF_MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} OCI_BUILD_OPTS="--label quay.expires-after=2w" make image-build
       - name: push images
         run: |
-          MULTIARCH_TARGETS=${{ env.MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.VERSION }} make image-push
-          MULTIARCH_TARGETS=${{ env.MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make image-push
+          MULTIARCH_TARGETS=${{ env.WF_MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.WF_VERSION }} make image-push
+          MULTIARCH_TARGETS=${{ env.WF_MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make image-push
       - name: build and push manifest
         run: |
-          IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.VERSION }} make manifest-build manifest-push
-          IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make manifest-build manifest-push
+          IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.WF_VERSION }} make manifest-build manifest-push
+          IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make manifest-build manifest-push
       - name: build bundle
-        run: IMAGE_ORG=${{ env.ORG }} VERSION=${{ env.VERSION }} PLG_VERSION=${{ env.VERSION }} FLP_VERSION=${{ env.VERSION }} BPF_VERSION=${{ env.VERSION }} BUNDLE_VERSION=0.0.0-${{ env.VERSION }} make bundle bundle-build
+        run: IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.WF_VERSION }} PLG_VERSION=${{ env.WF_VERSION }} FLP_VERSION=${{ env.WF_VERSION }} BPF_VERSION=${{ env.WF_VERSION }} BUNDLE_VERSION=0.0.0-${{ env.WF_VERSION }} make bundle bundle-build
       - name: push bundle to quay.io
         id: push-bundle
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: ${{ env.IMAGE }}-bundle
-          tags: v0.0.0-${{ env.VERSION }}
-          registry: ${{ env.REGISTRY }}
+          image: ${{ env.WF_IMAGE }}-bundle
+          tags: v0.0.0-${{ env.WF_VERSION }}
+          registry: ${{ env.WF_REGISTRY }}
       - name: build catalog
-        run: IMAGE_ORG=${{ env.ORG }} BUNDLE_VERSION=0.0.0-${{ env.VERSION }} make catalog-build
+        run: IMAGE_ORG=${{ env.WF_ORG }} BUNDLE_VERSION=0.0.0-${{ env.WF_VERSION }} make catalog-build
       - name: push catalog to quay.io
         id: push-catalog
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: ${{ env.IMAGE }}-catalog
-          tags: v0.0.0-${{ env.VERSION }}
-          registry: ${{ env.REGISTRY }}
+          image: ${{ env.WF_IMAGE }}-catalog
+          tags: v0.0.0-${{ env.WF_VERSION }}
+          registry: ${{ env.WF_REGISTRY }}
 
   codecov:
     name: Codecov upload

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -8,7 +8,7 @@ env:
   WF_REGISTRY: quay.io/netobserv
   WF_IMAGE: network-observability-operator
   WF_ORG: netobserv
-  WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le
+  WF_MULTIARCH_TARGETS: "amd64 arm64 ppc64le"
   WF_VERSION: main
 
 jobs:

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -8,7 +8,6 @@ env:
   REGISTRY: quay.io/netobserv
   IMAGE: network-observability-operator
   ORG: netobserv
-  VERSION: temp
 
 jobs:
   push-pr-image:
@@ -37,12 +36,12 @@ jobs:
           registry: quay.io
       - name: get short sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-      - name: build images
-        run: IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make image-build
-      - name: push images
+      - name: build image
+        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make image-build
+      - name: push image
         run: IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make image-push
       - name: build and push manifest
-        run: IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make ci-manifest
+        run: IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make manifest-build manifest-push
       - name: build bundle
         run: IMAGE_ORG=${{ env.ORG }} VERSION=${{ env.short_sha }} PLG_VERSION=main FLP_VERSION=main BPF_VERSION=main BUNDLE_VERSION=0.0.0-${{ env.short_sha }} make bundle shortlived-bundle-build
       - name: push bundle to quay.io

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -4,10 +4,10 @@ on:
     types: [labeled]
 
 env:
-  REGISTRY_USER: netobserv+github_ci
-  REGISTRY: quay.io/netobserv
-  IMAGE: network-observability-operator
-  ORG: netobserv
+  WF_REGISTRY_USER: netobserv+github_ci
+  WF_REGISTRY: quay.io/netobserv
+  WF_IMAGE: network-observability-operator
+  WF_ORG: netobserv
 
 jobs:
   push-pr-image:
@@ -31,35 +31,35 @@ jobs:
       - name: docker login to quay.io
         uses: docker/login-action@v2
         with:
-          username: ${{ env.REGISTRY_USER }}
+          username: ${{ env.WF_REGISTRY_USER }}
           password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
       - name: get short sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build image
-        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make image-build
+        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make image-build
       - name: push image
-        run: IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make image-push
+        run: IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make image-push
       - name: build and push manifest
-        run: IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make manifest-build manifest-push
+        run: IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make manifest-build manifest-push
       - name: build bundle
-        run: IMAGE_ORG=${{ env.ORG }} VERSION=${{ env.short_sha }} PLG_VERSION=main FLP_VERSION=main BPF_VERSION=main BUNDLE_VERSION=0.0.0-${{ env.short_sha }} make bundle shortlived-bundle-build
+        run: IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.short_sha }} PLG_VERSION=main FLP_VERSION=main BPF_VERSION=main BUNDLE_VERSION=0.0.0-${{ env.short_sha }} make bundle shortlived-bundle-build
       - name: push bundle to quay.io
         id: push-bundle
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: ${{ env.IMAGE }}-bundle
+          image: ${{ env.WF_IMAGE }}-bundle
           tags: v0.0.0-${{ env.short_sha }}
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.WF_REGISTRY }}
       - name: build catalog
-        run: IMAGE_ORG=${{ env.ORG }} BUNDLE_VERSION=0.0.0-${{ env.short_sha }} make shortlived-catalog-build
+        run: IMAGE_ORG=${{ env.WF_ORG }} BUNDLE_VERSION=0.0.0-${{ env.short_sha }} make shortlived-catalog-build
       - name: push catalog to quay.io
         id: push-catalog
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: ${{ env.IMAGE }}-catalog
+          image: ${{ env.WF_IMAGE }}-catalog
           tags: v0.0.0-${{ env.short_sha }}
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.WF_REGISTRY }}
       - uses: actions/github-script@v5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -69,9 +69,9 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `New images:
-            * ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }}
-            * ${{ env.REGISTRY }}/${{ env.IMAGE }}-bundle:v0.0.0-${{ env.short_sha }}
-            * ${{ env.REGISTRY }}/${{ env.IMAGE }}-catalog:v0.0.0-${{ env.short_sha }}
+            * ${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }}
+            * ${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}-bundle:v0.0.0-${{ env.short_sha }}
+            * ${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}-catalog:v0.0.0-${{ env.short_sha }}
 
             They will expire after two weeks.
             
@@ -84,7 +84,7 @@ jobs:
               namespace: openshift-marketplace
             spec:
               sourceType: grpc
-              image: ${{ env.REGISTRY }}/${{ env.IMAGE }}-catalog:v0.0.0-${{ env.short_sha }}
+              image: ${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}-catalog:v0.0.0-${{ env.short_sha }}
               displayName: NetObserv development catalog
               publisher: Me
               updateStrategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,10 @@ on:
 
 env:
   REGISTRY_USER: netobserv+github_ci
-  REGISTRY_PASSWORD: ${{ secrets.QUAY_SECRET }}
   REGISTRY: quay.io/netobserv
   IMAGE: network-observability-operator
+  ORG: netobserv
+  MULTIARCH_TARGETS: amd64 arm64 ppc64le
 
 jobs:
   push-image:
@@ -23,7 +24,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: ${{ env.REGISTRY_USER }}
-          password: ${{ env.REGISTRY_PASSWORD }}
+          password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
       - name: validate tag
         run: |
@@ -43,15 +44,16 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: build operator
-        run: IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.tag }} make image-build
+        run: |
+          MULTIARCH_TARGETS=${{ env.MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.tag }} make image-build
       - name: push operator
-        run: IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.tag }} make image-push
-      - name: build manifest
-        run: IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.tag }} make manifest-build
-      - name: push manifest
-        run: IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.tag }} make manifest-push
+        run: |
+          MULTIARCH_TARGETS=${{ env.MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.tag }} make image-push
+      - name: build and push manifest
+        run: |
+          IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.tag }} make manifest-build manifest-push
       - name: build bundle
-        run: BUNDLE_VERSION=${{ env.tag }} IMAGE_TAG_BASE=${{ env.REGISTRY }}/${{ env.IMAGE }} make bundle-build
+        run: IMAGE_ORG=${{ env.ORG }} BUNDLE_VERSION=${{ env.tag }} IMAGE_TAG_BASE=${{ env.REGISTRY }}/${{ env.IMAGE }} make bundle-build
       - name: push bundle to quay.io
         id: push-bundle
         uses: redhat-actions/push-to-registry@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,11 @@ on:
     tags: ['*']
 
 env:
-  REGISTRY_USER: netobserv+github_ci
-  REGISTRY: quay.io/netobserv
-  IMAGE: network-observability-operator
-  ORG: netobserv
-  MULTIARCH_TARGETS: amd64 arm64 ppc64le
+  WF_REGISTRY_USER: netobserv+github_ci
+  WF_REGISTRY: quay.io/netobserv
+  WF_IMAGE: network-observability-operator
+  WF_ORG: netobserv
+  WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le
 
 jobs:
   push-image:
@@ -23,7 +23,7 @@ jobs:
       - name: docker login to quay.io
         uses: docker/login-action@v2
         with:
-          username: ${{ env.REGISTRY_USER }}
+          username: ${{ env.WF_REGISTRY_USER }}
           password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
       - name: validate tag
@@ -45,31 +45,28 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: build operator
         run: |
-          MULTIARCH_TARGETS=${{ env.MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.tag }} make image-build
+          MULTIARCH_TARGETS=${{ env.WF_MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.tag }} make image-build
       - name: push operator
         run: |
-          MULTIARCH_TARGETS=${{ env.MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.tag }} make image-push
+          MULTIARCH_TARGETS=${{ env.WF_MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.tag }} make image-push
       - name: build and push manifest
         run: |
-          IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.tag }} make manifest-build manifest-push
+          IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.tag }} make manifest-build manifest-push
       - name: build bundle
-        run: IMAGE_ORG=${{ env.ORG }} BUNDLE_VERSION=${{ env.tag }} IMAGE_TAG_BASE=${{ env.REGISTRY }}/${{ env.IMAGE }} make bundle-build
+        run: IMAGE_ORG=${{ env.WF_ORG }} BUNDLE_VERSION=${{ env.tag }} IMAGE_TAG_BASE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }} make bundle-build
       - name: push bundle to quay.io
         id: push-bundle
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: ${{ env.IMAGE }}-bundle
+          image: ${{ env.WF_IMAGE }}-bundle
           tags: v${{ env.tag }}
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.WF_REGISTRY }}
       - name: build catalog
-        run: BUNDLE_VERSION=${{ env.tag }} IMAGE_TAG_BASE=${{ env.REGISTRY }}/${{ env.IMAGE }} make catalog-build
+        run: BUNDLE_VERSION=${{ env.tag }} IMAGE_TAG_BASE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }} make catalog-build
       - name: push catalog to quay.io
         id: push-catalog
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: ${{ env.IMAGE }}-catalog
+          image: ${{ env.WF_IMAGE }}-catalog
           tags: v${{ env.tag }}
-          registry: ${{ env.REGISTRY }}
-      - name: print images reference
-        run: |
-          echo "Images: ${{ steps.push-operator.outputs.registry-paths }}, ${{ steps.push-bundle.outputs.registry-paths }}, ${{ steps.push-catalog.outputs.registry-paths }}"
+          registry: ${{ env.WF_REGISTRY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   WF_REGISTRY: quay.io/netobserv
   WF_IMAGE: network-observability-operator
   WF_ORG: netobserv
-  WF_MULTIARCH_TARGETS: "amd64 arm64 ppc64le"
+  WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le
 
 jobs:
   push-image:
@@ -45,10 +45,10 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: build operator
         run: |
-          MULTIARCH_TARGETS=${{ env.WF_MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.tag }} make image-build
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.tag }} make image-build
       - name: push operator
         run: |
-          MULTIARCH_TARGETS=${{ env.WF_MULTIARCH_TARGETS }} IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.tag }} make image-push
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.tag }} make image-push
       - name: build and push manifest
         run: |
           IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.tag }} make manifest-build manifest-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   WF_REGISTRY: quay.io/netobserv
   WF_IMAGE: network-observability-operator
   WF_ORG: netobserv
-  WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le
+  WF_MULTIARCH_TARGETS: "amd64 arm64 ppc64le"
 
 jobs:
   push-image:

--- a/.mk/shortcuts.mk
+++ b/.mk/shortcuts.mk
@@ -14,18 +14,6 @@ push-manifest: manifest-push ## Push MULTIARCH_TARGETS manifest
 .PHONY: images
 images: image-build image-push manifest-build manifest-push ## Build and push MULTIARCH_TARGETS images and related manifest
 
-.PHONY: build-ci-manifest
-build-ci-manifest: ci-manifest-build ## Build CI manifest
-
-.PHONY: push-ci-manifest
-push-ci-manifest: ci-manifest-push ## Push CI manifest
-
-.PHONY: ci-manifest
-ci-manifest: ci-manifest-build ci-manifest-push ## Build and push CI manifest
-
-.PHONY: ci
-ci: images ci-manifest ## Build and push CI images and manifest
-
 .PHONY: build-catalog
 build-catalog: catalog-build ## Build a catalog image
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -213,3 +213,15 @@ make set-release-kind-downstream
 ```
 
 Most notably change will concern the monitoring part which will use the platoform monitoring stack instead of the user workload monitoring stack.
+
+## Testing the github workflow
+
+Testing github workflows can sometimes be tricky as it's not always possible to run everything locally, and they depend on triggers such as merging a commit, or pushing a tag on the upstream.
+
+One thing you should do if you modified the workflows and/or the Makefiles, is to run the `hack/test-workflow.sh` script. It is not a silver bullet, but it will test a bunch of things in the workflows, such as expecting some images to be built, and correctly referenced in the CSV. But it cannot cover everything, like it won't push anything to the image registry.
+
+The second thing you can do is to push your commits to the upstream `workflow-test` branch. The `push_image.yml` workflow is triggered on that branch, just like when something is merged on the `main` branch. So, you can open the [corresponding page](https://github.com/netobserv/network-observability-operator/actions/workflows/push_image.yml) in Github to monitor the jobs triggered. Make sure on Quay that you get the expected images for the [Operator](https://quay.io/repository/netobserv/network-observability-operator?tab=tags), the [bundle](https://quay.io/repository/netobserv/network-observability-operator-bundle?tab=tags) and the [catalog](https://quay.io/repository/netobserv/network-observability-operator-catalog?tab=tags).
+
+Then, you can test the upstream release process by [following the doc](./RELEASE.md). Don't do a full release of course, but just create a release candidate (e.g. set version to 1.0.3-rc0). When the tag is pushed, it will trigger the corresponding workflow ([view on github](https://github.com/netobserv/network-observability-operator/actions/workflows/release.yml)). As above, you should check that the images are well created in Quay.. It's fine if you tag from the `workflow-test` branch (or any branch). You can remove the tag after you tested.
+
+Finally, to test the per-PR workflow (pre-merge testing), just open a dummy PR against the upstream branch `workflow-test` (where you pushed your workflow changes), and add the usual `ok-to-test` label. This will trigger the corresponding `push_image_pr.yml` workflow ([view on github](https://github.com/netobserv/network-observability-operator/actions/workflows/push_image_pr.yml)). As above, you should check that the images are well created in Quay.

--- a/hack/test-workflow.sh
+++ b/hack/test-workflow.sh
@@ -20,12 +20,12 @@ run_step() {
 
   version=$(cat .github/workflows/$file | yq ".env.VERSION")
   step=$(cat .github/workflows/$file | yq ".jobs.$job.steps[] | select(.name==\"$name\").run")
-  step=$(echo $step | sed -r "s~\\$\{\{ env\.ORG \}\}~netobserv~g" | sed -r "s~\\$\{\{ env\.VERSION \}\}~$version~g" | sed -r "s~\\$\{\{ env\.REGISTRY \}\}~quay.io/netobserv~g" | sed -r "s~\\$\{\{ env\.IMAGE \}\}~network-observability-operator~g" | sed -r "s~\\$\{\{ env\.short_sha \}\}~$short_sha~g" | sed -r "s~\\$\{\{ env\.tag \}\}~$fake_tag~g")
+  step=$(echo "$step" | sed -r "s~\\$\{\{ env\.ORG \}\}~netobserv~g" | sed -r "s~\\$\{\{ env\.VERSION \}\}~$version~g" | sed -r "s~\\$\{\{ env\.REGISTRY \}\}~quay.io/netobserv~g" | sed -r "s~\\$\{\{ env\.IMAGE \}\}~network-observability-operator~g" | sed -r "s~\\$\{\{ env\.MULTIARCH_TARGETS \}\}~\"amd64 arm64 ppc64le\"~g" | sed -r "s~\\$\{\{ env\.short_sha \}\}~$short_sha~g" | sed -r "s~\\$\{\{ env\.tag \}\}~$fake_tag~g")
   step="$opts $step"
 
   echo "↘️  Running step '$name' ($file)"
-  echo $step
-  eval $step > $test_out 2>&1
+  echo "$step"
+  eval "$step" > $test_out 2>&1
 
   if [ $? -ne 0 ]; then
       echo "❌ Step failed"
@@ -67,10 +67,8 @@ expect_occurrences_at_least() {
 echo -e "🥁🥁🥁 TESTING push_image_pr.yml 🥁🥁🥁"
 
 # we only test images here as manifest-build need images to be pushed
-run_step "push_image_pr.yml" "push-pr-image" "build images"
+run_step "push_image_pr.yml" "push-pr-image" "build image"
 expect_image_tagged "quay.io/netobserv/network-observability-operator:$short_sha-amd64"
-expect_image_tagged "quay.io/netobserv/network-observability-operator:$short_sha-arm64"
-expect_image_tagged "quay.io/netobserv/network-observability-operator:$short_sha-ppc64le"
 
 run_step "push_image_pr.yml" "push-pr-image" "build bundle"
 expect_image_tagged "quay.io/netobserv/network-observability-operator-bundle:v0.0.0-$short_sha"
@@ -91,6 +89,9 @@ run_step "push_image.yml" "push-image" "build images"
 expect_image_tagged "quay.io/netobserv/network-observability-operator:main-amd64"
 expect_image_tagged "quay.io/netobserv/network-observability-operator:main-arm64"
 expect_image_tagged "quay.io/netobserv/network-observability-operator:main-ppc64le"
+expect_image_tagged "quay.io/netobserv/network-observability-operator:$short_sha-amd64"
+expect_image_tagged "quay.io/netobserv/network-observability-operator:$short_sha-arm64"
+expect_image_tagged "quay.io/netobserv/network-observability-operator:$short_sha-ppc64le"
 
 run_step "push_image.yml" "push-image" "build bundle"
 expect_image_tagged "quay.io/netobserv/network-observability-operator-bundle:v0.0.0-main"

--- a/hack/test-workflow.sh
+++ b/hack/test-workflow.sh
@@ -20,7 +20,7 @@ run_step() {
 
   version=$(cat .github/workflows/$file | yq ".env.WF_VERSION")
   step=$(cat .github/workflows/$file | yq ".jobs.$job.steps[] | select(.name==\"$name\").run")
-  step=$(echo "$step" | sed -r "s~\\$\{\{ env\.WF_ORG \}\}~netobserv~g" | sed -r "s~\\$\{\{ env\.WF_VERSION \}\}~$version~g" | sed -r "s~\\$\{\{ env\.WF_REGISTRY \}\}~quay.io/netobserv~g" | sed -r "s~\\$\{\{ env\.WF_IMAGE \}\}~network-observability-operator~g" | sed -r "s~\\$\{\{ env\.WF_MULTIARCH_TARGETS \}\}~\"amd64 arm64 ppc64le\"~g" | sed -r "s~\\$\{\{ env\.short_sha \}\}~$short_sha~g" | sed -r "s~\\$\{\{ env\.tag \}\}~$fake_tag~g")
+  step=$(echo "$step" | sed -r "s~\\$\{\{ env\.WF_ORG \}\}~netobserv~g" | sed -r "s~\\$\{\{ env\.WF_VERSION \}\}~$version~g" | sed -r "s~\\$\{\{ env\.WF_REGISTRY \}\}~quay.io/netobserv~g" | sed -r "s~\\$\{\{ env\.WF_IMAGE \}\}~network-observability-operator~g" | sed -r "s~\\$\{\{ env\.WF_MULTIARCH_TARGETS \}\}~amd64 arm64 ppc64le~g" | sed -r "s~\\$\{\{ env\.short_sha \}\}~$short_sha~g" | sed -r "s~\\$\{\{ env\.tag \}\}~$fake_tag~g")
   step="$opts $step"
 
   echo "↘️  Running step '$name' ($file)"

--- a/hack/test-workflow.sh
+++ b/hack/test-workflow.sh
@@ -18,9 +18,9 @@ run_step() {
   name=$3
   opts=$4
 
-  version=$(cat .github/workflows/$file | yq ".env.VERSION")
+  version=$(cat .github/workflows/$file | yq ".env.WF_VERSION")
   step=$(cat .github/workflows/$file | yq ".jobs.$job.steps[] | select(.name==\"$name\").run")
-  step=$(echo "$step" | sed -r "s~\\$\{\{ env\.ORG \}\}~netobserv~g" | sed -r "s~\\$\{\{ env\.VERSION \}\}~$version~g" | sed -r "s~\\$\{\{ env\.REGISTRY \}\}~quay.io/netobserv~g" | sed -r "s~\\$\{\{ env\.IMAGE \}\}~network-observability-operator~g" | sed -r "s~\\$\{\{ env\.MULTIARCH_TARGETS \}\}~\"amd64 arm64 ppc64le\"~g" | sed -r "s~\\$\{\{ env\.short_sha \}\}~$short_sha~g" | sed -r "s~\\$\{\{ env\.tag \}\}~$fake_tag~g")
+  step=$(echo "$step" | sed -r "s~\\$\{\{ env\.WF_ORG \}\}~netobserv~g" | sed -r "s~\\$\{\{ env\.WF_VERSION \}\}~$version~g" | sed -r "s~\\$\{\{ env\.WF_REGISTRY \}\}~quay.io/netobserv~g" | sed -r "s~\\$\{\{ env\.WF_IMAGE \}\}~network-observability-operator~g" | sed -r "s~\\$\{\{ env\.WF_MULTIARCH_TARGETS \}\}~\"amd64 arm64 ppc64le\"~g" | sed -r "s~\\$\{\{ env\.short_sha \}\}~$short_sha~g" | sed -r "s~\\$\{\{ env\.tag \}\}~$fake_tag~g")
   step="$opts $step"
 
   echo "↘️  Running step '$name' ($file)"


### PR DESCRIPTION
Shortlived images are now built from scratch, not from a base. (Same can be done later for bundle & catalog)

It simplifies the workflows especially with multiarch. We don't need anymore the "ci*" make targets.

Restore the SHA-builds on merged commits

Also make multiarch configurable, and only for merged commits, not per PR