### PR TITLE
[Backport] NETOBSERV-1050 & NETOBSERV-1065 Transport field in IPFIX exporter not working

### DIFF
--- a/config/samples/flows_v1beta1_flowcollector.yaml
+++ b/config/samples/flows_v1beta1_flowcollector.yaml
@@ -141,4 +141,4 @@ spec:
     #   ipfix:
     #     targetHost: "ipfix-collector.ipfix.svc.cluster.local"
     #     targetPort: 4739
-    #     transport: tcp or udp (optional - defaults to tcp)
+    #     transport: TCP or UDP (optional - defaults to TCP)

--- a/controllers/flowlogspipeline/flp_common_objects.go
+++ b/controllers/flowlogspipeline/flp_common_objects.go
@@ -536,7 +536,7 @@ func createIPFIXWriteStage(name string, spec *flowslatest.FlowCollectorIPFIXRece
 	return fromStage.WriteIpfix(name, api.WriteIpfix{
 		TargetHost:   spec.TargetHost,
 		TargetPort:   spec.TargetPort,
-		Transport:    spec.Transport,
+		Transport:    getIPFIXTransport(spec.Transport),
 		EnterpriseID: 2,
 	})
 }
@@ -552,6 +552,15 @@ func (b *builder) getKafkaTLS(tls *flowslatest.ClientTLS, volumeName string) *ap
 		}
 	}
 	return nil
+}
+
+func getIPFIXTransport(transport string) string {
+	switch transport {
+	case "UDP":
+		return "udp"
+	default:
+		return "tcp" //always fallback on tcp
+	}
 }
 
 // returns a configmap with a digest of its configuration contents, which will be used to

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -859,7 +859,7 @@ func TestPipelineWithExporter(t *testing.T) {
 		IPFIX: flowslatest.FlowCollectorIPFIXReceiver{
 			TargetHost: "ipfix-receiver-test",
 			TargetPort: 9999,
-			Transport:  "tcp",
+			Transport:  "TCP",
 		},
 	})
 


### PR DESCRIPTION
Backport of https://github.com/netobserv/network-observability-operator/pull/351