### PR TITLE
NETOBSERV-1224 Flowcollector does not report status != Ready in OCP Console

### DIFF
--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -397,6 +397,7 @@ func (r *FlowCollectorReconciler) newCommonInfo(ctx context.Context, desired *fl
 }
 
 func (r *FlowCollectorReconciler) failure(ctx context.Context, errcond *conditions.ErrorCondition, fc *flowslatest.FlowCollector) error {
+	log.FromContext(ctx).Info("Updating failure status to " + errcond.Reason)
 	log := log.FromContext(ctx)
 	log.Error(errcond.Error, errcond.Message)
 	conditions.AddUniqueCondition(&errcond.Condition, fc)
@@ -407,6 +408,7 @@ func (r *FlowCollectorReconciler) failure(ctx context.Context, errcond *conditio
 }
 
 func (r *FlowCollectorReconciler) updateCondition(ctx context.Context, cond *metav1.Condition, fc *flowslatest.FlowCollector) error {
+	log.FromContext(ctx).Info("Updating status to " + cond.Reason)
 	conditions.AddUniqueCondition(cond, fc)
 	if err := r.Status().Update(ctx, fc); err != nil {
 		log.FromContext(ctx).Error(err, "Set conditions failed")

--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -1,10 +1,18 @@
 package conditions
 
 import (
+	"sort"
+
+	flowslatest "github.com/netobserv/network-observability-operator/api/v1beta1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const TypeReady = "Ready"
+const (
+	TypePending    = "Pending"
+	TypeFailed     = "Failed"
+	MessagePending = "Some FlowCollector components pending on dependencies"
+)
 
 type ErrorCondition struct {
 	metav1.Condition
@@ -13,33 +21,32 @@ type ErrorCondition struct {
 
 func Updating() *metav1.Condition {
 	return &metav1.Condition{
-		Type:   TypeReady,
-		Status: metav1.ConditionFalse,
-		Reason: "Updating",
+		Type:    TypePending,
+		Reason:  "Updating",
+		Message: MessagePending,
 	}
 }
 
 func DeploymentInProgress() *metav1.Condition {
 	return &metav1.Condition{
-		Type:   TypeReady,
-		Status: metav1.ConditionFalse,
-		Reason: "DeploymentInProgress",
+		Type:    TypePending,
+		Reason:  "DeploymentInProgress",
+		Message: MessagePending,
 	}
 }
 
 func Ready() *metav1.Condition {
 	return &metav1.Condition{
-		Type:   TypeReady,
-		Status: metav1.ConditionTrue,
-		Reason: "Ready",
+		Type:    "Ready",
+		Reason:  "Ready",
+		Message: "All components ready",
 	}
 }
 
 func CannotCreateNamespace(err error) *ErrorCondition {
 	return &ErrorCondition{
 		Condition: metav1.Condition{
-			Type:    TypeReady,
-			Status:  metav1.ConditionFalse,
+			Type:    TypeFailed,
 			Reason:  "CannotCreateNamespace",
 			Message: "Cannot create namespace: " + err.Error(),
 		},
@@ -50,8 +57,7 @@ func CannotCreateNamespace(err error) *ErrorCondition {
 func NamespaceChangeFailed(err error) *ErrorCondition {
 	return &ErrorCondition{
 		Condition: metav1.Condition{
-			Type:    TypeReady,
-			Status:  metav1.ConditionFalse,
+			Type:    TypeFailed,
 			Reason:  "NamespaceChangeFailed",
 			Message: "Failed to handle namespace change: " + err.Error(),
 		},
@@ -62,8 +68,7 @@ func NamespaceChangeFailed(err error) *ErrorCondition {
 func ReconcileFLPFailed(err error) *ErrorCondition {
 	return &ErrorCondition{
 		Condition: metav1.Condition{
-			Type:    TypeReady,
-			Status:  metav1.ConditionFalse,
+			Type:    TypeFailed,
 			Reason:  "ReconcileFLPFailed",
 			Message: "Failed to reconcile flowlogs-pipeline: " + err.Error(),
 		},
@@ -74,8 +79,7 @@ func ReconcileFLPFailed(err error) *ErrorCondition {
 func ReconcileCNOFailed(err error) *ErrorCondition {
 	return &ErrorCondition{
 		Condition: metav1.Condition{
-			Type:    TypeReady,
-			Status:  metav1.ConditionFalse,
+			Type:    TypeFailed,
 			Reason:  "ReconcileCNOFailed",
 			Message: "Failed to reconcile ovs-flows-config ConfigMap: " + err.Error(),
 		},
@@ -86,8 +90,7 @@ func ReconcileCNOFailed(err error) *ErrorCondition {
 func ReconcileOVNKFailed(err error) *ErrorCondition {
 	return &ErrorCondition{
 		Condition: metav1.Condition{
-			Type:    TypeReady,
-			Status:  metav1.ConditionFalse,
+			Type:    TypeFailed,
 			Reason:  "ReconcileOVNKFailed",
 			Message: "Failed to reconcile ovn-kubernetes DaemonSet: " + err.Error(),
 		},
@@ -98,8 +101,7 @@ func ReconcileOVNKFailed(err error) *ErrorCondition {
 func ReconcileAgentFailed(err error) *ErrorCondition {
 	return &ErrorCondition{
 		Condition: metav1.Condition{
-			Type:    TypeReady,
-			Status:  metav1.ConditionFalse,
+			Type:    TypeFailed,
 			Reason:  "ReconcileAgentFailed",
 			Message: "Failed to reconcile eBPF Netobserv Agent: " + err.Error(),
 		},
@@ -110,11 +112,33 @@ func ReconcileAgentFailed(err error) *ErrorCondition {
 func ReconcileConsolePluginFailed(err error) *ErrorCondition {
 	return &ErrorCondition{
 		Condition: metav1.Condition{
-			Type:    TypeReady,
-			Status:  metav1.ConditionFalse,
+			Type:    TypeFailed,
 			Reason:  "ReconcileConsolePluginFailed",
 			Message: "Failed to reconcile Console plugin: " + err.Error(),
 		},
 		Error: err,
 	}
+}
+
+// set previous conditions to false as FlowCollector manage only one status at a time
+func clearPreviousConditions(fc *flowslatest.FlowCollector) {
+	for _, existingCondition := range fc.Status.Conditions {
+		existingCondition.Status = metav1.ConditionFalse
+		meta.SetStatusCondition(&fc.Status.Conditions, existingCondition)
+	}
+}
+
+// sort conditions by date, latest first
+func sortConditions(fc *flowslatest.FlowCollector) {
+	sort.SliceStable(fc.Status.Conditions, func(i, j int) bool {
+		return !fc.Status.Conditions[i].LastTransitionTime.Before(&fc.Status.Conditions[j].LastTransitionTime)
+	})
+}
+
+// add a single condition to true, keeping the others to status false
+func AddUniqueCondition(cond *metav1.Condition, fc *flowslatest.FlowCollector) {
+	clearPreviousConditions(fc)
+	cond.Status = metav1.ConditionTrue
+	meta.SetStatusCondition(&fc.Status.Conditions, *cond)
+	sortConditions(fc)
 }


### PR DESCRIPTION
## Description

Improve CR status update:
- Fix `condition.Status` field. Only the active one should show `True`
- Fix Type field. It will now keep latests `Ready` / `Pending` / `Failed` messages with only one of these `True`
- Added messages
- Sorted conditions as oc command only show first item without checking `Status` field

[Screencast from 2023-08-23 11-15-55.webm](https://github.com/netobserv/network-observability-operator/assets/91894519/f12408a6-91fa-4762-ab2e-c6ae84ba38e1)

```
[julien@fedora network-observability-operator]$ oc get flowcollector
NAME      AGENT   SAMPLING (EBPF)   DEPLOYMENT MODEL   STATUS
cluster   EBPF    50                DIRECT             DeploymentInProgress

[julien@fedora network-observability-operator]$ oc get flowcollector
NAME      AGENT   SAMPLING (EBPF)   DEPLOYMENT MODEL   STATUS
cluster   EBPF    50                DIRECT             Ready
```

Related issues:
https://issues.redhat.com/browse/NETOBSERV-1224
https://issues.redhat.com/browse/NETOBSERV-610

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
