### PR TITLE
NETOBSERV-1050 Transport field in IPFIX exporter not working

### DIFF
--- a/config/samples/flows_v1beta1_flowcollector.yaml
+++ b/config/samples/flows_v1beta1_flowcollector.yaml
@@ -141,4 +141,4 @@ spec:
     #   ipfix:
     #     targetHost: "ipfix-collector.ipfix.svc.cluster.local"
     #     targetPort: 4739
-    #     transport: tcp or udp (optional - defaults to tcp)
+    #     transport: TCP or UDP (optional - defaults to TCP)

--- a/controllers/flowlogspipeline/flp_common_objects.go
+++ b/controllers/flowlogspipeline/flp_common_objects.go
@@ -556,7 +556,7 @@ func createIPFIXWriteStage(name string, spec *flowslatest.FlowCollectorIPFIXRece
 	return fromStage.WriteIpfix(name, api.WriteIpfix{
 		TargetHost:   spec.TargetHost,
 		TargetPort:   spec.TargetPort,
-		Transport:    spec.Transport,
+		Transport:    getIPFIXTransport(spec.Transport),
 		EnterpriseID: 2,
 	})
 }
@@ -571,6 +571,17 @@ func getKafkaTLS(tls *flowslatest.ClientTLS) *api.ClientTLS {
 		}
 	}
 	return nil
+}
+
+func getIPFIXTransport(transport string) string {
+	switch transport {
+	case "TCP":
+		return "tcp"
+	case "UDP":
+		return "udp"
+	default:
+		return "" //empty value will fallback on default (tcp)
+	}
 }
 
 // returns a configmap with a digest of its configuration contents, which will be used to

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -838,7 +838,7 @@ func TestPipelineWithExporter(t *testing.T) {
 		IPFIX: flowslatest.FlowCollectorIPFIXReceiver{
 			TargetHost: "ipfix-receiver-test",
 			TargetPort: 9999,
-			Transport:  "tcp",
+			Transport:  "TCP",
 		},
 	})
 


### PR DESCRIPTION
It seems FLP manages only lowercase for IPFIX export Transport field.

I have created a `getIPFIXTransport` function to convert values from CR to FLP values. 
Empty values will fallback on "tcp" in `write_ipfix.go` -> `SetDefaults`