### PR TITLE
NETOBSERV-1231 RTT metrics

### DIFF
--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -348,9 +348,9 @@ type FLPMetrics struct {
 	Server MetricsServerConfig `json:"server,omitempty"`
 
 	// `ignoreTags` is a list of tags to specify which metrics to ignore. Each metric is associated with a list of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions .
-	// Available tags are: `egress`, `ingress`, `flows`, `bytes`, `packets`, `namespaces`, `nodes`, `workloads`, `nodes-flows`, `namespaces-flows`, `workloads-flows`.
+	// Available tags are: `egress`, `ingress`, `flows`, `bytes`, `packets`, `rtt`, `namespaces`, `nodes`, `workloads`, `nodes-flows`, `namespaces-flows`, `workloads-flows`.
 	// Namespace-based metrics are covered by both `workloads` and `namespaces` tags, hence it is recommended to always ignore one of them (`workloads` offering a finer granularity).
-	//+kubebuilder:default:={"egress","packets","nodes-flows","namespaces-flows","workloads-flows","namespaces"}
+	//+kubebuilder:default:={"egress","packets","rtt","nodes-flows","namespaces-flows","workloads-flows","namespaces"}
 	// +optional
 	IgnoreTags []string `json:"ignoreTags"`
 

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -4527,6 +4527,7 @@ spec:
                         default:
                         - egress
                         - packets
+                        - rtt
                         - nodes-flows
                         - namespaces-flows
                         - workloads-flows
@@ -4535,7 +4536,7 @@ spec:
                           metrics to ignore. Each metric is associated with a list
                           of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions
                           . Available tags are: `egress`, `ingress`, `flows`, `bytes`,
-                          `packets`, `namespaces`, `nodes`, `workloads`, `nodes-flows`,
+                          `packets`, `rtt`, `namespaces`, `nodes`, `workloads`, `nodes-flows`,
                           `namespaces-flows`, `workloads-flows`. Namespace-based metrics
                           are covered by both `workloads` and `namespaces` tags, hence
                           it is recommended to always ignore one of them (`workloads`

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -328,6 +328,7 @@ metadata:
                 "ignoreTags": [
                   "egress",
                   "packets",
+                  "rtt",
                   "nodes-flows",
                   "namespaces-flows",
                   "workloads-flows",

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -4514,6 +4514,7 @@ spec:
                         default:
                         - egress
                         - packets
+                        - rtt
                         - nodes-flows
                         - namespaces-flows
                         - workloads-flows
@@ -4522,7 +4523,7 @@ spec:
                           metrics to ignore. Each metric is associated with a list
                           of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions
                           . Available tags are: `egress`, `ingress`, `flows`, `bytes`,
-                          `packets`, `namespaces`, `nodes`, `workloads`, `nodes-flows`,
+                          `packets`, `rtt`, `namespaces`, `nodes`, `workloads`, `nodes-flows`,
                           `namespaces-flows`, `workloads-flows`. Namespace-based metrics
                           are covered by both `workloads` and `namespaces` tags, hence
                           it is recommended to always ignore one of them (`workloads`

--- a/config/samples/flows_v1beta1_flowcollector.yaml
+++ b/config/samples/flows_v1beta1_flowcollector.yaml
@@ -38,6 +38,7 @@ spec:
       ignoreTags:
         - egress
         - packets
+        - rtt
         - nodes-flows
         - namespaces-flows
         - workloads-flows

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -814,22 +814,33 @@ func TestMergeMetricsConfigurationNoIgnore(t *testing.T) {
 	assert.True(validatePipelineConfig(stages, parameters))
 	jsonStages, _ := json.Marshal(stages)
 	assert.Equal(`[{"name":"ipfix"},{"name":"extract_conntrack","follows":"ipfix"},{"name":"enrich","follows":"extract_conntrack"},{"name":"loki","follows":"enrich"},{"name":"stdout","follows":"enrich"},{"name":"prometheus","follows":"enrich"}]`, string(jsonStages))
-	assert.Len(parameters[5].Encode.Prom.Metrics, 15)
-	assert.Equal("namespace_egress_bytes_total", parameters[5].Encode.Prom.Metrics[0].Name)
-	assert.Equal("namespace_egress_packets_total", parameters[5].Encode.Prom.Metrics[1].Name)
-	assert.Equal("namespace_flows_total", parameters[5].Encode.Prom.Metrics[2].Name)
-	assert.Equal("namespace_ingress_bytes_total", parameters[5].Encode.Prom.Metrics[3].Name)
-	assert.Equal("namespace_ingress_packets_total", parameters[5].Encode.Prom.Metrics[4].Name)
-	assert.Equal("node_egress_bytes_total", parameters[5].Encode.Prom.Metrics[5].Name)
-	assert.Equal("node_egress_packets_total", parameters[5].Encode.Prom.Metrics[6].Name)
-	assert.Equal("node_flows_total", parameters[5].Encode.Prom.Metrics[7].Name)
-	assert.Equal("node_ingress_bytes_total", parameters[5].Encode.Prom.Metrics[8].Name)
-	assert.Equal("node_ingress_packets_total", parameters[5].Encode.Prom.Metrics[9].Name)
-	assert.Equal("workload_egress_bytes_total", parameters[5].Encode.Prom.Metrics[10].Name)
-	assert.Equal("workload_egress_packets_total", parameters[5].Encode.Prom.Metrics[11].Name)
-	assert.Equal("workload_flows_total", parameters[5].Encode.Prom.Metrics[12].Name)
-	assert.Equal("workload_ingress_bytes_total", parameters[5].Encode.Prom.Metrics[13].Name)
-	assert.Equal("workload_ingress_packets_total", parameters[5].Encode.Prom.Metrics[14].Name)
+	assert.Len(parameters[5].Encode.Prom.Metrics, 21)
+	definitions := []string{
+		"namespace_egress_bytes_total",
+		"namespace_egress_packets_total",
+		"namespace_egress_rtt_total",
+		"namespace_flows_total",
+		"namespace_ingress_bytes_total",
+		"namespace_ingress_packets_total",
+		"namespace_ingress_rtt_total",
+		"node_egress_bytes_total",
+		"node_egress_packets_total",
+		"node_egress_rtt_total",
+		"node_flows_total",
+		"node_ingress_bytes_total",
+		"node_ingress_packets_total",
+		"node_ingress_rtt_total",
+		"workload_egress_bytes_total",
+		"workload_egress_packets_total",
+		"workload_egress_rtt_total",
+		"workload_flows_total",
+		"workload_ingress_bytes_total",
+		"workload_ingress_packets_total",
+		"workload_ingress_rtt_total",
+	}
+	for i, def := range definitions {
+		assert.Equal(def, parameters[5].Encode.Prom.Metrics[i].Name)
+	}
 	assert.Equal("netobserv_", parameters[5].Encode.Prom.Prefix)
 }
 
@@ -845,7 +856,7 @@ func TestMergeMetricsConfigurationWithIgnore(t *testing.T) {
 	assert.True(validatePipelineConfig(stages, parameters))
 	jsonStages, _ := json.Marshal(stages)
 	assert.Equal(`[{"name":"ipfix"},{"name":"extract_conntrack","follows":"ipfix"},{"name":"enrich","follows":"extract_conntrack"},{"name":"loki","follows":"enrich"},{"name":"stdout","follows":"enrich"},{"name":"prometheus","follows":"enrich"}]`, string(jsonStages))
-	assert.Len(parameters[5].Encode.Prom.Metrics, 10)
+	assert.Len(parameters[5].Encode.Prom.Metrics, 14)
 	assert.Equal("namespace_egress_bytes_total", parameters[5].Encode.Prom.Metrics[0].Name)
 	assert.Equal("netobserv_", parameters[5].Encode.Prom.Prefix)
 }

--- a/controllers/flowlogspipeline/metrics_definitions/namespace_egress_rtt_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/namespace_egress_rtt_total.yaml
@@ -1,0 +1,28 @@
+#flp_confgen
+description:
+  This metric observes the namespaces outgoing traffic
+details:
+  Sum RTT for outgoing traffic per source and destination namespaces
+usage:
+  Evaluate network outgoing TCP hanshakes Round Trip Time per source and destination namespaces
+tags:
+  - egress
+  - rtt
+  - namespaces
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: namespace_egress_rtt_total
+        type: histogram
+        valuekey: TimeFlowRttNs
+        filters:
+        - key: FlowDirection
+          value: "1"
+        - key: Duplicate
+          value: "false"
+        - key: TimeFlowRttNs
+          value: "!nil"
+        labels:
+          - SrcK8S_Namespace
+          - DstK8S_Namespace

--- a/controllers/flowlogspipeline/metrics_definitions/namespace_ingress_rtt_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/namespace_ingress_rtt_total.yaml
@@ -1,0 +1,28 @@
+#flp_confgen
+description:
+  This metric observes the namespaces incoming traffic
+details:
+  Sum RTT for incoming traffic per source and destination namespaces
+usage:
+  Evaluate network incoming TCP hanshakes Round Trip Time per source and destination namespaces
+tags:
+  - ingress
+  - rtt
+  - namespaces
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: namespace_ingress_rtt_total
+        type: histogram
+        valuekey: TimeFlowRttNs
+        filters:
+        - key: FlowDirection
+          value: "0"
+        - key: Duplicate
+          value: "false"
+        - key: TimeFlowRttNs
+          value: "!nil"
+        labels:
+          - SrcK8S_Namespace
+          - DstK8S_Namespace

--- a/controllers/flowlogspipeline/metrics_definitions/node_egress_rtt_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/node_egress_rtt_total.yaml
@@ -1,0 +1,28 @@
+#flp_confgen
+description:
+  This metric observes the nodes outgoing traffic
+details:
+  Sum RTT for outgoing traffic per source and destination nodes
+usage:
+  Evaluate network outgoing TCP hanshakes Round Trip Time per source and destination nodes
+tags:
+  - egress
+  - rtt
+  - nodes
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: node_egress_rtt_total
+        type: histogram
+        valuekey: TimeFlowRttNs
+        filters:
+        - key: FlowDirection
+          value: "1"
+        - key: Duplicate
+          value: "false"
+        - key: TimeFlowRttNs
+          value: "!nil"
+        labels:
+          - SrcK8S_HostName
+          - DstK8S_HostName

--- a/controllers/flowlogspipeline/metrics_definitions/node_ingress_rtt_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/node_ingress_rtt_total.yaml
@@ -1,0 +1,28 @@
+#flp_confgen
+description:
+  This metric observes the nodes incoming traffic
+details:
+  Sum RTT for incoming traffic per source and destination nodes
+usage:
+  Evaluate network incoming TCP hanshakes Round Trip Time per source and destination nodes
+tags:
+  - ingress
+  - rtt
+  - nodes
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: node_ingress_rtt_total
+        type: histogram
+        valuekey: TimeFlowRttNs
+        filters:
+        - key: FlowDirection
+          value: "0"
+        - key: Duplicate
+          value: "false"
+        - key: TimeFlowRttNs
+          value: "!nil"
+        labels:
+          - SrcK8S_HostName
+          - DstK8S_HostName

--- a/controllers/flowlogspipeline/metrics_definitions/workload_egress_rtt_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_egress_rtt_total.yaml
@@ -1,0 +1,32 @@
+#flp_confgen
+description:
+  This metric observes the outgoing traffic
+details:
+  Sum RTT for outgoing traffic per source and destination namespaces and owners
+usage:
+  Evaluate network outgoing TCP hanshakes Round Trip Time per source and destination namespaces and owners
+tags:
+  - egress
+  - rtt
+  - workloads
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: workload_egress_rtt_total
+        type: histogram
+        valuekey: TimeFlowRttNs
+        filters:
+        - key: FlowDirection
+          value: "1"
+        - key: Duplicate
+          value: "false"
+        - key: TimeFlowRttNs
+          value: "!nil"
+        labels:
+          - SrcK8S_Namespace
+          - DstK8S_Namespace
+          - SrcK8S_OwnerName
+          - DstK8S_OwnerName
+          - SrcK8S_OwnerType
+          - DstK8S_OwnerType

--- a/controllers/flowlogspipeline/metrics_definitions/workload_ingress_rtt_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_ingress_rtt_total.yaml
@@ -1,0 +1,32 @@
+#flp_confgen
+description:
+  This metric observes the incoming traffic
+details:
+  Sum RTT for incoming traffic per source and destination namespaces and owners
+usage:
+  Evaluate network incoming TCP hanshakes Round Trip Time per source and destination namespaces and owners
+tags:
+  - ingress
+  - rtt
+  - workloads
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: workload_ingress_rtt_total
+        type: histogram
+        valuekey: TimeFlowRttNs
+        filters:
+        - key: FlowDirection
+          value: "0"
+        - key: Duplicate
+          value: "false"
+        - key: TimeFlowRttNs
+          value: "!nil"
+        labels:
+          - SrcK8S_Namespace
+          - DstK8S_Namespace
+          - SrcK8S_OwnerName
+          - DstK8S_OwnerName
+          - SrcK8S_OwnerType
+          - DstK8S_OwnerType

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -8002,9 +8002,9 @@ target specifies the target value for the given metric
         <td><b>ignoreTags</b></td>
         <td>[]string</td>
         <td>
-          `ignoreTags` is a list of tags to specify which metrics to ignore. Each metric is associated with a list of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions . Available tags are: `egress`, `ingress`, `flows`, `bytes`, `packets`, `namespaces`, `nodes`, `workloads`, `nodes-flows`, `namespaces-flows`, `workloads-flows`. Namespace-based metrics are covered by both `workloads` and `namespaces` tags, hence it is recommended to always ignore one of them (`workloads` offering a finer granularity).<br/>
+          `ignoreTags` is a list of tags to specify which metrics to ignore. Each metric is associated with a list of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions . Available tags are: `egress`, `ingress`, `flows`, `bytes`, `packets`, `rtt`, `namespaces`, `nodes`, `workloads`, `nodes-flows`, `namespaces-flows`, `workloads-flows`. Namespace-based metrics are covered by both `workloads` and `namespaces` tags, hence it is recommended to always ignore one of them (`workloads` offering a finer granularity).<br/>
           <br/>
-            <i>Default</i>: [egress packets nodes-flows namespaces-flows workloads-flows namespaces]<br/>
+            <i>Default</i>: [egress packets rtt nodes-flows namespaces-flows workloads-flows namespaces]<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
## Description

- adds RTT metrics to FLP metrics definitions

~As RTT is dev preview for 1.4, we don't need to document and test this unless it's merged after 1.4 release.
It can be backported if needed.~
 
## Dependencies

Rely on https://github.com/netobserv/network-observability-operator/pull/394. Merge first !
Requires https://github.com/netobserv/flowlogs-pipeline/pull/478 to skip flows that doesn't contains `TimeFlowRttNs` field

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
