### PR TITLE
NETOBSERV-1131: Filter for Duplicate=false in metrics

### DIFF
--- a/controllers/flowlogspipeline/metrics_definitions/node_egress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/node_egress_bytes_total.yaml
@@ -16,9 +16,11 @@ encode:
       - name: node_egress_bytes_total
         type: counter
         valuekey: Bytes
-        filter:
-          key: FlowDirection
+        filters:
+        - key: FlowDirection
           value: "1"
+        - key: Duplicate
+          value: "false"
         labels:
           - SrcK8S_HostName
           - DstK8S_HostName

--- a/controllers/flowlogspipeline/metrics_definitions/node_ingress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/node_ingress_bytes_total.yaml
@@ -16,9 +16,11 @@ encode:
       - name: node_ingress_bytes_total
         type: counter
         valuekey: Bytes
-        filter:
-          key: FlowDirection
+        filters:
+        - key: FlowDirection
           value: "0"
+        - key: Duplicate
+          value: "false"
         labels:
           - SrcK8S_HostName
           - DstK8S_HostName

--- a/controllers/flowlogspipeline/metrics_definitions/workload_egress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_egress_bytes_total.yaml
@@ -16,9 +16,11 @@ encode:
       - name: workload_egress_bytes_total
         type: counter
         valuekey: Bytes
-        filter:
-          key: FlowDirection
+        filters:
+        - key: FlowDirection
           value: "1"
+        - key: Duplicate
+          value: "false"
         labels:
           - SrcK8S_Namespace
           - DstK8S_Namespace

--- a/controllers/flowlogspipeline/metrics_definitions/workload_egress_packets_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_egress_packets_total.yaml
@@ -16,9 +16,11 @@ encode:
       - name: workload_egress_packets_total
         type: counter
         valuekey: Packets
-        filter:
-          key: FlowDirection
+        filters:
+        - key: FlowDirection
           value: "1"
+        - key: Duplicate
+          value: "false"
         labels:
           - SrcK8S_Namespace
           - DstK8S_Namespace

--- a/controllers/flowlogspipeline/metrics_definitions/workload_ingress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_ingress_bytes_total.yaml
@@ -16,9 +16,11 @@ encode:
       - name: workload_ingress_bytes_total
         type: counter
         valuekey: Bytes
-        filter:
-          key: FlowDirection
+        filters:
+        - key: FlowDirection
           value: "0"
+        - key: Duplicate
+          value: "false"
         labels:
           - SrcK8S_Namespace
           - DstK8S_Namespace

--- a/controllers/flowlogspipeline/metrics_definitions/workload_ingress_packets_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_ingress_packets_total.yaml
@@ -16,9 +16,11 @@ encode:
       - name: workload_ingress_packets_total
         type: counter
         valuekey: Packets
-        filter:
-          key: FlowDirection
+        filters:
+        - key: FlowDirection
           value: "0"
+        - key: Duplicate
+          value: "false"
         labels:
           - SrcK8S_Namespace
           - DstK8S_Namespace

--- a/go.mod
+++ b/go.mod
@@ -94,3 +94,5 @@ require (
 )
 
 replace github.com/prometheus/common v0.32.1 => github.com/netobserv/prometheus-common v0.31.2-0.20220720134304-43e74fd22881
+
+replace github.com/netobserv/flowlogs-pipeline => ../flowlogs-pipeline

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/mitchellh/mapstructure v1.4.3
-	github.com/netobserv/flowlogs-pipeline v0.1.9
+	github.com/netobserv/flowlogs-pipeline v0.1.10-0.20230705074433-8d40b3290d93
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.19.0
 	github.com/openshift/api v0.0.0-20220112145620-704957ce4980
@@ -94,5 +94,3 @@ require (
 )
 
 replace github.com/prometheus/common v0.32.1 => github.com/netobserv/prometheus-common v0.31.2-0.20220720134304-43e74fd22881
-
-replace github.com/netobserv/flowlogs-pipeline => ../flowlogs-pipeline

