### PR TITLE
NETOBSERV-1295 backport: Fix certs monitoring copy 

### DIFF
--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -32,6 +32,9 @@ const (
 	NewConnectionType = "newConnection"
 	HeartbeatType     = "heartbeat"
 	EndConnectionType = "endConnection"
+
+	MonitoringNamespace      = "openshift-monitoring"
+	MonitoringServiceAccount = "prometheus-k8s"
 )
 
 var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "DstK8S_Namespace", "DstK8S_OwnerName", "FlowDirection"}

--- a/controllers/flowcollector_objects.go
+++ b/controllers/flowcollector_objects.go
@@ -14,13 +14,11 @@ import (
 var healthDashboardEmbed string
 
 const (
-	downstreamLabelKey       = "openshift.io/cluster-monitoring"
-	downstreamLabelValue     = "true"
-	roleSuffix               = "-metrics-reader"
-	monitoringServiceAccount = "prometheus-k8s"
-	monitoringNamespace      = "openshift-monitoring"
-	dashboardCMNamespace     = "openshift-config-managed"
-	dashboardCMAnnotation    = "console.openshift.io/dashboard"
+	downstreamLabelKey    = "openshift.io/cluster-monitoring"
+	downstreamLabelValue  = "true"
+	roleSuffix            = "-metrics-reader"
+	dashboardCMNamespace  = "openshift-config-managed"
+	dashboardCMAnnotation = "console.openshift.io/dashboard"
 
 	flowDashboardCMName = "grafana-dashboard-netobserv-flow-metrics"
 	flowDashboardCMFile = "netobserv-flow-metrics.json"
@@ -74,8 +72,8 @@ func buildRoleBindingMonitoringReader(ns string) *rbacv1.ClusterRoleBinding {
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind:      "ServiceAccount",
-			Name:      monitoringServiceAccount,
-			Namespace: monitoringNamespace,
+			Name:      constants.MonitoringServiceAccount,
+			Namespace: constants.MonitoringNamespace,
 		}},
 	}
 }

--- a/controllers/flowlogspipeline/flp_ingest_reconciler.go
+++ b/controllers/flowlogspipeline/flp_ingest_reconciler.go
@@ -116,6 +116,11 @@ func (r *flpIngesterReconciler) reconcile(ctx context.Context, desired *flowslat
 		return err
 	}
 
+	// Watch for monitoring caCert
+	if err = reconcileMonitoringCerts(ctx, r.Common, &desired.Spec.Processor.Metrics.Server.TLS, r.Namespace); err != nil {
+		return err
+	}
+
 	return r.reconcileDaemonSet(ctx, builder.daemonSet(annotations))
 }
 

--- a/controllers/flowlogspipeline/flp_monolith_reconciler.go
+++ b/controllers/flowlogspipeline/flp_monolith_reconciler.go
@@ -125,6 +125,11 @@ func (r *flpMonolithReconciler) reconcile(ctx context.Context, desired *flowslat
 		return err
 	}
 
+	// Watch for monitoring caCert
+	if err = reconcileMonitoringCerts(ctx, r.Common, &desired.Spec.Processor.Metrics.Server.TLS, r.Namespace); err != nil {
+		return err
+	}
+
 	return r.reconcileDaemonSet(ctx, builder.daemonSet(annotations))
 }
 

--- a/controllers/flowlogspipeline/flp_reconciler.go
+++ b/controllers/flowlogspipeline/flp_reconciler.go
@@ -101,3 +101,20 @@ func annotateKafkaCerts(ctx context.Context, info *reconcilers.Common, spec *flo
 	}
 	return nil
 }
+
+func reconcileMonitoringCerts(ctx context.Context, info *reconcilers.Common, tlsConfig *flowslatest.ServerTLS, ns string) error {
+	if tlsConfig.Type == flowslatest.ServerTLSProvided && tlsConfig.Provided != nil {
+		_, err := info.Watcher.ProcessCertRef(ctx, info.Client, tlsConfig.Provided, ns)
+		if err != nil {
+			return err
+		}
+	}
+	if !tlsConfig.InsecureSkipVerify && tlsConfig.ProvidedCaFile != nil && tlsConfig.ProvidedCaFile.File != "" {
+		_, err := info.Watcher.ProcessFileReference(ctx, info.Client, *tlsConfig.ProvidedCaFile, ns)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/controllers/flowlogspipeline/flp_transfo_reconciler.go
+++ b/controllers/flowlogspipeline/flp_transfo_reconciler.go
@@ -128,6 +128,10 @@ func (r *flpTransformerReconciler) reconcile(ctx context.Context, desired *flows
 	if err = annotateKafkaExporterCerts(ctx, r.Common, desired.Spec.Exporters, annotations); err != nil {
 		return err
 	}
+	// Watch for monitoring caCert
+	if err = reconcileMonitoringCerts(ctx, r.Common, &desired.Spec.Processor.Metrics.Server.TLS, r.Namespace); err != nil {
+		return err
+	}
 
 	return r.reconcileDeployment(ctx, &desired.Spec.Processor, &builder, annotations)
 }

--- a/pkg/watchers/watcher.go
+++ b/pkg/watchers/watcher.go
@@ -101,6 +101,26 @@ func (w *Watcher) ProcessCACert(ctx context.Context, cl helper.Client, tls *flow
 	return caDigest, nil
 }
 
+func (w *Watcher) ProcessCertRef(ctx context.Context, cl helper.Client, cert *flowslatest.CertificateReference, targetNamespace string) (certDigest string, err error) {
+	if cert != nil {
+		certRef := w.refFromCert(cert)
+		certDigest, err = w.reconcile(ctx, cl, certRef, targetNamespace)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return certDigest, nil
+}
+
+func (w *Watcher) ProcessFileReference(ctx context.Context, cl helper.Client, file flowslatest.FileReference, targetNamespace string) (fileDigest string, err error) {
+	fileDigest, err = w.reconcile(ctx, cl, w.refFromFile(&file), targetNamespace)
+	if err != nil {
+		return "", err
+	}
+	return fileDigest, nil
+}
+
 func (w *Watcher) ProcessSASL(ctx context.Context, cl helper.Client, sasl *flowslatest.SASLConfig, targetNamespace string) (idDigest string, secretDigest string, err error) {
 	idDigest, err = w.reconcile(ctx, cl, w.refFromFile(&sasl.ClientIDReference), targetNamespace)
 	if err != nil {


### PR DESCRIPTION
## Description

Backport of [NETOBSERV-1295](https://issues.redhat.com//browse/NETOBSERV-1295)

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
