### PR TITLE
NETOBSERV-1104: remove italic text in CRD doc

### DIFF
--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -39,7 +39,7 @@ const (
 
 // Defines the desired state of the FlowCollector resource.
 // <br><br>
-// *: the mention of <i>"unsupported"</i>, or <i>"deprecated"</i> for a feature throughout this document means that this feature
+// *: the mention of "unsupported", or "deprecated" for a feature throughout this document means that this feature
 // is not officially supported by Red Hat. It might have been, for instance, contributed by the community
 // and accepted without a formal agreement for maintenance. The product maintainers might provide some support
 // for these features as a best effort only.
@@ -89,7 +89,7 @@ type FlowCollectorSpec struct {
 type FlowCollectorAgent struct {
 	// `type` selects the flows tracing agent. Possible values are:<br>
 	// - `EBPF` (default) to use NetObserv eBPF agent.<br>
-	// - `IPFIX` - <i>deprecated (*)</i> - to use the legacy IPFIX collector.<br>
+	// - `IPFIX` [deprecated (*)] - to use the legacy IPFIX collector.<br>
 	// `EBPF` is recommended as it offers better performances and should work regardless of the CNI installed on the cluster.
 	// `IPFIX` works with OVN-Kubernetes CNI (other CNIs could work if they support exporting IPFIX,
 	// but they would require manual configuration).
@@ -98,7 +98,7 @@ type FlowCollectorAgent struct {
 	// +kubebuilder:default:=EBPF
 	Type string `json:"type,omitempty"`
 
-	// `ipfix` - <i>deprecated (*)</i> - describes the settings related to the IPFIX-based flow reporter when `spec.agent.type`
+	// `ipfix` [deprecated (*)] - describes the settings related to the IPFIX-based flow reporter when `spec.agent.type`
 	// is set to `IPFIX`.
 	// +optional
 	IPFIX FlowCollectorIPFIX `json:"ipfix,omitempty"`
@@ -250,7 +250,7 @@ type FlowCollectorKafka struct {
 	// +optional
 	TLS ClientTLS `json:"tls"`
 
-	// SASL authentication configuration. <i>Unsupported (*)</i>
+	// SASL authentication configuration. [Unsupported (*)].
 	// +optional
 	// +k8s:conversion-gen=false
 	SASL SASLConfig `json:"sasl"`
@@ -535,7 +535,7 @@ type FlowCollectorLoki struct {
 	// `authToken` describes the way to get a token to authenticate to Loki.<br>
 	// - `DISABLED` will not send any token with the request.<br>
 	// - `FORWARD` will forward the user token for authorization.<br>
-	// - `HOST` - <i>deprecated (*)</i> - will use the local pod service account to authenticate to Loki.<br>
+	// - `HOST` [deprecated (*)] - will use the local pod service account to authenticate to Loki.<br>
 	// When using the Loki Operator, this must be set to `FORWARD`.
 	AuthToken string `json:"authToken,omitempty"`
 
@@ -797,7 +797,7 @@ const (
 
 // `FlowCollectorExporter` defines an additional exporter to send enriched flows to.
 type FlowCollectorExporter struct {
-	// `type` selects the type of exporters. The available options are `KAFKA` and `IPFIX`. `IPFIX` is <i>unsupported (*)</i>.
+	// `type` selects the type of exporters. The available options are `KAFKA` and `IPFIX`. `IPFIX` is unsupported (*).
 	// +unionDiscriminator
 	// +kubebuilder:validation:Enum:="KAFKA";"IPFIX"
 	// +kubebuilder:validation:Required
@@ -807,7 +807,7 @@ type FlowCollectorExporter struct {
 	// +optional
 	Kafka FlowCollectorKafka `json:"kafka,omitempty"`
 
-	// IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. <i>Unsupported (*)</i>.
+	// IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. [Unsupported (*)].
 	// +optional
 	IPFIX FlowCollectorIPFIXReceiver `json:"ipfix,omitempty"`
 }

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -2247,12 +2247,12 @@ spec:
             type: object
           spec:
             description: 'Defines the desired state of the FlowCollector resource.
-              <br><br> *: the mention of <i>"unsupported"</i>, or <i>"deprecated"</i>
-              for a feature throughout this document means that this feature is not
-              officially supported by Red Hat. It might have been, for instance, contributed
-              by the community and accepted without a formal agreement for maintenance.
-              The product maintainers might provide some support for these features
-              as a best effort only.'
+              <br><br> *: the mention of "unsupported", or "deprecated" for a feature
+              throughout this document means that this feature is not officially supported
+              by Red Hat. It might have been, for instance, contributed by the community
+              and accepted without a formal agreement for maintenance. The product
+              maintainers might provide some support for these features as a best
+              effort only.'
             properties:
               agent:
                 description: Agent configuration for flows extraction.
@@ -2415,8 +2415,8 @@ spec:
                         type: integer
                     type: object
                   ipfix:
-                    description: '`ipfix` - <i>deprecated (*)</i> - describes the
-                      settings related to the IPFIX-based flow reporter when `spec.agent.type`
+                    description: '`ipfix` [deprecated (*)] - describes the settings
+                      related to the IPFIX-based flow reporter when `spec.agent.type`
                       is set to `IPFIX`.'
                     properties:
                       cacheActiveTimeout:
@@ -2490,12 +2490,11 @@ spec:
                     default: EBPF
                     description: '`type` selects the flows tracing agent. Possible
                       values are:<br> - `EBPF` (default) to use NetObserv eBPF agent.<br>
-                      - `IPFIX` - <i>deprecated (*)</i> - to use the legacy IPFIX
-                      collector.<br> `EBPF` is recommended as it offers better performances
-                      and should work regardless of the CNI installed on the cluster.
-                      `IPFIX` works with OVN-Kubernetes CNI (other CNIs could work
-                      if they support exporting IPFIX, but they would require manual
-                      configuration).'
+                      - `IPFIX` [deprecated (*)] - to use the legacy IPFIX collector.<br>
+                      `EBPF` is recommended as it offers better performances and should
+                      work regardless of the CNI installed on the cluster. `IPFIX`
+                      works with OVN-Kubernetes CNI (other CNIs could work if they
+                      support exporting IPFIX, but they would require manual configuration).'
                     enum:
                     - EBPF
                     - IPFIX
@@ -3202,7 +3201,7 @@ spec:
                   properties:
                     ipfix:
                       description: IPFIX configuration, such as the IP address and
-                        port to send enriched IPFIX flows to. <i>Unsupported (*)</i>.
+                        port to send enriched IPFIX flows to. [Unsupported (*)].
                       properties:
                         targetHost:
                           default: ""
@@ -3231,8 +3230,8 @@ spec:
                           description: Address of the Kafka server
                           type: string
                         sasl:
-                          description: SASL authentication configuration. <i>Unsupported
-                            (*)</i>
+                          description: SASL authentication configuration. [Unsupported
+                            (*)].
                           properties:
                             clientIDKey:
                               description: Key for client ID within the provided `reference`
@@ -3373,8 +3372,7 @@ spec:
                       type: object
                     type:
                       description: '`type` selects the type of exporters. The available
-                        options are `KAFKA` and `IPFIX`. `IPFIX` is <i>unsupported
-                        (*)</i>.'
+                        options are `KAFKA` and `IPFIX`. `IPFIX` is unsupported (*).'
                       enum:
                       - KAFKA
                       - IPFIX
@@ -3393,8 +3391,7 @@ spec:
                     description: Address of the Kafka server
                     type: string
                   sasl:
-                    description: SASL authentication configuration. <i>Unsupported
-                      (*)</i>
+                    description: SASL authentication configuration. [Unsupported (*)].
                     properties:
                       clientIDKey:
                         description: Key for client ID within the provided `reference`
@@ -3534,9 +3531,9 @@ spec:
                     description: '`authToken` describes the way to get a token to
                       authenticate to Loki.<br> - `DISABLED` will not send any token
                       with the request.<br> - `FORWARD` will forward the user token
-                      for authorization.<br> - `HOST` - <i>deprecated (*)</i> - will
-                      use the local pod service account to authenticate to Loki.<br>
-                      When using the Loki Operator, this must be set to `FORWARD`.'
+                      for authorization.<br> - `HOST` [deprecated (*)] - will use
+                      the local pod service account to authenticate to Loki.<br> When
+                      using the Loki Operator, this must be set to `FORWARD`.'
                     enum:
                     - DISABLED
                     - HOST

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -2234,12 +2234,12 @@ spec:
             type: object
           spec:
             description: 'Defines the desired state of the FlowCollector resource.
-              <br><br> *: the mention of <i>"unsupported"</i>, or <i>"deprecated"</i>
-              for a feature throughout this document means that this feature is not
-              officially supported by Red Hat. It might have been, for instance, contributed
-              by the community and accepted without a formal agreement for maintenance.
-              The product maintainers might provide some support for these features
-              as a best effort only.'
+              <br><br> *: the mention of "unsupported", or "deprecated" for a feature
+              throughout this document means that this feature is not officially supported
+              by Red Hat. It might have been, for instance, contributed by the community
+              and accepted without a formal agreement for maintenance. The product
+              maintainers might provide some support for these features as a best
+              effort only.'
             properties:
               agent:
                 description: Agent configuration for flows extraction.
@@ -2402,8 +2402,8 @@ spec:
                         type: integer
                     type: object
                   ipfix:
-                    description: '`ipfix` - <i>deprecated (*)</i> - describes the
-                      settings related to the IPFIX-based flow reporter when `spec.agent.type`
+                    description: '`ipfix` [deprecated (*)] - describes the settings
+                      related to the IPFIX-based flow reporter when `spec.agent.type`
                       is set to `IPFIX`.'
                     properties:
                       cacheActiveTimeout:
@@ -2477,12 +2477,11 @@ spec:
                     default: EBPF
                     description: '`type` selects the flows tracing agent. Possible
                       values are:<br> - `EBPF` (default) to use NetObserv eBPF agent.<br>
-                      - `IPFIX` - <i>deprecated (*)</i> - to use the legacy IPFIX
-                      collector.<br> `EBPF` is recommended as it offers better performances
-                      and should work regardless of the CNI installed on the cluster.
-                      `IPFIX` works with OVN-Kubernetes CNI (other CNIs could work
-                      if they support exporting IPFIX, but they would require manual
-                      configuration).'
+                      - `IPFIX` [deprecated (*)] - to use the legacy IPFIX collector.<br>
+                      `EBPF` is recommended as it offers better performances and should
+                      work regardless of the CNI installed on the cluster. `IPFIX`
+                      works with OVN-Kubernetes CNI (other CNIs could work if they
+                      support exporting IPFIX, but they would require manual configuration).'
                     enum:
                     - EBPF
                     - IPFIX
@@ -3189,7 +3188,7 @@ spec:
                   properties:
                     ipfix:
                       description: IPFIX configuration, such as the IP address and
-                        port to send enriched IPFIX flows to. <i>Unsupported (*)</i>.
+                        port to send enriched IPFIX flows to. [Unsupported (*)].
                       properties:
                         targetHost:
                           default: ""
@@ -3218,8 +3217,8 @@ spec:
                           description: Address of the Kafka server
                           type: string
                         sasl:
-                          description: SASL authentication configuration. <i>Unsupported
-                            (*)</i>
+                          description: SASL authentication configuration. [Unsupported
+                            (*)].
                           properties:
                             clientIDKey:
                               description: Key for client ID within the provided `reference`
@@ -3360,8 +3359,7 @@ spec:
                       type: object
                     type:
                       description: '`type` selects the type of exporters. The available
-                        options are `KAFKA` and `IPFIX`. `IPFIX` is <i>unsupported
-                        (*)</i>.'
+                        options are `KAFKA` and `IPFIX`. `IPFIX` is unsupported (*).'
                       enum:
                       - KAFKA
                       - IPFIX
@@ -3380,8 +3378,7 @@ spec:
                     description: Address of the Kafka server
                     type: string
                   sasl:
-                    description: SASL authentication configuration. <i>Unsupported
-                      (*)</i>
+                    description: SASL authentication configuration. [Unsupported (*)].
                     properties:
                       clientIDKey:
                         description: Key for client ID within the provided `reference`
@@ -3521,9 +3518,9 @@ spec:
                     description: '`authToken` describes the way to get a token to
                       authenticate to Loki.<br> - `DISABLED` will not send any token
                       with the request.<br> - `FORWARD` will forward the user token
-                      for authorization.<br> - `HOST` - <i>deprecated (*)</i> - will
-                      use the local pod service account to authenticate to Loki.<br>
-                      When using the Loki Operator, this must be set to `FORWARD`.'
+                      for authorization.<br> - `HOST` [deprecated (*)] - will use
+                      the local pod service account to authenticate to Loki.<br> When
+                      using the Loki Operator, this must be set to `FORWARD`.'
                     enum:
                     - DISABLED
                     - HOST

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -3888,7 +3888,7 @@ Resource Types:
         <td><b><a href="#flowcollectorspec-1">spec</a></b></td>
         <td>object</td>
         <td>
-          Defines the desired state of the FlowCollector resource. <br><br> *: the mention of <i>"unsupported"</i>, or <i>"deprecated"</i> for a feature throughout this document means that this feature is not officially supported by Red Hat. It might have been, for instance, contributed by the community and accepted without a formal agreement for maintenance. The product maintainers might provide some support for these features as a best effort only.<br/>
+          Defines the desired state of the FlowCollector resource. <br><br> *: the mention of "unsupported", or "deprecated" for a feature throughout this document means that this feature is not officially supported by Red Hat. It might have been, for instance, contributed by the community and accepted without a formal agreement for maintenance. The product maintainers might provide some support for these features as a best effort only.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -3907,7 +3907,7 @@ Resource Types:
 
 
 
-Defines the desired state of the FlowCollector resource. <br><br> *: the mention of <i>"unsupported"</i>, or <i>"deprecated"</i> for a feature throughout this document means that this feature is not officially supported by Red Hat. It might have been, for instance, contributed by the community and accepted without a formal agreement for maintenance. The product maintainers might provide some support for these features as a best effort only.
+Defines the desired state of the FlowCollector resource. <br><br> *: the mention of "unsupported", or "deprecated" for a feature throughout this document means that this feature is not officially supported by Red Hat. It might have been, for instance, contributed by the community and accepted without a formal agreement for maintenance. The product maintainers might provide some support for these features as a best effort only.
 
 <table>
     <thead>
@@ -4010,14 +4010,14 @@ Agent configuration for flows extraction.
         <td><b><a href="#flowcollectorspecagentipfix-1">ipfix</a></b></td>
         <td>object</td>
         <td>
-          `ipfix` - <i>deprecated (*)</i> - describes the settings related to the IPFIX-based flow reporter when `spec.agent.type` is set to `IPFIX`.<br/>
+          `ipfix` [deprecated (*)] - describes the settings related to the IPFIX-based flow reporter when `spec.agent.type` is set to `IPFIX`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          `type` selects the flows tracing agent. Possible values are:<br> - `EBPF` (default) to use NetObserv eBPF agent.<br> - `IPFIX` - <i>deprecated (*)</i> - to use the legacy IPFIX collector.<br> `EBPF` is recommended as it offers better performances and should work regardless of the CNI installed on the cluster. `IPFIX` works with OVN-Kubernetes CNI (other CNIs could work if they support exporting IPFIX, but they would require manual configuration).<br/>
+          `type` selects the flows tracing agent. Possible values are:<br> - `EBPF` (default) to use NetObserv eBPF agent.<br> - `IPFIX` [deprecated (*)] - to use the legacy IPFIX collector.<br> `EBPF` is recommended as it offers better performances and should work regardless of the CNI installed on the cluster. `IPFIX` works with OVN-Kubernetes CNI (other CNIs could work if they support exporting IPFIX, but they would require manual configuration).<br/>
           <br/>
             <i>Enum</i>: EBPF, IPFIX<br/>
             <i>Default</i>: EBPF<br/>
@@ -4230,7 +4230,7 @@ Agent configuration for flows extraction.
 
 
 
-`ipfix` - <i>deprecated (*)</i> - describes the settings related to the IPFIX-based flow reporter when `spec.agent.type` is set to `IPFIX`.
+`ipfix` [deprecated (*)] - describes the settings related to the IPFIX-based flow reporter when `spec.agent.type` is set to `IPFIX`.
 
 <table>
     <thead>
@@ -5541,7 +5541,7 @@ target specifies the target value for the given metric
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          `type` selects the type of exporters. The available options are `KAFKA` and `IPFIX`. `IPFIX` is <i>unsupported (*)</i>.<br/>
+          `type` selects the type of exporters. The available options are `KAFKA` and `IPFIX`. `IPFIX` is unsupported (*).<br/>
           <br/>
             <i>Enum</i>: KAFKA, IPFIX<br/>
         </td>
@@ -5550,7 +5550,7 @@ target specifies the target value for the given metric
         <td><b><a href="#flowcollectorspecexportersindexipfix">ipfix</a></b></td>
         <td>object</td>
         <td>
-          IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. <i>Unsupported (*)</i>.<br/>
+          IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. [Unsupported (*)].<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5569,7 +5569,7 @@ target specifies the target value for the given metric
 
 
 
-IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. <i>Unsupported (*)</i>.
+IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. [Unsupported (*)].
 
 <table>
     <thead>
@@ -5647,7 +5647,7 @@ Kafka configuration, such as the address and topic, to send enriched flows to.
         <td><b><a href="#flowcollectorspecexportersindexkafkasasl">sasl</a></b></td>
         <td>object</td>
         <td>
-          SASL authentication configuration. <i>Unsupported (*)</i><br/>
+          SASL authentication configuration. [Unsupported (*)].<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5666,7 +5666,7 @@ Kafka configuration, such as the address and topic, to send enriched flows to.
 
 
 
-SASL authentication configuration. <i>Unsupported (*)</i>
+SASL authentication configuration. [Unsupported (*)].
 
 <table>
     <thead>
@@ -5965,7 +5965,7 @@ Kafka configuration, allowing to use Kafka as a broker as part of the flow colle
         <td><b><a href="#flowcollectorspeckafkasasl">sasl</a></b></td>
         <td>object</td>
         <td>
-          SASL authentication configuration. <i>Unsupported (*)</i><br/>
+          SASL authentication configuration. [Unsupported (*)].<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5984,7 +5984,7 @@ Kafka configuration, allowing to use Kafka as a broker as part of the flow colle
 
 
 
-SASL authentication configuration. <i>Unsupported (*)</i>
+SASL authentication configuration. [Unsupported (*)].
 
 <table>
     <thead>
@@ -6265,7 +6265,7 @@ Loki, the flow store, client settings.
         <td><b>authToken</b></td>
         <td>enum</td>
         <td>
-          `authToken` describes the way to get a token to authenticate to Loki.<br> - `DISABLED` will not send any token with the request.<br> - `FORWARD` will forward the user token for authorization.<br> - `HOST` - <i>deprecated (*)</i> - will use the local pod service account to authenticate to Loki.<br> When using the Loki Operator, this must be set to `FORWARD`.<br/>
+          `authToken` describes the way to get a token to authenticate to Loki.<br> - `DISABLED` will not send any token with the request.<br> - `FORWARD` will forward the user token for authorization.<br> - `HOST` [deprecated (*)] - will use the local pod service account to authenticate to Loki.<br> When using the Loki Operator, this must be set to `FORWARD`.<br/>
           <br/>
             <i>Enum</i>: DISABLED, HOST, FORWARD<br/>
             <i>Default</i>: DISABLED<br/>


### PR DESCRIPTION
## Description

The CRD doc displayed in the OLM console doesn't support italic text, so remove it from the doc (replaced with brackets)

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