--- a/go.sum
+++ b/go.sum
@@ -481,8 +481,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/netobserv/flowlogs-pipeline v0.1.9 h1:6qDlGxW49rdN0BIyEtQov0XBx06H4od63cCqnXOG6Hw=
-github.com/netobserv/flowlogs-pipeline v0.1.9/go.mod h1:Vxct8MkKFtT8iR60wpHFErBuTM04XFaLdQmDxoypCfs=
 github.com/netobserv/loki-client-go v0.0.0-20220927092034-f37122a54500 h1:RmnoJe/ci5q+QdM7upFdxiU+D8F3L3qTd5wXCwwHefw=
 github.com/netobserv/prometheus-common v0.31.2-0.20220720134304-43e74fd22881 h1:hx5bi6xBovRjmwUoVJBzhJ3EDo4K4ZUsqqKrJuQ2vMI=
 github.com/netobserv/prometheus-common v0.31.2-0.20220720134304-43e74fd22881/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=

--- a/go.sum
+++ b/go.sum
@@ -481,6 +481,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/netobserv/flowlogs-pipeline v0.1.10-0.20230705074433-8d40b3290d93 h1:Ctd0uUYyvv3Ii8tZRNrlFjozPXHrw3csT9gv7ldhWno=
+github.com/netobserv/flowlogs-pipeline v0.1.10-0.20230705074433-8d40b3290d93/go.mod h1:XaqtpgdNtPj1/NoCn8zrOt3vrOQdolA7gobpt15lIC0=
 github.com/netobserv/loki-client-go v0.0.0-20220927092034-f37122a54500 h1:RmnoJe/ci5q+QdM7upFdxiU+D8F3L3qTd5wXCwwHefw=
 github.com/netobserv/prometheus-common v0.31.2-0.20220720134304-43e74fd22881 h1:hx5bi6xBovRjmwUoVJBzhJ3EDo4K4ZUsqqKrJuQ2vMI=
 github.com/netobserv/prometheus-common v0.31.2-0.20220720134304-43e74fd22881/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=

--- a/vendor/github.com/netobserv/flowlogs-pipeline/pkg/api/encode_prom.go
+++ b/vendor/github.com/netobserv/flowlogs-pipeline/pkg/api/encode_prom.go
@@ -41,12 +41,20 @@ func PromEncodeOperationName(operation string) string {
 }
 
 type PromMetricsItem struct {
-	Name     string            `yaml:"name" json:"name" doc:"the metric name"`
-	Type     string            `yaml:"type" json:"type" enum:"PromEncodeOperationEnum" doc:"one of the following:"`
-	Filter   PromMetricsFilter `yaml:"filter" json:"filter" doc:"an optional criterion to filter entries by"`
-	ValueKey string            `yaml:"valueKey" json:"valueKey" doc:"entry key from which to resolve metric value"`
-	Labels   []string          `yaml:"labels" json:"labels" doc:"labels to be associated with the metric"`
-	Buckets  []float64         `yaml:"buckets" json:"buckets" doc:"histogram buckets"`
+	Name     string              `yaml:"name" json:"name" doc:"the metric name"`
+	Type     string              `yaml:"type" json:"type" enum:"PromEncodeOperationEnum" doc:"one of the following:"`
+	Filter   PromMetricsFilter   `yaml:"filter" json:"filter" doc:"an optional criterion to filter entries by. Deprecated: use filters instead."`
+	Filters  []PromMetricsFilter `yaml:"filters" json:"filters" doc:"a list of criteria to filter entries by"`
+	ValueKey string              `yaml:"valueKey" json:"valueKey" doc:"entry key from which to resolve metric value"`
+	Labels   []string            `yaml:"labels" json:"labels" doc:"labels to be associated with the metric"`
+	Buckets  []float64           `yaml:"buckets" json:"buckets" doc:"histogram buckets"`
+}
+
+func (i *PromMetricsItem) GetFilters() []PromMetricsFilter {
+	if len(i.Filters) == 0 && i.Filter.Key != "" {
+		return []PromMetricsFilter{i.Filter}
+	}
+	return i.Filters
 }
 
 type PromMetricsItems []PromMetricsItem

