### PR TITLE
NETOBSERV-1076 Fix CR stuck in Updating state [1.3 backport]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,13 +303,10 @@ image-push: ## Push MULTIARCH_TARGETS images
 .PHONY: manifest-build
 manifest-build: ## Build MULTIARCH_TARGETS manifest
 	@echo 'building manifest $(IMAGE)'
-ifeq (${OCI_BIN}, docker)
-	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest create ${IMAGE} $(foreach target,$(MULTIARCH_TARGETS), --amend ${IMAGE}-$(target));
-else
+	DOCKER_BUILDKIT=1 $(OCI_BIN) rmi ${IMAGE}; \
+	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest create ${IMAGE}
 	trap 'exit' INT; \
-	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest create ${IMAGE} ||:
 	$(foreach target,$(MULTIARCH_TARGETS),$(call manifest_add_target,$(target)))
-endif
 
 .PHONY: manifest-push
 manifest-push: ## Push MULTIARCH_TARGETS manifest

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -87,7 +87,7 @@ func NewAgentController(common *reconcilers.Common, config *operator.Config) *Ag
 
 func (c *AgentController) Reconcile(
 	ctx context.Context, target *flowslatest.FlowCollector) error {
-	rlog := log.FromContext(ctx).WithName("ebpf.AgentController")
+	rlog := log.FromContext(ctx).WithName("ebpf")
 	ctx = log.IntoContext(ctx, rlog)
 	current, err := c.current(ctx)
 	if err != nil {

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -809,8 +809,8 @@ func GetCR(key types.NamespacedName) *flowslatest.FlowCollector {
 }
 
 func UpdateCR(key types.NamespacedName, updater func(*flowslatest.FlowCollector)) {
-	cr := GetCR(key)
 	Eventually(func() error {
+		cr := GetCR(key)
 		updater(cr)
 		return k8sClient.Update(ctx, cr)
 	}, timeout, interval).Should(Succeed())

--- a/controllers/reconcilers/namespaced_objects_manager.go
+++ b/controllers/reconcilers/namespaced_objects_manager.go
@@ -68,7 +68,12 @@ func (m *NamespacedObjectManager) FetchAll(ctx context.Context) error {
 			// On success, placeholder is filled with resource. Caller should keep a pointer to it.
 		}
 	}
-	log.Info("Fetched: " + strings.Join(fetched, ",") + ". Not found: " + strings.Join(notFound, ","))
+	if len(fetched) > 0 {
+		log.Info("FETCHED: " + strings.Join(fetched, ","))
+	}
+	if len(notFound) > 0 {
+		log.Info("(Items not deployed: " + strings.Join(notFound, ",") + ")")
+	}
 	return nil
 }
 
@@ -83,7 +88,7 @@ func (m *NamespacedObjectManager) cleanup(ctx context.Context, namespace string)
 		ref := obj.placeholder.DeepCopyObject().(client.Object)
 		ref.SetName(obj.name)
 		ref.SetNamespace(namespace)
-		log.Info("Deleting old "+obj.kind, "Namespace", namespace, "Name", obj.name)
+		log.Info("DELETING "+obj.kind, "Namespace", namespace, "Name", obj.name)
 		err := m.client.Delete(ctx, ref)
 		if client.IgnoreNotFound(err) != nil {
 			log.Error(err, "Failed to delete old "+obj.kind, "Namespace", namespace, "Name", obj.name)
@@ -103,7 +108,7 @@ func (m *NamespacedObjectManager) TryDelete(ctx context.Context, obj client.Obje
 	if m.Exists(obj) {
 		log := log.FromContext(ctx)
 		kind := reflect.TypeOf(obj).String()
-		log.Info("Deleting old "+kind, "Namespace", obj.GetNamespace(), "Name", obj.GetName())
+		log.Info("DELETING "+kind, "Namespace", obj.GetNamespace(), "Name", obj.GetName())
 		err := m.client.Delete(ctx, obj)
 		if err != nil {
 			log.Error(err, "Failed to delete old "+kind, "Namespace", obj.GetNamespace(), "Name", obj.GetName())


### PR DESCRIPTION
Backport of https://github.com/netobserv/network-observability-operator/pull/374

The problem was that copying certificates across namespaces was done on every reconciliation call, with or without digest change. This is not a critical issue as it would only trigger a no-op update, but it was screwing up our "updating" state detection.

There's actually two changes in this commit:
1. Fixing the "Updating" flag, so that it's not set when an update is actually performed (we need to fetch back the object (from cache) and check if the resource version was actually modified)
2. Fixing the certificate watching process to avoid unnecessary tries to update

Also:
- Add / fix tests
- Modify some logs to make important information more visible
- Makefile change for building manifest without error (unrelated)