### PR TITLE
 NETOBSERV-314: NETOBSERV-1274 index type and duplicate (improve query perfs) [1.4 backport candidate]

### DIFF
--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -34,6 +34,6 @@ const (
 	EndConnectionType = "endConnection"
 )
 
-var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "DstK8S_Namespace", "DstK8S_OwnerName", "FlowDirection", "Duplicate"}
+var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstK8S_Type", "FlowDirection", "Duplicate"}
 var LokiConnectionIndexFields = []string{"_RecordType"}
 var FlowCollectorName = types.NamespacedName{Name: "cluster"}

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -34,6 +34,6 @@ const (
 	EndConnectionType = "endConnection"
 )
 
-var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "DstK8S_Namespace", "DstK8S_OwnerName", "FlowDirection"}
+var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "DstK8S_Namespace", "DstK8S_OwnerName", "FlowDirection", "Duplicate"}
 var LokiConnectionIndexFields = []string{"_RecordType"}
 var FlowCollectorName = types.NamespacedName{Name: "cluster"}

--- a/controllers/flowlogspipeline/flp_common_objects.go
+++ b/controllers/flowlogspipeline/flp_common_objects.go
@@ -540,7 +540,6 @@ func (b *builder) addConnectionTracking(indexFields []string, lastStage config.P
 				SwapAB:              true,
 			},
 		})
-
 	}
 	return indexFields, lastStage
 }

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -630,7 +630,17 @@ func TestConfigMapShouldDeserializeAsJSON(t *testing.T) {
 	assert.Equal(loki.MaxBackoff.Duration.String(), lokiCfg.MaxBackoff)
 	assert.EqualValues(*loki.MaxRetries, lokiCfg.MaxRetries)
 	assert.EqualValues(loki.BatchSize, lokiCfg.BatchSize)
-	assert.EqualValues([]string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "DstK8S_Namespace", "DstK8S_OwnerName", "FlowDirection", "_RecordType"}, lokiCfg.Labels)
+	assert.EqualValues([]string{
+		"SrcK8S_Namespace",
+		"SrcK8S_OwnerName",
+		"SrcK8S_Type",
+		"DstK8S_Namespace",
+		"DstK8S_OwnerName",
+		"DstK8S_Type",
+		"FlowDirection",
+		"Duplicate",
+		"_RecordType",
+	}, lokiCfg.Labels)
 	assert.Equal(`{app="netobserv-flowcollector"}`, fmt.Sprintf("%v", lokiCfg.StaticLabels))
 
 	assert.Equal(cfg.Processor.Metrics.Server.Port, int32(decoded.MetricsSettings.Port))


### PR DESCRIPTION
## Description

Add new indexes to improve query performances:
- Duplicate field
- Src/Dst Types fields

## Dependencies

- UI: TODO

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
