### PR TITLE
NETOBSERV-1109 remove reinterpret direction

### DIFF
--- a/controllers/flowlogspipeline/flp_common_objects.go
+++ b/controllers/flowlogspipeline/flp_common_objects.go
@@ -294,16 +294,7 @@ func (b *builder) addTransformStages(stage *config.PipelineBuilderStage) error {
 			Input:  "DstAddr",
 			Output: "DstK8S",
 			Type:   api.AddKubernetesRuleType,
-		}, {
-			Type: api.ReinterpretDirectionRuleType,
 		}},
-		DirectionInfo: api.NetworkTransformDirectionInfo{
-			ReporterIPField:    "AgentIP",
-			SrcHostField:       "SrcK8S_HostIP",
-			DstHostField:       "DstK8S_HostIP",
-			FlowDirectionField: "FlowDirection",
-			IfDirectionField:   "IfDirection",
-		},
 	})
 
 	// loki stage (write) configuration


### PR DESCRIPTION
Following [NETOBSERV-1099](https://issues.redhat.com/browse/NETOBSERV-1099) EGRESS / INGRESS metrics are not consistent using `reinterpretDirection` function.

I suggest to simply remove it to stick with IPFIX definition. The metrics are consistent after that (see https://github.com/netobserv/network-observability-console-plugin/pull/366#issuecomment-1686139968).
Keeping it double the numbers in the `Overview` section graphs