### PR TITLE
NETOBSERV-1070: Fix reconcile from DISABLED to AUTO configuration

### DIFF
--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -482,6 +482,18 @@ func TestServiceChanged(t *testing.T) {
 	report = helper.NewChangeReport("")
 	assert.False(helper.ServiceChanged(second, third, &report))
 	assert.Contains(report.String(), "no change")
+
+	// Check annotations change
+	cfg.Processor.LogLevel = "error"
+	b = monoBuilder(ns, &cfg)
+	fourth := b.promService()
+	fourth.ObjectMeta.Annotations = map[string]string{
+		"name": "value",
+	}
+
+	report = helper.NewChangeReport("")
+	assert.True(helper.ServiceChanged(third, fourth, &report))
+	assert.Contains(report.String(), "Service annotations changed")
 }
 
 func TestServiceMonitorNoChange(t *testing.T) {
@@ -526,6 +538,15 @@ func TestServiceMonitorChanged(t *testing.T) {
 	report = helper.NewChangeReport("")
 	assert.True(helper.ServiceMonitorChanged(second, third, &report))
 	assert.Contains(report.String(), "ServiceMonitor labels changed")
+
+	// Check scheme changed
+	b = newMonolithBuilder(info.NewInstance(image2), &cfg)
+	fourth := b.generic.serviceMonitor()
+	fourth.Spec.Endpoints[0].Scheme = "https"
+
+	report = helper.NewChangeReport("")
+	assert.True(helper.ServiceMonitorChanged(third, fourth, &report))
+	assert.Contains(report.String(), "ServiceMonitor spec changed")
 }
 
 func TestPrometheusRuleNoChange(t *testing.T) {

--- a/controllers/reconcilers/common.go
+++ b/controllers/reconcilers/common.go
@@ -166,6 +166,7 @@ func (i *Instance) ReconcileService(ctx context.Context, old, new *corev1.Servic
 		// In case we're updating an existing service, we need to build from the old one to keep immutable fields such as clusterIP
 		newSVC := old.DeepCopy()
 		newSVC.Spec.Ports = new.Spec.Ports
+		newSVC.ObjectMeta.Annotations = new.ObjectMeta.Annotations
 		if err := i.UpdateOwned(ctx, old, newSVC); err != nil {
 			return err
 		}


### PR DESCRIPTION
Two bug correction here:

Service annotations not being updated during reconcile, this had two effects:
- secret for TLS certificate were not being created resulting in pod failing to start
- the operator was  trying indefinitely to update the service

ServiceMonitor now adapt to the TLS configuration