### PR TITLE
CRD doc updates

### DIFF
--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -37,7 +37,12 @@ const (
 // This is a workaround for the related issue:
 // https://github.com/kubernetes-sigs/controller-tools/issues/622
 
-// FlowCollectorSpec defines the desired state of FlowCollector
+// FlowCollectorSpec defines the desired state of FlowCollector.
+// <br><br>
+// *: the mention of <i>"unsupported"</i>, or <i>"deprecated"</i> for a feature throughout this document means that this feature
+// is not officially supported by Red Hat. It may have been, for instance, contributed by the community
+// and accepted without a formal agreement for maintenance. The product maintainers may provide some support
+// for these features as a best effort only.
 type FlowCollectorSpec struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
 
@@ -74,7 +79,7 @@ type FlowCollectorSpec struct {
 	// +optional
 	Kafka FlowCollectorKafka `json:"kafka,omitempty"`
 
-	// exporters defines additional optional exporters for custom consumption or storage. This is an experimental feature. Currently, only KAFKA exporter is available.
+	// exporters define additional optional exporters for custom consumption or storage.
 	// +optional
 	// +k8s:conversion-gen=false
 	Exporters []*FlowCollectorExporter `json:"exporters"`
@@ -85,7 +90,7 @@ type FlowCollectorSpec struct {
 // +union
 type FlowCollectorAgent struct {
 	// type selects the flows tracing agent. Possible values are "EBPF" (default) to use NetObserv eBPF agent,
-	// "IPFIX" to use the legacy IPFIX collector. "EBPF" is recommended in most cases as it offers better
+	// "IPFIX" - <i>deprecated (*)</i> - to use the legacy IPFIX collector. "EBPF" is recommended in most cases as it offers better
 	// performances and should work regardless of the CNI installed on the cluster.
 	// "IPFIX" works with OVN-Kubernetes CNI (other CNIs could work if they support exporting IPFIX,
 	// but they would require manual configuration).
@@ -95,7 +100,7 @@ type FlowCollectorAgent struct {
 	// +kubebuilder:default:=EBPF
 	Type string `json:"type"`
 
-	// ipfix describes the settings related to the IPFIX-based flow reporter when the "agent.type"
+	// ipfix - <i>deprecated (*)</i> - describes the settings related to the IPFIX-based flow reporter when the "agent.type"
 	// property is set to "IPFIX".
 	// +optional
 	IPFIX FlowCollectorIPFIX `json:"ipfix,omitempty"`
@@ -708,19 +713,19 @@ const (
 	IpfixExporter ExporterType = "IPFIX"
 )
 
-// FlowCollectorExporter defines an additional exporter to send enriched flows to
+// FlowCollectorExporter defines an additional exporter to send enriched flows to.
 type FlowCollectorExporter struct {
-	// type selects the type of exporters. "KAFKA" and "IPFIX" are the available options at this moment.
+	// type selects the type of exporters. The available options are "KAFKA" and "IPFIX". "IPFIX" is <i>unsupported (*)</i>.
 	// +unionDiscriminator
 	// +kubebuilder:validation:Enum:="KAFKA";"IPFIX"
 	// +kubebuilder:validation:Required
 	Type ExporterType `json:"type"`
 
-	// kafka configuration, such as address or topic, to send enriched flows to.
+	// kafka configuration, such as the address and topic, to send enriched flows to.
 	// +optional
 	Kafka FlowCollectorKafka `json:"kafka,omitempty"`
 
-	// ipfix configuration, such as ip address and port to send ipfix flows to.
+	// IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. <i>Unsupported (*)</i>.
 	// +optional
 	IPFIX FlowCollectorIPFIXReceiver `json:"ipfix,omitempty"`
 }
@@ -745,7 +750,7 @@ type FlowCollectorStatus struct {
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[*].reason"
 // +kubebuilder:storageversion
 
-// FlowCollector is the Schema for the flowcollectors API, which pilots and configures netflow collection.
+// FlowCollector is the schema for the network flows collection API, which pilots and configures the underlying deployments.
 type FlowCollector struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -497,9 +497,9 @@ type FlowCollectorLoki struct {
 	//+kubebuilder:default:="DISABLED"
 	// AuthToken describe the way to get a token to authenticate to Loki.
 	// DISABLED will not send any token with the request.
-	// HOST will use the local pod service account to authenticate to Loki.
-	// FORWARD will forward user token, in this mode, pod that are not receiving user request like the processor will use the local pod service account. Similar to HOST mode.
-	// When using the Loki Operator, set it to `HOST` or `FORWARD`.
+	// HOST - <i>deprecated (*)</i> - will use the local pod service account to authenticate to Loki.
+	// FORWARD will forward the user token for authorization.
+	// When using the Loki Operator, this should be set to `FORWARD`.
 	AuthToken string `json:"authToken,omitempty"`
 
 	//+kubebuilder:default:="1s"

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -3431,11 +3431,10 @@ spec:
                     default: DISABLED
                     description: AuthToken describe the way to get a token to authenticate
                       to Loki. DISABLED will not send any token with the request.
-                      HOST will use the local pod service account to authenticate
-                      to Loki. FORWARD will forward user token, in this mode, pod
-                      that are not receiving user request like the processor will
-                      use the local pod service account. Similar to HOST mode. When
-                      using the Loki Operator, set it to `HOST` or `FORWARD`.
+                      HOST - <i>deprecated (*)</i> - will use the local pod service
+                      account to authenticate to Loki. FORWARD will forward the user
+                      token for authorization. When using the Loki Operator, this
+                      should be set to `FORWARD`.
                     enum:
                     - DISABLED
                     - HOST

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -2230,8 +2230,8 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: FlowCollector is the Schema for the flowcollectors API, which
-          pilots and configures netflow collection.
+        description: FlowCollector is the schema for the network flows collection
+          API, which pilots and configures the underlying deployments.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -2246,7 +2246,13 @@ spec:
           metadata:
             type: object
           spec:
-            description: FlowCollectorSpec defines the desired state of FlowCollector
+            description: 'FlowCollectorSpec defines the desired state of FlowCollector.
+              <br><br> *: the mention of <i>"unsupported"</i>, or <i>"deprecated"</i>
+              for a feature throughout this document means that this feature is not
+              officially supported by Red Hat. It may have been, for instance, contributed
+              by the community and accepted without a formal agreement for maintenance.
+              The product maintainers may provide some support for these features
+              as a best effort only.'
             properties:
               agent:
                 default:
@@ -2398,8 +2404,9 @@ spec:
                         type: integer
                     type: object
                   ipfix:
-                    description: ipfix describes the settings related to the IPFIX-based
-                      flow reporter when the "agent.type" property is set to "IPFIX".
+                    description: ipfix - <i>deprecated (*)</i> - describes the settings
+                      related to the IPFIX-based flow reporter when the "agent.type"
+                      property is set to "IPFIX".
                     properties:
                       cacheActiveTimeout:
                         default: 20s
@@ -2469,12 +2476,13 @@ spec:
                   type:
                     default: EBPF
                     description: type selects the flows tracing agent. Possible values
-                      are "EBPF" (default) to use NetObserv eBPF agent, "IPFIX" to
-                      use the legacy IPFIX collector. "EBPF" is recommended in most
-                      cases as it offers better performances and should work regardless
-                      of the CNI installed on the cluster. "IPFIX" works with OVN-Kubernetes
-                      CNI (other CNIs could work if they support exporting IPFIX,
-                      but they would require manual configuration).
+                      are "EBPF" (default) to use NetObserv eBPF agent, "IPFIX" -
+                      <i>deprecated (*)</i> - to use the legacy IPFIX collector. "EBPF"
+                      is recommended in most cases as it offers better performances
+                      and should work regardless of the CNI installed on the cluster.
+                      "IPFIX" works with OVN-Kubernetes CNI (other CNIs could work
+                      if they support exporting IPFIX, but they would require manual
+                      configuration).
                     enum:
                     - EBPF
                     - IPFIX
@@ -3170,16 +3178,15 @@ spec:
                 - KAFKA
                 type: string
               exporters:
-                description: exporters defines additional optional exporters for custom
-                  consumption or storage. This is an experimental feature. Currently,
-                  only KAFKA exporter is available.
+                description: exporters define additional optional exporters for custom
+                  consumption or storage.
                 items:
                   description: FlowCollectorExporter defines an additional exporter
-                    to send enriched flows to
+                    to send enriched flows to.
                   properties:
                     ipfix:
-                      description: ipfix configuration, such as ip address and port
-                        to send ipfix flows to.
+                      description: IPFIX configuration, such as the IP address and
+                        port to send enriched IPFIX flows to. <i>Unsupported (*)</i>.
                       properties:
                         targetHost:
                           default: ""
@@ -3200,7 +3207,7 @@ spec:
                       - targetPort
                       type: object
                     kafka:
-                      description: kafka configuration, such as address or topic,
+                      description: kafka configuration, such as the address and topic,
                         to send enriched flows to.
                       properties:
                         address:
@@ -3304,8 +3311,9 @@ spec:
                       - topic
                       type: object
                     type:
-                      description: type selects the type of exporters. "KAFKA" and
-                        "IPFIX" are the available options at this moment.
+                      description: type selects the type of exporters. The available
+                        options are "KAFKA" and "IPFIX". "IPFIX" is <i>unsupported
+                        (*)</i>.
                       enum:
                       - KAFKA
                       - IPFIX

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -371,8 +371,8 @@ spec:
       kind: FlowCollector
       name: flowcollectors.flows.netobserv.io
       version: v1alpha1
-    - description: FlowCollector is the Schema for the flowcollectors API, which pilots
-        and configures netflow collection.
+    - description: FlowCollector is the schema for the network flows collection API,
+        which pilots and configures the underlying deployments.
       displayName: Flow Collector
       kind: FlowCollector
       name: flowcollectors.flows.netobserv.io

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -3418,11 +3418,10 @@ spec:
                     default: DISABLED
                     description: AuthToken describe the way to get a token to authenticate
                       to Loki. DISABLED will not send any token with the request.
-                      HOST will use the local pod service account to authenticate
-                      to Loki. FORWARD will forward user token, in this mode, pod
-                      that are not receiving user request like the processor will
-                      use the local pod service account. Similar to HOST mode. When
-                      using the Loki Operator, set it to `HOST` or `FORWARD`.
+                      HOST - <i>deprecated (*)</i> - will use the local pod service
+                      account to authenticate to Loki. FORWARD will forward the user
+                      token for authorization. When using the Loki Operator, this
+                      should be set to `FORWARD`.
                     enum:
                     - DISABLED
                     - HOST

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -2217,8 +2217,8 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: FlowCollector is the Schema for the flowcollectors API, which
-          pilots and configures netflow collection.
+        description: FlowCollector is the schema for the network flows collection
+          API, which pilots and configures the underlying deployments.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -2233,7 +2233,13 @@ spec:
           metadata:
             type: object
           spec:
-            description: FlowCollectorSpec defines the desired state of FlowCollector
+            description: 'FlowCollectorSpec defines the desired state of FlowCollector.
+              <br><br> *: the mention of <i>"unsupported"</i>, or <i>"deprecated"</i>
+              for a feature throughout this document means that this feature is not
+              officially supported by Red Hat. It may have been, for instance, contributed
+              by the community and accepted without a formal agreement for maintenance.
+              The product maintainers may provide some support for these features
+              as a best effort only.'
             properties:
               agent:
                 default:
@@ -2385,8 +2391,9 @@ spec:
                         type: integer
                     type: object
                   ipfix:
-                    description: ipfix describes the settings related to the IPFIX-based
-                      flow reporter when the "agent.type" property is set to "IPFIX".
+                    description: ipfix - <i>deprecated (*)</i> - describes the settings
+                      related to the IPFIX-based flow reporter when the "agent.type"
+                      property is set to "IPFIX".
                     properties:
                       cacheActiveTimeout:
                         default: 20s
@@ -2456,12 +2463,13 @@ spec:
                   type:
                     default: EBPF
                     description: type selects the flows tracing agent. Possible values
-                      are "EBPF" (default) to use NetObserv eBPF agent, "IPFIX" to
-                      use the legacy IPFIX collector. "EBPF" is recommended in most
-                      cases as it offers better performances and should work regardless
-                      of the CNI installed on the cluster. "IPFIX" works with OVN-Kubernetes
-                      CNI (other CNIs could work if they support exporting IPFIX,
-                      but they would require manual configuration).
+                      are "EBPF" (default) to use NetObserv eBPF agent, "IPFIX" -
+                      <i>deprecated (*)</i> - to use the legacy IPFIX collector. "EBPF"
+                      is recommended in most cases as it offers better performances
+                      and should work regardless of the CNI installed on the cluster.
+                      "IPFIX" works with OVN-Kubernetes CNI (other CNIs could work
+                      if they support exporting IPFIX, but they would require manual
+                      configuration).
                     enum:
                     - EBPF
                     - IPFIX
@@ -3157,16 +3165,15 @@ spec:
                 - KAFKA
                 type: string
               exporters:
-                description: exporters defines additional optional exporters for custom
-                  consumption or storage. This is an experimental feature. Currently,
-                  only KAFKA exporter is available.
+                description: exporters define additional optional exporters for custom
+                  consumption or storage.
                 items:
                   description: FlowCollectorExporter defines an additional exporter
-                    to send enriched flows to
+                    to send enriched flows to.
                   properties:
                     ipfix:
-                      description: ipfix configuration, such as ip address and port
-                        to send ipfix flows to.
+                      description: IPFIX configuration, such as the IP address and
+                        port to send enriched IPFIX flows to. <i>Unsupported (*)</i>.
                       properties:
                         targetHost:
                           default: ""
@@ -3187,7 +3194,7 @@ spec:
                       - targetPort
                       type: object
                     kafka:
-                      description: kafka configuration, such as address or topic,
+                      description: kafka configuration, such as the address and topic,
                         to send enriched flows to.
                       properties:
                         address:
@@ -3291,8 +3298,9 @@ spec:
                       - topic
                       type: object
                     type:
-                      description: type selects the type of exporters. "KAFKA" and
-                        "IPFIX" are the available options at this moment.
+                      description: type selects the type of exporters. The available
+                        options are "KAFKA" and "IPFIX". "IPFIX" is <i>unsupported
+                        (*)</i>.
                       enum:
                       - KAFKA
                       - IPFIX

--- a/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/netobserv-operator.clusterserviceversion.yaml
@@ -28,8 +28,8 @@ spec:
       kind: FlowCollector
       name: flowcollectors.flows.netobserv.io
       version: v1alpha1
-    - description: FlowCollector is the Schema for the flowcollectors API, which pilots
-        and configures netflow collection.
+    - description: FlowCollector is the schema for the network flows collection API,
+        which pilots and configures the underlying deployments.
       displayName: Flow Collector
       kind: FlowCollector
       name: flowcollectors.flows.netobserv.io

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -6032,7 +6032,7 @@ loki, the flow store, client settings.
         <td><b>authToken</b></td>
         <td>enum</td>
         <td>
-          AuthToken describe the way to get a token to authenticate to Loki. DISABLED will not send any token with the request. HOST will use the local pod service account to authenticate to Loki. FORWARD will forward user token, in this mode, pod that are not receiving user request like the processor will use the local pod service account. Similar to HOST mode. When using the Loki Operator, set it to `HOST` or `FORWARD`.<br/>
+          AuthToken describe the way to get a token to authenticate to Loki. DISABLED will not send any token with the request. HOST - <i>deprecated (*)</i> - will use the local pod service account to authenticate to Loki. FORWARD will forward the user token for authorization. When using the Loki Operator, this should be set to `FORWARD`.<br/>
           <br/>
             <i>Enum</i>: DISABLED, HOST, FORWARD<br/>
             <i>Default</i>: DISABLED<br/>

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -3856,7 +3856,7 @@ Resource Types:
 
 
 
-FlowCollector is the Schema for the flowcollectors API, which pilots and configures netflow collection.
+FlowCollector is the schema for the network flows collection API, which pilots and configures the underlying deployments.
 
 <table>
     <thead>
@@ -3888,7 +3888,7 @@ FlowCollector is the Schema for the flowcollectors API, which pilots and configu
         <td><b><a href="#flowcollectorspec-1">spec</a></b></td>
         <td>object</td>
         <td>
-          FlowCollectorSpec defines the desired state of FlowCollector<br/>
+          FlowCollectorSpec defines the desired state of FlowCollector. <br><br> *: the mention of <i>"unsupported"</i>, or <i>"deprecated"</i> for a feature throughout this document means that this feature is not officially supported by Red Hat. It may have been, for instance, contributed by the community and accepted without a formal agreement for maintenance. The product maintainers may provide some support for these features as a best effort only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -3907,7 +3907,7 @@ FlowCollector is the Schema for the flowcollectors API, which pilots and configu
 
 
 
-FlowCollectorSpec defines the desired state of FlowCollector
+FlowCollectorSpec defines the desired state of FlowCollector. <br><br> *: the mention of <i>"unsupported"</i>, or <i>"deprecated"</i> for a feature throughout this document means that this feature is not officially supported by Red Hat. It may have been, for instance, contributed by the community and accepted without a formal agreement for maintenance. The product maintainers may provide some support for these features as a best effort only.
 
 <table>
     <thead>
@@ -3948,7 +3948,7 @@ FlowCollectorSpec defines the desired state of FlowCollector
         <td><b><a href="#flowcollectorspecexportersindex-1">exporters</a></b></td>
         <td>[]object</td>
         <td>
-          exporters defines additional optional exporters for custom consumption or storage. This is an experimental feature. Currently, only KAFKA exporter is available.<br/>
+          exporters define additional optional exporters for custom consumption or storage.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4003,7 +4003,7 @@ agent for flows extraction.
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          type selects the flows tracing agent. Possible values are "EBPF" (default) to use NetObserv eBPF agent, "IPFIX" to use the legacy IPFIX collector. "EBPF" is recommended in most cases as it offers better performances and should work regardless of the CNI installed on the cluster. "IPFIX" works with OVN-Kubernetes CNI (other CNIs could work if they support exporting IPFIX, but they would require manual configuration).<br/>
+          type selects the flows tracing agent. Possible values are "EBPF" (default) to use NetObserv eBPF agent, "IPFIX" - <i>deprecated (*)</i> - to use the legacy IPFIX collector. "EBPF" is recommended in most cases as it offers better performances and should work regardless of the CNI installed on the cluster. "IPFIX" works with OVN-Kubernetes CNI (other CNIs could work if they support exporting IPFIX, but they would require manual configuration).<br/>
           <br/>
             <i>Enum</i>: EBPF, IPFIX<br/>
             <i>Default</i>: EBPF<br/>
@@ -4020,7 +4020,7 @@ agent for flows extraction.
         <td><b><a href="#flowcollectorspecagentipfix-1">ipfix</a></b></td>
         <td>object</td>
         <td>
-          ipfix describes the settings related to the IPFIX-based flow reporter when the "agent.type" property is set to "IPFIX".<br/>
+          ipfix - <i>deprecated (*)</i> - describes the settings related to the IPFIX-based flow reporter when the "agent.type" property is set to "IPFIX".<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -4212,7 +4212,7 @@ resources are the compute resources required by this container. More info: https
 
 
 
-ipfix describes the settings related to the IPFIX-based flow reporter when the "agent.type" property is set to "IPFIX".
+ipfix - <i>deprecated (*)</i> - describes the settings related to the IPFIX-based flow reporter when the "agent.type" property is set to "IPFIX".
 
 <table>
     <thead>
@@ -5499,7 +5499,7 @@ resources, in terms of compute resources, required by this container. More info:
 
 
 
-FlowCollectorExporter defines an additional exporter to send enriched flows to
+FlowCollectorExporter defines an additional exporter to send enriched flows to.
 
 <table>
     <thead>
@@ -5514,7 +5514,7 @@ FlowCollectorExporter defines an additional exporter to send enriched flows to
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          type selects the type of exporters. "KAFKA" and "IPFIX" are the available options at this moment.<br/>
+          type selects the type of exporters. The available options are "KAFKA" and "IPFIX". "IPFIX" is <i>unsupported (*)</i>.<br/>
           <br/>
             <i>Enum</i>: KAFKA, IPFIX<br/>
         </td>
@@ -5523,14 +5523,14 @@ FlowCollectorExporter defines an additional exporter to send enriched flows to
         <td><b><a href="#flowcollectorspecexportersindexipfix">ipfix</a></b></td>
         <td>object</td>
         <td>
-          ipfix configuration, such as ip address and port to send ipfix flows to.<br/>
+          IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. <i>Unsupported (*)</i>.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#flowcollectorspecexportersindexkafka-1">kafka</a></b></td>
         <td>object</td>
         <td>
-          kafka configuration, such as address or topic, to send enriched flows to.<br/>
+          kafka configuration, such as the address and topic, to send enriched flows to.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -5542,7 +5542,7 @@ FlowCollectorExporter defines an additional exporter to send enriched flows to
 
 
 
-ipfix configuration, such as ip address and port to send ipfix flows to.
+IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. <i>Unsupported (*)</i>.
 
 <table>
     <thead>
@@ -5587,7 +5587,7 @@ ipfix configuration, such as ip address and port to send ipfix flows to.
 
 
 
-kafka configuration, such as address or topic, to send enriched flows to.
+kafka configuration, such as the address and topic, to send enriched flows to.
 
 <table>
     <thead>

--- a/docs/flowcollector-flows-netobserv-io-v1beta1.adoc
+++ b/docs/flowcollector-flows-netobserv-io-v1beta1.adoc
@@ -900,7 +900,7 @@ Type::
 
 | `authToken`
 | `string`
-| AuthToken describe the way to get a token to authenticate to Loki. DISABLED will not send any token with the request. HOST will use the local pod service account to authenticate to Loki. FORWARD will forward user token, in this mode, pod that are not receiving user request like the processor will use the local pod service account. Similar to HOST mode. When using the Loki Operator, set it to `HOST` or `FORWARD`.
+| AuthToken describe the way to get a token to authenticate to Loki. DISABLED will not send any token with the request. HOST - _deprecated (*)_ - will use the local pod service account to authenticate to Loki. FORWARD will forward the user token for authorization. When using the Loki Operator, this should be set to `FORWARD`.
 
 | `batchSize`
 | `integer`

--- a/docs/flowcollector-flows-netobserv-io-v1beta1.adoc
+++ b/docs/flowcollector-flows-netobserv-io-v1beta1.adoc
@@ -8,7 +8,7 @@
 Description::
 +
 --
-FlowCollector is the Schema for the flowcollectors API, which pilots and configures netflow collection.
+FlowCollector is the schema for the network flows collection API, which pilots and configures the underlying deployments.
 --
 
 Type::
@@ -35,7 +35,9 @@ Type::
 
 | `spec`
 | `object`
-| FlowCollectorSpec defines the desired state of FlowCollector
+| FlowCollectorSpec defines the desired state of FlowCollector.  +
+ +
+ *: the mention of _"unsupported"_, or _"deprecated"_ for a feature throughout this document means that this feature is not officially supported by Red Hat. It may have been, for instance, contributed by the community and accepted without a formal agreement for maintenance. The product maintainers may provide some support for these features as a best effort only.
 
 |===
 == .metadata
@@ -55,7 +57,9 @@ Type::
 Description::
 +
 --
-FlowCollectorSpec defines the desired state of FlowCollector
+FlowCollectorSpec defines the desired state of FlowCollector.  +
+ +
+ *: the mention of _"unsupported"_, or _"deprecated"_ for a feature throughout this document means that this feature is not officially supported by Red Hat. It may have been, for instance, contributed by the community and accepted without a formal agreement for maintenance. The product maintainers may provide some support for these features as a best effort only.
 --
 
 Type::
@@ -85,11 +89,11 @@ Required::
 
 | `exporters`
 | `array`
-| exporters defines additional optional exporters for custom consumption or storage. This is an experimental feature. Currently, only KAFKA exporter is available.
+| exporters define additional optional exporters for custom consumption or storage.
 
 | `exporters[]`
 | `object`
-| FlowCollectorExporter defines an additional exporter to send enriched flows to
+| FlowCollectorExporter defines an additional exporter to send enriched flows to.
 
 | `kafka`
 | `object`
@@ -133,11 +137,11 @@ Required::
 
 | `ipfix`
 | `object`
-| ipfix describes the settings related to the IPFIX-based flow reporter when the "agent.type" property is set to "IPFIX".
+| ipfix - _deprecated (*)_ - describes the settings related to the IPFIX-based flow reporter when the "agent.type" property is set to "IPFIX".
 
 | `type`
 | `string`
-| type selects the flows tracing agent. Possible values are "EBPF" (default) to use NetObserv eBPF agent, "IPFIX" to use the legacy IPFIX collector. "EBPF" is recommended in most cases as it offers better performances and should work regardless of the CNI installed on the cluster. "IPFIX" works with OVN-Kubernetes CNI (other CNIs could work if they support exporting IPFIX, but they would require manual configuration).
+| type selects the flows tracing agent. Possible values are "EBPF" (default) to use NetObserv eBPF agent, "IPFIX" - _deprecated (*)_ - to use the legacy IPFIX collector. "EBPF" is recommended in most cases as it offers better performances and should work regardless of the CNI installed on the cluster. "IPFIX" works with OVN-Kubernetes CNI (other CNIs could work if they support exporting IPFIX, but they would require manual configuration).
 
 |===
 == .spec.agent.ebpf
@@ -254,7 +258,7 @@ Type::
 Description::
 +
 --
-ipfix describes the settings related to the IPFIX-based flow reporter when the "agent.type" property is set to "IPFIX".
+ipfix - _deprecated (*)_ - describes the settings related to the IPFIX-based flow reporter when the "agent.type" property is set to "IPFIX".
 --
 
 Type::
@@ -354,8 +358,6 @@ consolePlugin defines the settings related to the {product-title} Console plugin
 Type::
   `object`
 
-Required::
-  - `register`
 
 
 
@@ -377,7 +379,7 @@ Required::
 
 | `port`
 | `integer`
-| port is the plugin service port
+| port is the plugin service port. Do not use 9002, which is reserved for metrics.
 
 | `portNaming`
 | `object`
@@ -519,7 +521,7 @@ Type::
 Description::
 +
 --
-exporters defines additional optional exporters for custom consumption or storage. This is an experimental feature. Currently, only KAFKA exporter is available.
+exporters define additional optional exporters for custom consumption or storage.
 --
 
 Type::
@@ -532,7 +534,7 @@ Type::
 Description::
 +
 --
-FlowCollectorExporter defines an additional exporter to send enriched flows to
+FlowCollectorExporter defines an additional exporter to send enriched flows to.
 --
 
 Type::
@@ -547,20 +549,57 @@ Required::
 |===
 | Property | Type | Description
 
+| `ipfix`
+| `object`
+| IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. _Unsupported (*)_.
+
 | `kafka`
 | `object`
-| kafka configuration, such as address or topic, to send enriched flows to.
+| kafka configuration, such as the address and topic, to send enriched flows to.
 
 | `type`
 | `string`
-| type selects the type of exporters. Only "KAFKA" is available at the moment.
+| type selects the type of exporters. The available options are "KAFKA" and "IPFIX". "IPFIX" is _unsupported (*)_.
+
+|===
+== .spec.exporters[].ipfix
+Description::
++
+--
+IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. _Unsupported (*)_.
+--
+
+Type::
+  `object`
+
+Required::
+  - `targetHost`
+  - `targetPort`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `targetHost`
+| `string`
+| address of the ipfix external receiver
+
+| `targetPort`
+| `integer`
+| port for the ipfix external receiver
+
+| `transport`
+| `string`
+| Transport protocol (tcp/udp) to be used for the IPFIX connection, defaults to tcp
 
 |===
 == .spec.exporters[].kafka
 Description::
 +
 --
-kafka configuration, such as address or topic, to send enriched flows to.
+kafka configuration, such as the address and topic, to send enriched flows to.
 --
 
 Type::
@@ -652,6 +691,10 @@ Type::
 | `string`
 | name of the config map or secret containing certificates
 
+| `namespace`
+| `string`
+| namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.
+
 | `type`
 | `string`
 | type for the certificate reference: "configmap" or "secret"
@@ -685,6 +728,10 @@ Type::
 | `name`
 | `string`
 | name of the config map or secret containing certificates
+
+| `namespace`
+| `string`
+| namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.
 
 | `type`
 | `string`
@@ -787,6 +834,10 @@ Type::
 | `string`
 | name of the config map or secret containing certificates
 
+| `namespace`
+| `string`
+| namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.
+
 | `type`
 | `string`
 | type for the certificate reference: "configmap" or "secret"
@@ -820,6 +871,10 @@ Type::
 | `name`
 | `string`
 | name of the config map or secret containing certificates
+
+| `namespace`
+| `string`
+| namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.
 
 | `type`
 | `string`
@@ -875,9 +930,13 @@ Type::
 | `object (string)`
 | staticLabels is a map of common labels to set on each flow.
 
+| `statusTls`
+| `object`
+| tls client configuration for loki status URL.
+
 | `statusUrl`
 | `string`
-| statusURL specifies the address of the Loki /ready /metrics /config endpoints, in case it is different from the Loki querier URL. If empty, the QuerierURL value will be used. This is useful to show error messages and some context in the frontend. When using the Loki Operator, set it to the Loki HTTP query frontend service, for example https://loki-query-frontend-http.netobserv.svc:3100/.
+| statusURL specifies the address of the Loki /ready /metrics /config endpoints, in case it is different from the Loki querier URL. If empty, the QuerierURL value will be used. This is useful to show error messages and some context in the frontend. When using the Loki Operator, set it to the Loki HTTP query frontend service, for example https://loki-query-frontend-http.netobserv.svc:3100/. statusTLS configuration will be used when statusUrl is set.
 
 | `tenantID`
 | `string`
@@ -889,18 +948,128 @@ Type::
 
 | `tls`
 | `object`
-| tls client configuration.
+| tls client configuration for loki URL.
 
 | `url`
 | `string`
 | url is the address of an existing Loki service to push the flows to. When using the Loki Operator, set it to the Loki gateway service with the `network` tenant set in path, for example https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.
 
 |===
+== .spec.loki.statusTls
+Description::
++
+--
+tls client configuration for loki status URL.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `caCert`
+| `object`
+| caCert defines the reference of the certificate for the Certificate Authority
+
+| `enable`
+| `boolean`
+| enable TLS
+
+| `insecureSkipVerify`
+| `boolean`
+| insecureSkipVerify allows skipping client-side verification of the server certificate If set to true, CACert field will be ignored
+
+| `userCert`
+| `object`
+| userCert defines the user certificate reference, used for mTLS (you can ignore it when using regular, one-way TLS)
+
+|===
+== .spec.loki.statusTls.caCert
+Description::
++
+--
+caCert defines the reference of the certificate for the Certificate Authority
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `certFile`
+| `string`
+| certFile defines the path to the certificate file name within the config map or secret
+
+| `certKey`
+| `string`
+| certKey defines the path to the certificate private key file name within the config map or secret. Omit when the key is not necessary.
+
+| `name`
+| `string`
+| name of the config map or secret containing certificates
+
+| `namespace`
+| `string`
+| namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| type for the certificate reference: "configmap" or "secret"
+
+|===
+== .spec.loki.statusTls.userCert
+Description::
++
+--
+userCert defines the user certificate reference, used for mTLS (you can ignore it when using regular, one-way TLS)
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `certFile`
+| `string`
+| certFile defines the path to the certificate file name within the config map or secret
+
+| `certKey`
+| `string`
+| certKey defines the path to the certificate private key file name within the config map or secret. Omit when the key is not necessary.
+
+| `name`
+| `string`
+| name of the config map or secret containing certificates
+
+| `namespace`
+| `string`
+| namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| type for the certificate reference: "configmap" or "secret"
+
+|===
 == .spec.loki.tls
 Description::
 +
 --
-tls client configuration.
+tls client configuration for loki URL.
 --
 
 Type::
@@ -959,6 +1128,10 @@ Type::
 | `string`
 | name of the config map or secret containing certificates
 
+| `namespace`
+| `string`
+| namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.
+
 | `type`
 | `string`
 | type for the certificate reference: "configmap" or "secret"
@@ -992,6 +1165,10 @@ Type::
 | `name`
 | `string`
 | name of the config map or secret containing certificates
+
+| `namespace`
+| `string`
+| namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.
 
 | `type`
 | `string`
@@ -1229,6 +1406,10 @@ Type::
 | `name`
 | `string`
 | name of the config map or secret containing certificates
+
+| `namespace`
+| `string`
+| namespace of the config map or secret containing certificates. If omitted, assumes same namespace as where NetObserv is deployed. If the namespace is different, the config map or the secret will be copied so that it can be mounted as required.
 
 | `type`
 | `string`

--- a/hack/asciidoc-gen.sh
+++ b/hack/asciidoc-gen.sh
@@ -31,3 +31,6 @@ sed -i -r '/^== Specification$/d ' $ADOC
 sed -i -r 's/^==/=/g' $ADOC
 sed -i -r '/^= API endpoints/Q' $ADOC
 sed -i -r 's/OpenShift/{product-title}/' $ADOC
+sed -i -r 's/<br>/ +\n/g' $ADOC
+sed -i -r 's/<i>/_/g' $ADOC
+sed -i -r 's/<\/i>/_/g' $ADOC


### PR DESCRIPTION
- clarify "deprecated" and "unsupported" features
- fix/remove a forgotten mention that kafka export is experimental
- reformulate the API description (it also appears on the CSV/operator description)
- a couple of minor fixes
- regenerate docs, update asciidoc