--- a/vendor/github.com/netobserv/flowlogs-pipeline/pkg/config/pipeline_builder.go
+++ b/vendor/github.com/netobserv/flowlogs-pipeline/pkg/config/pipeline_builder.go
@@ -135,6 +135,11 @@ func (b *PipelineBuilderStage) EncodeKafka(name string, kafka api.EncodeKafka) P
 	return b.next(name, NewEncodeKafkaParams(name, kafka))
 }
 
+// EncodeS3 chains the current stage with an EncodeS3 stage (writing to s3 bucket) and returns that new stage
+func (b *PipelineBuilderStage) EncodeS3(name string, s3 api.EncodeS3) PipelineBuilderStage {
+	return b.next(name, NewEncodeS3Params(name, s3))
+}
+
 // WriteStdout chains the current stage with a WriteStdout stage and returns that new stage
 func (b *PipelineBuilderStage) WriteStdout(name string, stdout api.WriteStdout) PipelineBuilderStage {
 	return b.next(name, NewWriteStdoutParams(name, stdout))

--- a/vendor/github.com/netobserv/flowlogs-pipeline/pkg/config/stage_params.go
+++ b/vendor/github.com/netobserv/flowlogs-pipeline/pkg/config/stage_params.go
@@ -65,6 +65,10 @@ func NewEncodeKafkaParams(name string, kafka api.EncodeKafka) StageParam {
 	return StageParam{Name: name, Encode: &Encode{Type: api.KafkaType, Kafka: &kafka}}
 }
 
+func NewEncodeS3Params(name string, s3 api.EncodeS3) StageParam {
+	return StageParam{Name: name, Encode: &Encode{Type: api.S3Type, S3: &s3}}
+}
+
 func NewWriteStdoutParams(name string, stdout api.WriteStdout) StageParam {
 	return StageParam{Name: name, Write: &Write{Type: api.StdoutType, Stdout: &stdout}}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/munnerz/goautoneg
 # github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 ## explicit
 github.com/mwitkow/go-conntrack
-# github.com/netobserv/flowlogs-pipeline v0.1.9
+# github.com/netobserv/flowlogs-pipeline v0.1.9 => ../flowlogs-pipeline
 ## explicit; go 1.18
 github.com/netobserv/flowlogs-pipeline/pkg/api
 github.com/netobserv/flowlogs-pipeline/pkg/confgen
@@ -691,3 +691,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# github.com/netobserv/flowlogs-pipeline => ../flowlogs-pipeline

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/munnerz/goautoneg
 # github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 ## explicit
 github.com/mwitkow/go-conntrack
-# github.com/netobserv/flowlogs-pipeline v0.1.9 => ../flowlogs-pipeline
+# github.com/netobserv/flowlogs-pipeline v0.1.10-0.20230705074433-8d40b3290d93
 ## explicit; go 1.18
 github.com/netobserv/flowlogs-pipeline/pkg/api
 github.com/netobserv/flowlogs-pipeline/pkg/confgen
@@ -691,4 +691,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/netobserv/flowlogs-pipeline => ../flowlogs-pipeline


### PR DESCRIPTION
Requires FLP PR: https://github.com/netobserv/flowlogs-pipeline/pull/448

Some observations when comparing byte rates from the plugin versus from prom metrics, e.g. between two nodes, e.g. with a promQL like that: 
```
sum(rate(netobserv_node_ingress_bytes_total{DstK8S_HostName="ip-10-0-137-27.eu-west-3.compute.internal"}[90s])) by (SrcK8S_HostName, DstK8S_HostName)
```
And on plugin's side, similarly, filtering on destination node name="ip-10-0-137-27.eu-west-3.compute.internal" , using Scope=Node and observing the top 5 flow rates in Overview:

Before this PR I see increased values, on prometheus side, in a range going from +20% to +80%
After this PR I still see increased values on prom side but seems much more reasonable, from +10% to +25%
([data](https://docs.google.com/spreadsheets/d/1LM7VCmiljdkpDSXDGpnlYLi_ajVumidD9v7eKb8wKLI/edit#gid=0))

I don't have a definitive explanation as to why I continue to see increased values, but I can make the hypothesis that they come from differences in rate calculation between loki and prometheus - also, the metrics view in the console provide a better resolution than our overview charts, which might play a role in the discrepancies. Anyway, I think this PR brings back values in a much more acceptable range.