### PR TITLE
NETOBSERV-1182 added cluster name to flp configuration

### DIFF
--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -659,6 +659,7 @@ func autoConvert_v1beta1_FlowCollectorFLP_To_v1alpha1_FlowCollectorFLP(in *v1bet
 	// WARNING: in.ConversationHeartbeatInterval requires manual conversion: does not exist in peer-type
 	// WARNING: in.ConversationEndTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.ConversationTerminatingTimeout requires manual conversion: does not exist in peer-type
+	// WARNING: in.ClusterName requires manual conversion: does not exist in peer-type
 	if err := Convert_v1beta1_DebugConfig_To_v1alpha1_DebugConfig(&in.Debug, &out.Debug, s); err != nil {
 		return err
 	}

--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -448,6 +448,11 @@ type FlowCollectorFLP struct {
 	// `conversationTerminatingTimeout` is the time to wait from detected FIN flag to end a conversation. Only relevant for TCP flows.
 	ConversationTerminatingTimeout *metav1.Duration `json:"conversationTerminatingTimeout,omitempty"`
 
+	//+kubebuilder:default:=""
+	// +optional
+	// `clusterName` is the name of the cluster to appear in the flows data. This is useful in a multi-cluster context. When using OpenShift, leave empty to make it automatically determined.
+	ClusterName string `json:"clusterName,omitempty"`
+
 	// `debug` allows setting some aspects of the internal configuration of the flow processor.
 	// This section is aimed exclusively for debugging and fine-grained performance optimizations,
 	// such as GOGC and GOMAXPROCS env vars. Users setting its values do it at their own risk.

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -3793,6 +3793,12 @@ spec:
                   and forwards them to the Loki persistence layer and/or any available
                   exporter.'
                 properties:
+                  clusterName:
+                    default: ""
+                    description: '`clusterName` is the name of the cluster to appear
+                      in the flows data. This is useful in a multi-cluster context.
+                      When using OpenShift, leave empty to make it automatically determined.'
+                    type: string
                   conversationEndTimeout:
                     default: 10s
                     description: '`conversationEndTimeout` is the time to wait after

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -517,6 +517,14 @@ spec:
           - update
           - watch
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - console.openshift.io
           resources:
           - consoleplugins
@@ -614,24 +622,15 @@ spec:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings
-          - rolebindings
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
           - clusterroles
+          - rolebindings
           - roles
           verbs:
           - create
           - delete
           - get
           - list
+          - update
           - watch
         - apiGroups:
           - security.openshift.io

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -3780,6 +3780,12 @@ spec:
                   and forwards them to the Loki persistence layer and/or any available
                   exporter.'
                 properties:
+                  clusterName:
+                    default: ""
+                    description: '`clusterName` is the name of the cluster to appear
+                      in the flows data. This is useful in a multi-cluster context.
+                      When using OpenShift, leave empty to make it automatically determined.'
+                    type: string
                   conversationEndTimeout:
                     default: 10s
                     description: '`conversationEndTimeout` is the time to wait after

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,6 +58,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - console.openshift.io
   resources:
   - consoleplugins
@@ -155,24 +163,15 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
-  - rolebindings
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - clusterroles
+  - rolebindings
   - roles
   verbs:
   - create
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - security.openshift.io

--- a/config/samples/flows_v1beta1_flowcollector.yaml
+++ b/config/samples/flows_v1beta1_flowcollector.yaml
@@ -58,6 +58,8 @@ spec:
     conversationTerminatingTimeout: 5s
     conversationHeartbeatInterval: 30s
     conversationEndTimeout: 10s
+    # Append a unique cluster name to each record
+    # clusterName: <CLUSTER NAME>
   kafka:
     address: "kafka-cluster-kafka-bootstrap.netobserv"
     topic: network-flows

--- a/controllers/flowcollector_controller_iso_test.go
+++ b/controllers/flowcollector_controller_iso_test.go
@@ -53,6 +53,7 @@ func flowCollectorIsoSpecs() {
 				ConversationHeartbeatInterval:  &metav1.Duration{Duration: time.Second},
 				ConversationEndTimeout:         &metav1.Duration{Duration: time.Second},
 				ConversationTerminatingTimeout: &metav1.Duration{Duration: time.Second},
+				ClusterName:                    "testCluster",
 				Debug:                          flowslatest.DebugConfig{},
 				LogTypes:                       &outputRecordTypes,
 				Metrics: flowslatest.FLPMetrics{

--- a/controllers/globals/globals.go
+++ b/controllers/globals/globals.go
@@ -1,0 +1,6 @@
+// Package globals defines some variables that are shared across multiple packages
+package globals
+
+import "github.com/openshift/api/config/v1"
+
+var DefaultClusterID v1.ClusterID

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -6754,6 +6754,15 @@ TLS client configuration for Loki URL.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>clusterName</b></td>
+        <td>string</td>
+        <td>
+          `clusterName` is the name of the cluster to appear in the flows data. This is useful in a multi-cluster context. When using OpenShift, leave empty to make it automatically determined.<br/>
+          <br/>
+            <i>Default</i>: <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>conversationEndTimeout</b></td>
         <td>string</td>
         <td>


### PR DESCRIPTION
Added transform_filter to flp pipeline to add a clusterName field to flow logs.
clusterName is taken from config file. If blank, take clusterID from clusterVersion struct.