### PR TITLE
NETOBSERV-791 Better organize OLM form

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,12 +387,15 @@ bundle-prepare: OPSDK generate kustomize ## Generate bundle manifests and metada
 bundle: bundle-prepare ## Generate final bundle files.
 	rm -r bundle/manifests
 	rm -r bundle/metadata
+	cp ./config/csv/bases/netobserv-operator.clusterserviceversion.yaml tmp-csv
+	hack/crd2csvSpecDesc.sh v1beta2
 	$(SED) -e 's/^/    /' config/descriptions/upstream.md > tmp-desc
 	$(KUSTOMIZE) build $(BUNDLE_CONFIG) \
 		| $(SED) -e 's~:container-image:~$(IMAGE)~' \
 		| $(SED) -e "/':full-description:'/r tmp-desc" \
 		| $(SED) -e "s/':full-description:'/|\-/" \
 		| $(OPSDK) generate bundle -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS)
+	mv tmp-csv ./config/csv/bases/netobserv-operator.clusterserviceversion.yaml
 	rm tmp-desc
 	sh -c '\
 	VALIDATION_OUTPUT=$$($(OPSDK) bundle validate ./bundle --select-optional suite=operatorframework); \

--- a/apis/flowcollector/v1beta1/flowcollector_types.go
+++ b/apis/flowcollector/v1beta1/flowcollector_types.go
@@ -212,11 +212,11 @@ type FlowCollectorEBPF struct {
 	// `logLevel` defines the log level for the NetObserv eBPF Agent
 	LogLevel string `json:"logLevel,omitempty"`
 
-	// Privileged mode for the eBPF Agent container. In general this setting can be ignored or set to `false`:
-	// in that case, the operator sets granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE)
-	// to the container, to enable its correct operation.
+	// Privileged mode for the eBPF Agent container. When ignored or set to `false`, the operator sets
+	// granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container.
 	// If for some reason these capabilities cannot be set, such as if an old kernel version not knowing CAP_BPF
 	// is in use, then you can turn on this mode for more global privileges.
+	// Some agent features require the privileged mode, such as packet drops tracking (see `features`).
 	// +optional
 	Privileged bool `json:"privileged,omitempty"`
 

--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -219,11 +219,11 @@ type FlowCollectorEBPF struct {
 	// `logLevel` defines the log level for the NetObserv eBPF Agent
 	LogLevel string `json:"logLevel,omitempty"`
 
-	// Privileged mode for the eBPF Agent container. In general this setting can be ignored or set to `false`:
-	// in that case, the operator sets granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE)
-	// to the container, to enable its correct operation.
+	// Privileged mode for the eBPF Agent container. When ignored or set to `false`, the operator sets
+	// granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container.
 	// If for some reason these capabilities cannot be set, such as if an old kernel version not knowing CAP_BPF
 	// is in use, then you can turn on this mode for more global privileges.
+	// Some agent features require the privileged mode, such as packet drops tracking (see `features`).
 	// +optional
 	Privileged bool `json:"privileged,omitempty"`
 

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -2608,14 +2608,14 @@ spec:
                         - panic
                         type: string
                       privileged:
-                        description: 'Privileged mode for the eBPF Agent container.
-                          In general this setting can be ignored or set to `false`:
-                          in that case, the operator sets granular capabilities (BPF,
-                          PERFMON, NET_ADMIN, SYS_RESOURCE) to the container, to enable
-                          its correct operation. If for some reason these capabilities
-                          cannot be set, such as if an old kernel version not knowing
-                          CAP_BPF is in use, then you can turn on this mode for more
-                          global privileges.'
+                        description: Privileged mode for the eBPF Agent container.
+                          When ignored or set to `false`, the operator sets granular
+                          capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to
+                          the container. If for some reason these capabilities cannot
+                          be set, such as if an old kernel version not knowing CAP_BPF
+                          is in use, then you can turn on this mode for more global
+                          privileges. Some agent features require the privileged mode,
+                          such as packet drops tracking (see `features`).
                         type: boolean
                       resources:
                         default:
@@ -5293,14 +5293,14 @@ spec:
                         - panic
                         type: string
                       privileged:
-                        description: 'Privileged mode for the eBPF Agent container.
-                          In general this setting can be ignored or set to `false`:
-                          in that case, the operator sets granular capabilities (BPF,
-                          PERFMON, NET_ADMIN, SYS_RESOURCE) to the container, to enable
-                          its correct operation. If for some reason these capabilities
-                          cannot be set, such as if an old kernel version not knowing
-                          CAP_BPF is in use, then you can turn on this mode for more
-                          global privileges.'
+                        description: Privileged mode for the eBPF Agent container.
+                          When ignored or set to `false`, the operator sets granular
+                          capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to
+                          the container. If for some reason these capabilities cannot
+                          be set, such as if an old kernel version not knowing CAP_BPF
+                          is in use, then you can turn on this mode for more global
+                          privileges. Some agent features require the privileged mode,
+                          such as packet drops tracking (see `features`).
                         type: boolean
                       resources:
                         default:

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -409,7 +409,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Networking
     console.openshift.io/plugins: '["netobserv-plugin"]'
-    containerImage: quay.io/netobserv/network-observability-operator:1.0.4
+    containerImage: quay.io/netobserv/network-observability-operator:main
     createdAt: ':created-at:'
     description: Network flows collector and monitoring solution
     operatorframework.io/suggested-namespace: openshift-netobserv-operator
@@ -454,45 +454,17 @@ spec:
       - description: for flows extraction.
         displayName: Agent configuration
         path: agent
-      - description: Flows tracing agent. EBPF (default) is recommended as it offers
-          better performances and should work regardless of the CNI installed on the
-          cluster. `IPFIX` works with OVN-Kubernetes CNI (other CNIs could work if
-          they support exporting IPFIX,
-        displayName: Agent type
-        path: agent.type
+      - path: agent.type
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:select:EBPF
-        - urn:alm:descriptor:com.tectonic.ui:select:IPFIX
-      - description: Deprecated - Settings related to the IPFIX-based flow reporter.
-        displayName: IPFIX Agent configuration
-        path: agent.ipfix
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - path: agent.ipfix
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:IPFIX
-      - displayName: Sampling
-        path: agent.ipfix.sampling
-      - displayName: Cache timeout
-        path: agent.ipfix.cacheActiveTimeout
-      - displayName: Cache max flows
-        path: agent.ipfix.cacheMaxFlows
-      - displayName: Force sample ALL
-        path: agent.ipfix.forceSampleAll
-      - displayName: OpenShift Cluster Network Operator settings
-        path: agent.ipfix.clusterNetworkOperator
-      - displayName: Namespace
-        path: agent.ipfix.clusterNetworkOperator.namespace
-      - displayName: OVN-Kubernetes settings
-        path: agent.ipfix.ovnKubernetes
-      - displayName: Namespace
-        path: agent.ipfix.ovnKubernetes.namespace
-      - displayName: DaemonSet name
-        path: agent.ipfix.ovnKubernetes.daemonSetName
-      - displayName: Container name
-        path: agent.ipfix.ovnKubernetes.containerName
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Settings related to the eBPF-based flow reporter.
         displayName: eBPF Agent configuration
         path: agent.ebpf
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:EBPF
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:eBPF
       - displayName: Sampling
         path: agent.ebpf.sampling
       - displayName: Privileged mode
@@ -503,31 +475,42 @@ spec:
         path: agent.ebpf.features
       - displayName: Cache timeout
         path: agent.ebpf.cacheActiveTimeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Cache max flows
         path: agent.ebpf.cacheMaxFlows
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Kafka maximum request size
         path: agent.ebpf.kafkaBatchSize
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Interfaces
         path: agent.ebpf.interfaces
       - displayName: Exclude interfaces
         path: agent.ebpf.excludeInterfaces
       - displayName: Log level
         path: agent.ebpf.logLevel
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Image pull policy
         path: agent.ebpf.imagePullPolicy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Resource Requirements
         path: agent.ebpf.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - path: agent.ebpf.advanced
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: to use Kafka as a broker as part of the flow collection pipeline.
         displayName: Kafka configuration
         path: kafka
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
       - displayName: Address
         path: kafka.address
       - displayName: Topic
@@ -564,20 +547,21 @@ spec:
           and/or any available exporter.
         displayName: Processor configuration
         path: processor
-      - displayName: ClusterName
+      - displayName: Multi-cluster deployment
+        path: processor.multiClusterDeployment
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Cluster name
         path: processor.clusterName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.multiClusterDeployment:true
       - displayName: Log types
         path: processor.logTypes
-      - displayName: Conversation heartbeat interval
-        path: processor.conversationHeartbeatInterval
-      - displayName: Conversation terminating timeout
-        path: processor.conversationTerminatingTimeout
-      - displayName: Conversation end timeout
-        path: processor.conversationEndTimeout
-      - displayName: Enable kubernetes probes
-        path: processor.enableKubeProbes
+      - path: processor.advanced
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Metrics configuration
         path: processor.metrics
       - displayName: Server configuration
@@ -591,51 +575,48 @@ spec:
       - displayName: Insecure
         path: processor.metrics.server.tls.insecureSkipVerify
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:PROVIDED
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided
       - displayName: Cert
         path: processor.metrics.server.tls.provided
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:PROVIDED
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided
       - displayName: CA
         path: processor.metrics.server.tls.providedCaFile
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:PROVIDED
-      - displayName: Ignore tags
-        path: processor.metrics.ignoreTags
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided
+      - displayName: Include list
+        path: processor.metrics.includeList
       - displayName: Disable alerts
         path: processor.metrics.disableAlerts
-      - displayName: Drop unused fields
-        path: processor.dropUnusedFields
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - displayName: Port
-        path: processor.port
-      - displayName: Health port
-        path: processor.healthPort
-      - displayName: ProfilePort
-        path: processor.profilePort
       - displayName: Kafka consumer replicas
         path: processor.kafkaConsumerReplicas
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: kafka consumer autoscaler
         path: processor.kafkaConsumerAutoscaler
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Kafka consumer queue capacity
         path: processor.kafkaConsumerQueueCapacity
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Kafka consumer batch size
         path: processor.kafkaConsumerBatchSize
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Log level
         path: processor.logLevel
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Image pull policy
         path: processor.imagePullPolicy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Resource Requirements
         path: processor.resources
         x-descriptors:
@@ -647,94 +628,44 @@ spec:
         path: loki.enable
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - displayName: URL
-        path: loki.url
+      - displayName: Mode
+        path: loki.mode
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: TLS configuration
-        path: loki.tls
+      - displayName: Loki Stack
+        path: loki.lokiStack
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:LokiStack
+      - displayName: Monolithic
+        path: loki.monolithic
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Monolithic
+      - displayName: Microservices
+        path: loki.microservices
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Microservices
+      - displayName: Manual
+        path: loki.manual
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Manual
+      - displayName: Write batch timeout
+        path: loki.writeBatchWait
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Enable
-        path: loki.tls.enable
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Insecure
-        path: loki.tls.insecureSkipVerify
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true
-      - displayName: User cert
-        path: loki.tls.userCert
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true
-      - displayName: CA cert
-        path: loki.tls.caCert
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true
-      - displayName: Querier URL
-        path: loki.querierUrl
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Write batch size
+        path: loki.writeBatchSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Status URL
-        path: loki.statusUrl
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Write timeout
+        path: loki.writeTimeout
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Status TLS configuration
-        path: loki.statusTls
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - path: loki.advanced
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Enable
-        path: loki.statusTls.enable
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Insecure
-        path: loki.statusTls.insecureSkipVerify
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true
-      - displayName: User cert
-        path: loki.statusTls.userCert
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true
-      - displayName: CA cert
-        path: loki.statusTls.caCert
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true
-      - displayName: Tenant ID
-        path: loki.tenantID
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Authentication Token
-        path: loki.authToken
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Batch wait
-        path: loki.batchWait
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Batch size
-        path: loki.batchSize
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Min backoff
-        path: loki.minBackoff
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Max backoff
-        path: loki.maxBackoff
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Max retries
-        path: loki.maxRetries
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Timeout
-        path: loki.timeout
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: related to the OpenShift Console integration.
         displayName: Console plugin configuration
         path: consolePlugin
@@ -744,15 +675,6 @@ spec:
         path: consolePlugin.enable
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - displayName: Register
-        path: consolePlugin.register
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
-      - displayName: Port
-        path: consolePlugin.port
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
       - displayName: Port naming
         path: consolePlugin.portNaming
         x-descriptors:
@@ -765,24 +687,31 @@ spec:
         path: consolePlugin.replicas
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Horizontal pod autoscaler
         path: consolePlugin.autoscaler
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Log level
         path: consolePlugin.logLevel
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Image pull policy
         path: consolePlugin.imagePullPolicy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Resource Requirements
         path: consolePlugin.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+      - path: consolePlugin.advanced
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: additional optional exporters for custom consumption or storage.
         displayName: Exporters
         path: exporters
@@ -797,7 +726,7 @@ spec:
       - displayName: Kafka configuration
         path: exporters[0].kafka
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:KAFKA
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:Kafka
       statusDescriptors:
       - description: Namespace where console plugin and flowlogs-pipeline have been
           deployed.
@@ -854,7 +783,7 @@ spec:
 
     ## Configuration
 
-    The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/1.0.4/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/1.0.4/config/samples/flows_v1beta1_flowcollector.yaml).
+    The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/main/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/main/config/samples/flows_v1beta1_flowcollector.yaml).
 
     To edit configuration in cluster, run:
 
@@ -872,7 +801,7 @@ spec:
 
     - Loki (`spec.loki`): configure here how to reach Loki. The default values match the Loki quick install paths mentioned above, but you may have to configure differently if you used another installation method.
 
-    - Quick filters (`spec.consolePlugin.quickFilters`): configure preset filters to be displayed in the Console plugin. They offer a way to quickly switch from filters to others, such as showing / hiding pods network, or infrastructure network, or application network, etc. They can be tuned to reflect the different workloads running on your cluster. For a list of available filters, [check this page](https://github.com/netobserv/network-observability-operator/blob/1.0.4/docs/QuickFilters.md).
+    - Quick filters (`spec.consolePlugin.quickFilters`): configure preset filters to be displayed in the Console plugin. They offer a way to quickly switch from filters to others, such as showing / hiding pods network, or infrastructure network, or application network, etc. They can be tuned to reflect the different workloads running on your cluster. For a list of available filters, [check this page](https://github.com/netobserv/network-observability-operator/blob/main/docs/QuickFilters.md).
 
     - Kafka (`spec.deploymentModel: KAFKA` and `spec.kafka`): when enabled, integrates the flow collection pipeline with Kafka, by splitting ingestion from transformation (kube enrichment, derived metrics, ...). Kafka can provide better scalability, resiliency and high availability ([view more details](https://www.redhat.com/en/topics/integration/what-is-apache-kafka)). Assumes Kafka is already deployed and a topic is created.
 
@@ -1150,7 +1079,7 @@ spec:
                 - name: DOWNSTREAM_DEPLOYMENT
                   value: "false"
                 - name: PROFILING_BIND_ADDRESS
-                image: quay.io/netobserv/network-observability-operator:1.0.4
+                image: quay.io/netobserv/network-observability-operator:main
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -412,6 +412,8 @@ metadata:
     containerImage: quay.io/netobserv/network-observability-operator:1.0.4
     createdAt: ':created-at:'
     description: Network flows collector and monitoring solution
+    operatorframework.io/initialization-resource: '{"apiVersion":"flowcollectors.flows.netobserv.io/v1beta2",
+      "kind":"FlowCollector","metadata":{"name":"cluster"},"spec": {}}'
     operatorframework.io/suggested-namespace: openshift-netobserv-operator
     operators.operatorframework.io/builder: operator-sdk-v1.25.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -412,7 +412,7 @@ metadata:
     containerImage: quay.io/netobserv/network-observability-operator:1.0.4
     createdAt: ':created-at:'
     description: Network flows collector and monitoring solution
-    operatorframework.io/initialization-resource: '{"apiVersion":"flowcollectors.flows.netobserv.io/v1beta2",
+    operatorframework.io/initialization-resource: '{"apiVersion":"flows.netobserv.io/v1beta2",
       "kind":"FlowCollector","metadata":{"name":"cluster"},"spec": {}}'
     operatorframework.io/suggested-namespace: openshift-netobserv-operator
     operators.operatorframework.io/builder: operator-sdk-v1.25.3

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -409,7 +409,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Networking
     console.openshift.io/plugins: '["netobserv-plugin"]'
-    containerImage: quay.io/netobserv/network-observability-operator:main
+    containerImage: quay.io/netobserv/network-observability-operator:1.0.4
     createdAt: ':created-at:'
     description: Network flows collector and monitoring solution
     operatorframework.io/suggested-namespace: openshift-netobserv-operator
@@ -446,8 +446,6 @@ spec:
       kind: FlowCollector
       name: flowcollectors.flows.netobserv.io
       specDescriptors:
-      - displayName: Namespace
-        path: namespace
       - description: defines the desired type of deployment for flow processing.
         displayName: Deployment model
         path: deploymentModel
@@ -465,15 +463,11 @@ spec:
         path: agent.ebpf
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:eBPF
-      - displayName: Sampling
-        path: agent.ebpf.sampling
       - displayName: Privileged mode
         path: agent.ebpf.privileged
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - displayName: Features
-        path: agent.ebpf.features
-      - displayName: Cache timeout
+      - displayName: Cache active timeout
         path: agent.ebpf.cacheActiveTimeout
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
@@ -481,15 +475,11 @@ spec:
         path: agent.ebpf.cacheMaxFlows
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - displayName: Kafka maximum request size
+      - displayName: Kafka batch size
         path: agent.ebpf.kafkaBatchSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - displayName: Interfaces
-        path: agent.ebpf.interfaces
-      - displayName: Exclude interfaces
-        path: agent.ebpf.excludeInterfaces
       - displayName: Log level
         path: agent.ebpf.logLevel
         x-descriptors:
@@ -511,14 +501,9 @@ spec:
         path: kafka
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
-      - displayName: Address
-        path: kafka.address
-      - displayName: Topic
-        path: kafka.topic
       - displayName: TLS configuration
         path: kafka.tls
-      - displayName: Enable
-        path: kafka.tls.enable
+      - path: kafka.tls.enable
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Insecure
@@ -526,22 +511,17 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
-      - displayName: User cert
+      - displayName: User certificate when using mTLS
         path: kafka.tls.userCert
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
-      - displayName: CA cert
+      - displayName: CA certificate
         path: kafka.tls.caCert
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
-      - displayName: SASL configuration
-        path: kafka.sasl
-      - displayName: Type
-        path: kafka.sasl.type
-      - displayName: Client ID
-        path: kafka.sasl.clientIDReference
-      - displayName: Client secret
-        path: kafka.sasl.clientSecretReference
+      - path: kafka.sasl
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: of the component that receives the flows from the agent, enriches
           them, generates metrics, and forwards them to the Loki persistence layer
           and/or any available exporter.
@@ -557,8 +537,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.multiClusterDeployment:true
-      - displayName: Log types
-        path: processor.logTypes
       - path: processor.advanced
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
@@ -566,12 +544,8 @@ spec:
         path: processor.metrics
       - displayName: Server configuration
         path: processor.metrics.server
-      - displayName: Port
-        path: processor.metrics.server.port
       - displayName: TLS configuration
         path: processor.metrics.server.tls
-      - displayName: Type
-        path: processor.metrics.server.tls.type
       - displayName: Insecure
         path: processor.metrics.server.tls.insecureSkipVerify
         x-descriptors:
@@ -584,10 +558,6 @@ spec:
         path: processor.metrics.server.tls.providedCaFile
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided
-      - displayName: Include list
-        path: processor.metrics.includeList
-      - displayName: Disable alerts
-        path: processor.metrics.disableAlerts
       - displayName: Kafka consumer replicas
         path: processor.kafkaConsumerReplicas
         x-descriptors:
@@ -632,7 +602,7 @@ spec:
         path: loki.mode
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-      - displayName: Loki Stack
+      - displayName: Loki stack
         path: loki.lokiStack
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:LokiStack
@@ -648,7 +618,7 @@ spec:
         path: loki.manual
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Manual
-      - displayName: Write batch timeout
+      - displayName: Write batch wait
         path: loki.writeBatchWait
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
@@ -701,7 +671,7 @@ spec:
       - displayName: Image pull policy
         path: consolePlugin.imagePullPolicy
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+        - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy"
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Resource Requirements
@@ -727,6 +697,56 @@ spec:
         path: exporters[0].kafka
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:Kafka
+      - displayName: Exclude interfaces
+        path: agent.ebpf.excludeInterfaces
+      - displayName: Features
+        path: agent.ebpf.features
+      - displayName: Interfaces
+        path: agent.ebpf.interfaces
+      - displayName: Sampling
+        path: agent.ebpf.sampling
+      - displayName: Enable
+        path: consolePlugin.portNaming.enable
+      - displayName: Port names
+        path: consolePlugin.portNaming.portNames
+      - displayName: Address
+        path: kafka.address
+      - displayName: Topic
+        path: kafka.topic
+      - displayName: Name
+        path: loki.lokiStack.name
+      - displayName: Namespace
+        path: loki.lokiStack.namespace
+      - displayName: Auth token
+        path: loki.manual.authToken
+      - displayName: Ingester url
+        path: loki.manual.ingesterUrl
+      - displayName: Querier url
+        path: loki.manual.querierUrl
+      - displayName: Status url
+        path: loki.manual.statusUrl
+      - displayName: TenantID
+        path: loki.manual.tenantID
+      - displayName: Ingester url
+        path: loki.microservices.ingesterUrl
+      - displayName: Querier url
+        path: loki.microservices.querierUrl
+      - displayName: TenantID
+        path: loki.microservices.tenantID
+      - displayName: TenantID
+        path: loki.monolithic.tenantID
+      - displayName: Url
+        path: loki.monolithic.url
+      - displayName: Namespace
+        path: namespace
+      - displayName: Log types
+        path: processor.logTypes
+      - displayName: Disable alerts
+        path: processor.metrics.disableAlerts
+      - displayName: Include list
+        path: processor.metrics.includeList
+      - displayName: Port
+        path: processor.metrics.server.port
       statusDescriptors:
       - description: Namespace where console plugin and flowlogs-pipeline have been
           deployed.
@@ -783,7 +803,7 @@ spec:
 
     ## Configuration
 
-    The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/main/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/main/config/samples/flows_v1beta1_flowcollector.yaml).
+    The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/1.0.4/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/1.0.4/config/samples/flows_v1beta1_flowcollector.yaml).
 
     To edit configuration in cluster, run:
 
@@ -801,7 +821,7 @@ spec:
 
     - Loki (`spec.loki`): configure here how to reach Loki. The default values match the Loki quick install paths mentioned above, but you may have to configure differently if you used another installation method.
 
-    - Quick filters (`spec.consolePlugin.quickFilters`): configure preset filters to be displayed in the Console plugin. They offer a way to quickly switch from filters to others, such as showing / hiding pods network, or infrastructure network, or application network, etc. They can be tuned to reflect the different workloads running on your cluster. For a list of available filters, [check this page](https://github.com/netobserv/network-observability-operator/blob/main/docs/QuickFilters.md).
+    - Quick filters (`spec.consolePlugin.quickFilters`): configure preset filters to be displayed in the Console plugin. They offer a way to quickly switch from filters to others, such as showing / hiding pods network, or infrastructure network, or application network, etc. They can be tuned to reflect the different workloads running on your cluster. For a list of available filters, [check this page](https://github.com/netobserv/network-observability-operator/blob/1.0.4/docs/QuickFilters.md).
 
     - Kafka (`spec.deploymentModel: KAFKA` and `spec.kafka`): when enabled, integrates the flow collection pipeline with Kafka, by splitting ingestion from transformation (kube enrichment, derived metrics, ...). Kafka can provide better scalability, resiliency and high availability ([view more details](https://www.redhat.com/en/topics/integration/what-is-apache-kafka)). Assumes Kafka is already deployed and a topic is created.
 
@@ -1079,7 +1099,7 @@ spec:
                 - name: DOWNSTREAM_DEPLOYMENT
                   value: "false"
                 - name: PROFILING_BIND_ADDRESS
-                image: quay.io/netobserv/network-observability-operator:main
+                image: quay.io/netobserv/network-observability-operator:1.0.4
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -445,6 +445,371 @@ spec:
       displayName: Flow Collector
       kind: FlowCollector
       name: flowcollectors.flows.netobserv.io
+      specDescriptors:
+      - displayName: Namespace
+        path: namespace
+      - description: defines the desired type of deployment for flow processing.
+        displayName: Deployment model
+        path: deploymentModel
+      - description: for flows extraction.
+        displayName: Agent configuration
+        path: agent
+      - description: Flows tracing agent. EBPF (default) is recommended as it offers
+          better performances and should work regardless of the CNI installed on the
+          cluster. `IPFIX` works with OVN-Kubernetes CNI (other CNIs could work if
+          they support exporting IPFIX,
+        displayName: Agent type
+        path: agent.type
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select:EBPF
+        - urn:alm:descriptor:com.tectonic.ui:select:IPFIX
+      - description: Deprecated - Settings related to the IPFIX-based flow reporter.
+        displayName: IPFIX Agent configuration
+        path: agent.ipfix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:IPFIX
+      - displayName: Sampling
+        path: agent.ipfix.sampling
+      - displayName: Cache timeout
+        path: agent.ipfix.cacheActiveTimeout
+      - displayName: Cache max flows
+        path: agent.ipfix.cacheMaxFlows
+      - displayName: Force sample ALL
+        path: agent.ipfix.forceSampleAll
+      - displayName: OpenShift Cluster Network Operator settings
+        path: agent.ipfix.clusterNetworkOperator
+      - displayName: Namespace
+        path: agent.ipfix.clusterNetworkOperator.namespace
+      - displayName: OVN-Kubernetes settings
+        path: agent.ipfix.ovnKubernetes
+      - displayName: Namespace
+        path: agent.ipfix.ovnKubernetes.namespace
+      - displayName: DaemonSet name
+        path: agent.ipfix.ovnKubernetes.daemonSetName
+      - displayName: Container name
+        path: agent.ipfix.ovnKubernetes.containerName
+      - description: Settings related to the eBPF-based flow reporter.
+        displayName: eBPF Agent configuration
+        path: agent.ebpf
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:EBPF
+      - displayName: Sampling
+        path: agent.ebpf.sampling
+      - displayName: Privileged mode
+        path: agent.ebpf.privileged
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Features
+        path: agent.ebpf.features
+      - displayName: Cache timeout
+        path: agent.ebpf.cacheActiveTimeout
+      - displayName: Cache max flows
+        path: agent.ebpf.cacheMaxFlows
+      - displayName: Kafka maximum request size
+        path: agent.ebpf.kafkaBatchSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA
+      - displayName: Interfaces
+        path: agent.ebpf.interfaces
+      - displayName: Exclude interfaces
+        path: agent.ebpf.excludeInterfaces
+      - displayName: Log level
+        path: agent.ebpf.logLevel
+      - displayName: Image pull policy
+        path: agent.ebpf.imagePullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+      - displayName: Resource Requirements
+        path: agent.ebpf.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: to use Kafka as a broker as part of the flow collection pipeline.
+        displayName: Kafka configuration
+        path: kafka
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA
+      - displayName: Address
+        path: kafka.address
+      - displayName: Topic
+        path: kafka.topic
+      - displayName: TLS configuration
+        path: kafka.tls
+      - displayName: Enable
+        path: kafka.tls.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Insecure
+        path: kafka.tls.insecureSkipVerify
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
+      - displayName: User cert
+        path: kafka.tls.userCert
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
+      - displayName: CA cert
+        path: kafka.tls.caCert
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
+      - displayName: SASL configuration
+        path: kafka.sasl
+      - displayName: Type
+        path: kafka.sasl.type
+      - displayName: Client ID
+        path: kafka.sasl.clientIDReference
+      - displayName: Client secret
+        path: kafka.sasl.clientSecretReference
+      - description: of the component that receives the flows from the agent, enriches
+          them, generates metrics, and forwards them to the Loki persistence layer
+          and/or any available exporter.
+        displayName: Processor configuration
+        path: processor
+      - displayName: ClusterName
+        path: processor.clusterName
+      - displayName: Log types
+        path: processor.logTypes
+      - displayName: Conversation heartbeat interval
+        path: processor.conversationHeartbeatInterval
+      - displayName: Conversation terminating timeout
+        path: processor.conversationTerminatingTimeout
+      - displayName: Conversation end timeout
+        path: processor.conversationEndTimeout
+      - displayName: Enable kubernetes probes
+        path: processor.enableKubeProbes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Metrics configuration
+        path: processor.metrics
+      - displayName: Server configuration
+        path: processor.metrics.server
+      - displayName: Port
+        path: processor.metrics.server.port
+      - displayName: TLS configuration
+        path: processor.metrics.server.tls
+      - displayName: Type
+        path: processor.metrics.server.tls.type
+      - displayName: Insecure
+        path: processor.metrics.server.tls.insecureSkipVerify
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:PROVIDED
+      - displayName: Cert
+        path: processor.metrics.server.tls.provided
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:PROVIDED
+      - displayName: CA
+        path: processor.metrics.server.tls.providedCaFile
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:PROVIDED
+      - displayName: Ignore tags
+        path: processor.metrics.ignoreTags
+      - displayName: Disable alerts
+        path: processor.metrics.disableAlerts
+      - displayName: Drop unused fields
+        path: processor.dropUnusedFields
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Port
+        path: processor.port
+      - displayName: Health port
+        path: processor.healthPort
+      - displayName: ProfilePort
+        path: processor.profilePort
+      - displayName: Kafka consumer replicas
+        path: processor.kafkaConsumerReplicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA
+      - displayName: kafka consumer autoscaler
+        path: processor.kafkaConsumerAutoscaler
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA
+      - displayName: Kafka consumer queue capacity
+        path: processor.kafkaConsumerQueueCapacity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA
+      - displayName: Kafka consumer batch size
+        path: processor.kafkaConsumerBatchSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA
+      - displayName: Log level
+        path: processor.logLevel
+      - displayName: Image pull policy
+        path: processor.imagePullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+      - displayName: Resource Requirements
+        path: processor.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: for the flow store.
+        displayName: Loki client settings
+        path: loki
+      - displayName: Enable
+        path: loki.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: URL
+        path: loki.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: TLS configuration
+        path: loki.tls
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Enable
+        path: loki.tls.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Insecure
+        path: loki.tls.insecureSkipVerify
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true
+      - displayName: User cert
+        path: loki.tls.userCert
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true
+      - displayName: CA cert
+        path: loki.tls.caCert
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true
+      - displayName: Querier URL
+        path: loki.querierUrl
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Status URL
+        path: loki.statusUrl
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Status TLS configuration
+        path: loki.statusTls
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Enable
+        path: loki.statusTls.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Insecure
+        path: loki.statusTls.insecureSkipVerify
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true
+      - displayName: User cert
+        path: loki.statusTls.userCert
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true
+      - displayName: CA cert
+        path: loki.statusTls.caCert
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true
+      - displayName: Tenant ID
+        path: loki.tenantID
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Authentication Token
+        path: loki.authToken
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Batch wait
+        path: loki.batchWait
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Batch size
+        path: loki.batchSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Min backoff
+        path: loki.minBackoff
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Max backoff
+        path: loki.maxBackoff
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Max retries
+        path: loki.maxRetries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Timeout
+        path: loki.timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - description: related to the OpenShift Console integration.
+        displayName: Console plugin configuration
+        path: consolePlugin
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+      - displayName: Enable
+        path: consolePlugin.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Register
+        path: consolePlugin.register
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+      - displayName: Port
+        path: consolePlugin.port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+      - displayName: Port naming
+        path: consolePlugin.portNaming
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+      - displayName: Quick filters
+        path: consolePlugin.quickFilters
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+      - displayName: Replicas
+        path: consolePlugin.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+      - displayName: Horizontal pod autoscaler
+        path: consolePlugin.autoscaler
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+      - displayName: Log level
+        path: consolePlugin.logLevel
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+      - displayName: Image pull policy
+        path: consolePlugin.imagePullPolicy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+      - displayName: Resource Requirements
+        path: consolePlugin.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+      - description: additional optional exporters for custom consumption or storage.
+        displayName: Exporters
+        path: exporters
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - displayName: Type
+        path: exporters[0].type
+      - displayName: IPFIX configuration
+        path: exporters[0].ipfix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:IPFIX
+      - displayName: Kafka configuration
+        path: exporters[0].kafka
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:KAFKA
+      statusDescriptors:
+      - description: Namespace where console plugin and flowlogs-pipeline have been
+          deployed.
+        displayName: Namespace
+        path: namespace
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Conditions of the FlowCollector instance health.
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
       version: v1beta2
     - description: '`FlowMetric` is the schema for the custom metrics API, which allows
         to generate more metrics out of flow logs. It is at an early stage of development

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -2594,14 +2594,14 @@ spec:
                         - panic
                         type: string
                       privileged:
-                        description: 'Privileged mode for the eBPF Agent container.
-                          In general this setting can be ignored or set to `false`:
-                          in that case, the operator sets granular capabilities (BPF,
-                          PERFMON, NET_ADMIN, SYS_RESOURCE) to the container, to enable
-                          its correct operation. If for some reason these capabilities
-                          cannot be set, such as if an old kernel version not knowing
-                          CAP_BPF is in use, then you can turn on this mode for more
-                          global privileges.'
+                        description: Privileged mode for the eBPF Agent container.
+                          When ignored or set to `false`, the operator sets granular
+                          capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to
+                          the container. If for some reason these capabilities cannot
+                          be set, such as if an old kernel version not knowing CAP_BPF
+                          is in use, then you can turn on this mode for more global
+                          privileges. Some agent features require the privileged mode,
+                          such as packet drops tracking (see `features`).
                         type: boolean
                       resources:
                         default:
@@ -5279,14 +5279,14 @@ spec:
                         - panic
                         type: string
                       privileged:
-                        description: 'Privileged mode for the eBPF Agent container.
-                          In general this setting can be ignored or set to `false`:
-                          in that case, the operator sets granular capabilities (BPF,
-                          PERFMON, NET_ADMIN, SYS_RESOURCE) to the container, to enable
-                          its correct operation. If for some reason these capabilities
-                          cannot be set, such as if an old kernel version not knowing
-                          CAP_BPF is in use, then you can turn on this mode for more
-                          global privileges.'
+                        description: Privileged mode for the eBPF Agent container.
+                          When ignored or set to `false`, the operator sets granular
+                          capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to
+                          the container. If for some reason these capabilities cannot
+                          be set, such as if an old kernel version not knowing CAP_BPF
+                          is in use, then you can turn on this mode for more global
+                          privileges. Some agent features require the privileged mode,
+                          such as packet drops tracking (see `features`).
                         type: boolean
                       resources:
                         default:

--- a/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
@@ -42,54 +42,27 @@ spec:
       name: flowcollectors.flows.netobserv.io
       version: v1beta2
       specDescriptors:
+        # ROOT
         - displayName: Namespace
           path: namespace
         - description: defines the desired type of deployment for flow processing.
           displayName: Deployment model
           path: deploymentModel
+        # AGENT
         - description: for flows extraction.
           displayName: Agent configuration
           path: agent
-        - description: >-
-            Flows tracing agent. EBPF (default) is recommended as it offers
-            better performances and should work regardless of the CNI
-            installed on the cluster. `IPFIX` works with OVN-Kubernetes CNI
-            (other CNIs could work if they support exporting IPFIX,
-          displayName: Agent type
-          path: agent.type
+        - path: agent.type
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:select:EBPF"
-            - "urn:alm:descriptor:com.tectonic.ui:select:IPFIX"
-        - description: Deprecated - Settings related to the IPFIX-based flow reporter.
-          displayName: IPFIX Agent configuration
-          path: agent.ipfix
+            - urn:alm:descriptor:com.tectonic.ui:hidden
+        - path: agent.ipfix
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:IPFIX"
-        - displayName: Sampling
-          path: agent.ipfix.sampling
-        - displayName: Cache timeout
-          path: agent.ipfix.cacheActiveTimeout
-        - displayName: Cache max flows
-          path: agent.ipfix.cacheMaxFlows
-        - displayName: Force sample ALL
-          path: agent.ipfix.forceSampleAll
-        - displayName: OpenShift Cluster Network Operator settings
-          path: agent.ipfix.clusterNetworkOperator
-        - displayName: Namespace
-          path: agent.ipfix.clusterNetworkOperator.namespace
-        - displayName: OVN-Kubernetes settings
-          path: agent.ipfix.ovnKubernetes
-        - displayName: Namespace
-          path: agent.ipfix.ovnKubernetes.namespace
-        - displayName: DaemonSet name
-          path: agent.ipfix.ovnKubernetes.daemonSetName
-        - displayName: Container name
-          path: agent.ipfix.ovnKubernetes.containerName
+            - urn:alm:descriptor:com.tectonic.ui:hidden
         - description: Settings related to the eBPF-based flow reporter.
           displayName: eBPF Agent configuration
           path: agent.ebpf
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:EBPF"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:eBPF"
         - displayName: Sampling
           path: agent.ebpf.sampling
         - displayName: Privileged mode
@@ -100,31 +73,43 @@ spec:
           path: agent.ebpf.features
         - displayName: Cache timeout
           path: agent.ebpf.cacheActiveTimeout
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Cache max flows
           path: agent.ebpf.cacheMaxFlows
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Kafka maximum request size
           path: agent.ebpf.kafkaBatchSize
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka"
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Interfaces
           path: agent.ebpf.interfaces
         - displayName: Exclude interfaces
           path: agent.ebpf.excludeInterfaces
         - displayName: Log level
           path: agent.ebpf.logLevel
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Image pull policy
           path: agent.ebpf.imagePullPolicy
           x-descriptors:
             - "urn:alm:descriptor:com.tectonic.ui:imagePullPolicy"
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Resource Requirements
           path: agent.ebpf.resources
           x-descriptors:
             - "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+        - path: agent.ebpf.advanced
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:hidden
+        # KAFKA
         - description: to use Kafka as a broker as part of the flow collection pipeline.
           displayName: Kafka configuration
           path: kafka
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka"
         - displayName: Address
           path: kafka.address
         - displayName: Topic
@@ -156,23 +141,25 @@ spec:
           path: kafka.sasl.clientIDReference
         - displayName: Client secret
           path: kafka.sasl.clientSecretReference
+        # PROCESSOR / FLP
         - description: of the component that receives the flows from the agent, enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.
           displayName: Processor configuration
           path: processor
-        - displayName: ClusterName
+        - displayName: Multi-cluster deployment
+          path: processor.multiClusterDeployment
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:advanced
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - displayName: Cluster name
           path: processor.clusterName
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:advanced
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.multiClusterDeployment:true
         - displayName: Log types
           path: processor.logTypes
-        - displayName: Conversation heartbeat interval
-          path: processor.conversationHeartbeatInterval
-        - displayName: Conversation terminating timeout
-          path: processor.conversationTerminatingTimeout
-        - displayName: Conversation end timeout
-          path: processor.conversationEndTimeout
-        - displayName: Enable kubernetes probes
-          path: processor.enableKubeProbes
+        - path: processor.advanced
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+            - urn:alm:descriptor:com.tectonic.ui:hidden
         - displayName: Metrics configuration
           path: processor.metrics
         - displayName: Server configuration
@@ -186,55 +173,53 @@ spec:
         - displayName: Insecure
           path: processor.metrics.server.tls.insecureSkipVerify
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:PROVIDED"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided"
         - displayName: Cert
           path: processor.metrics.server.tls.provided
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:PROVIDED"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided"
         - displayName: CA
           path: processor.metrics.server.tls.providedCaFile
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:PROVIDED"
-        - displayName: Ignore tags
-          path: processor.metrics.ignoreTags
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided"
+        - displayName: Include list
+          path: processor.metrics.includeList
         - displayName: Disable alerts
           path: processor.metrics.disableAlerts
-        - displayName: Drop unused fields
-          path: processor.dropUnusedFields
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-        - displayName: Port
-          path: processor.port
-        - displayName: Health port
-          path: processor.healthPort
-        - displayName: ProfilePort
-          path: processor.profilePort
         - displayName: Kafka consumer replicas
           path: processor.kafkaConsumerReplicas
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka"
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: kafka consumer autoscaler
           path: processor.kafkaConsumerAutoscaler
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka"
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Kafka consumer queue capacity
           path: processor.kafkaConsumerQueueCapacity
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka"
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Kafka consumer batch size
           path: processor.kafkaConsumerBatchSize
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka"
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Log level
           path: processor.logLevel
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Image pull policy
           path: processor.imagePullPolicy
           x-descriptors:
             - "urn:alm:descriptor:com.tectonic.ui:imagePullPolicy"
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Resource Requirements
           path: processor.resources
           x-descriptors:
             - "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+        # LOKI
         - description: for the flow store.
           displayName: Loki client settings
           path: loki
@@ -242,94 +227,97 @@ spec:
           path: loki.enable
           x-descriptors:
             - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-        - displayName: URL
-          path: loki.url
+        - displayName: Mode
+          path: loki.mode
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: TLS configuration
-          path: loki.tls
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+        - displayName: Loki Stack
+          path: loki.lokiStack
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Enable
-          path: loki.tls.enable
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:LokiStack
+        - displayName: Monolithic
+          path: loki.monolithic
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Insecure
-          path: loki.tls.insecureSkipVerify
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Monolithic
+        - displayName: Microservices
+          path: loki.microservices
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true"
-        - displayName: User cert
-          path: loki.tls.userCert
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Microservices
+        - displayName: Manual
+          path: loki.manual
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true"
-        - displayName: CA cert
-          path: loki.tls.caCert
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Manual
+        - displayName: Write batch timeout
+          path: loki.writeBatchWait
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true"
-        - displayName: Querier URL
-          path: loki.querierUrl
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+            - urn:alm:descriptor:com.tectonic.ui:advanced
+        - displayName: Write batch size
+          path: loki.writeBatchSize
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Status URL
-          path: loki.statusUrl
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+            - urn:alm:descriptor:com.tectonic.ui:advanced
+        - displayName: Write timeout
+          path: loki.writeTimeout
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Status TLS configuration
-          path: loki.statusTls
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+            - urn:alm:descriptor:com.tectonic.ui:advanced
+        - path: loki.advanced
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Enable
-          path: loki.statusTls.enable
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Insecure
-          path: loki.statusTls.insecureSkipVerify
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true"
-        - displayName: User cert
-          path: loki.statusTls.userCert
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true"
-        - displayName: CA cert
-          path: loki.statusTls.caCert
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true"
-        - displayName: Tenant ID
-          path: loki.tenantID
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Authentication Token
-          path: loki.authToken
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Batch wait
-          path: loki.batchWait
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Batch size
-          path: loki.batchSize
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Min backoff
-          path: loki.minBackoff
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Max backoff
-          path: loki.maxBackoff
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Max retries
-          path: loki.maxRetries
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Timeout
-          path: loki.timeout
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+            - urn:alm:descriptor:com.tectonic.ui:hidden
+        # - displayName: TLS configuration
+        #   path: loki.tls
+        #   x-descriptors:
+        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        # - displayName: Enable
+        #   path: loki.tls.enable
+        #   x-descriptors:
+        #     - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        # - displayName: Insecure
+        #   path: loki.tls.insecureSkipVerify
+        #   x-descriptors:
+        #     - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true"
+        # - displayName: User cert
+        #   path: loki.tls.userCert
+        #   x-descriptors:
+        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true"
+        # - displayName: CA cert
+        #   path: loki.tls.caCert
+        #   x-descriptors:
+        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true"
+        # - displayName: Status TLS configuration
+        #   path: loki.statusTls
+        #   x-descriptors:
+        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        # - displayName: Enable
+        #   path: loki.statusTls.enable
+        #   x-descriptors:
+        #     - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        # - displayName: Insecure
+        #   path: loki.statusTls.insecureSkipVerify
+        #   x-descriptors:
+        #     - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true"
+        # - displayName: User cert
+        #   path: loki.statusTls.userCert
+        #   x-descriptors:
+        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true"
+        # - displayName: CA cert
+        #   path: loki.statusTls.caCert
+        #   x-descriptors:
+        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true"
+        # - displayName: Tenant ID
+        #   path: loki.tenantID
+        #   x-descriptors:
+        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        # - displayName: Authentication Token
+        #   path: loki.authToken
+        #   x-descriptors:
+        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        # CONSOLE PLUGIN
         - description: related to the OpenShift Console integration.
           displayName: Console plugin configuration
           path: consolePlugin
@@ -339,15 +327,6 @@ spec:
           path: consolePlugin.enable
           x-descriptors:
             - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-        - displayName: Register
-          path: consolePlugin.register
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
-        - displayName: Port
-          path: consolePlugin.port
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
         - displayName: Port naming
           path: consolePlugin.portNaming
           x-descriptors:
@@ -360,24 +339,32 @@ spec:
           path: consolePlugin.replicas
           x-descriptors:
             - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Horizontal pod autoscaler
           path: consolePlugin.autoscaler
           x-descriptors:
             - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Log level
           path: consolePlugin.logLevel
           x-descriptors:
             - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Image pull policy
           path: consolePlugin.imagePullPolicy
           x-descriptors:
             - "urn:alm:descriptor:com.tectonic.ui:imagePullPolicy"
             - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+            - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Resource Requirements
           path: consolePlugin.resources
           x-descriptors:
             - "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
             - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+        - path: consolePlugin.advanced
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:hidden
+        # EXPORTERS
         - description: additional optional exporters for custom consumption or storage.
           displayName: Exporters
           path: exporters
@@ -392,7 +379,7 @@ spec:
         - displayName: Kafka configuration
           path: exporters[0].kafka
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:KAFKA"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:Kafka"
       statusDescriptors:
         - displayName: Namespace
           description: Namespace where console plugin and flowlogs-pipeline have been deployed.

--- a/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
     createdAt: ':created-at:'
     description: Network flows collector and monitoring solution
     operatorframework.io/suggested-namespace: openshift-netobserv-operator
-    operatorframework.io/initialization-resource: '{"apiVersion":"flowcollectors.flows.netobserv.io/v1beta2",
+    operatorframework.io/initialization-resource: '{"apiVersion":"flows.netobserv.io/v1beta2",
       "kind":"FlowCollector","metadata":{"name":"cluster"},"spec": {}}'
     repository: https://github.com/netobserv/network-observability-operator
   labels:

--- a/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
@@ -43,10 +43,7 @@ spec:
       version: v1beta2
       specDescriptors:
         # ROOT
-        - displayName: Namespace
-          path: namespace
         - description: defines the desired type of deployment for flow processing.
-          displayName: Deployment model
           path: deploymentModel
         # AGENT
         - description: for flows extraction.
@@ -62,45 +59,32 @@ spec:
           displayName: eBPF Agent configuration
           path: agent.ebpf
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:eBPF"
-        - displayName: Sampling
-          path: agent.ebpf.sampling
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:eBPF
         - displayName: Privileged mode
           path: agent.ebpf.privileged
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-        - displayName: Features
-          path: agent.ebpf.features
-        - displayName: Cache timeout
-          path: agent.ebpf.cacheActiveTimeout
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - path: agent.ebpf.cacheActiveTimeout
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Cache max flows
-          path: agent.ebpf.cacheMaxFlows
+        - path: agent.ebpf.cacheMaxFlows
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Kafka maximum request size
-          path: agent.ebpf.kafkaBatchSize
+        - path: agent.ebpf.kafkaBatchSize
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka"
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
             - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Interfaces
-          path: agent.ebpf.interfaces
-        - displayName: Exclude interfaces
-          path: agent.ebpf.excludeInterfaces
-        - displayName: Log level
-          path: agent.ebpf.logLevel
+        - path: agent.ebpf.logLevel
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Image pull policy
-          path: agent.ebpf.imagePullPolicy
+        - path: agent.ebpf.imagePullPolicy
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:imagePullPolicy"
+            - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
             - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Resource Requirements
           path: agent.ebpf.resources
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+            - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
         - path: agent.ebpf.advanced
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:hidden
@@ -109,38 +93,28 @@ spec:
           displayName: Kafka configuration
           path: kafka
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka"
-        - displayName: Address
-          path: kafka.address
-        - displayName: Topic
-          path: kafka.topic
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
         - displayName: TLS configuration
           path: kafka.tls
-        - displayName: Enable
-          path: kafka.tls.enable
+        - path: kafka.tls.enable
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - displayName: Insecure
           path: kafka.tls.insecureSkipVerify
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true"
-        - displayName: User cert
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
+        - displayName: User certificate when using mTLS
           path: kafka.tls.userCert
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true"
-        - displayName: CA cert
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
+        - displayName: CA certificate
           path: kafka.tls.caCert
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true"
-        - displayName: SASL configuration
-          path: kafka.sasl
-        - displayName: Type
-          path: kafka.sasl.type
-        - displayName: Client ID
-          path: kafka.sasl.clientIDReference
-        - displayName: Client secret
-          path: kafka.sasl.clientSecretReference
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
+        - path: kafka.sasl
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:hidden
         # PROCESSOR / FLP
         - description: of the component that receives the flows from the agent, enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.
           displayName: Processor configuration
@@ -150,13 +124,10 @@ spec:
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:advanced
             - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - displayName: Cluster name
-          path: processor.clusterName
+        - path: processor.clusterName
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:advanced
             - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.multiClusterDeployment:true
-        - displayName: Log types
-          path: processor.logTypes
         - path: processor.advanced
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:hidden
@@ -164,209 +135,128 @@ spec:
           path: processor.metrics
         - displayName: Server configuration
           path: processor.metrics.server
-        - displayName: Port
-          path: processor.metrics.server.port
         - displayName: TLS configuration
           path: processor.metrics.server.tls
-        - displayName: Type
-          path: processor.metrics.server.tls.type
         - displayName: Insecure
           path: processor.metrics.server.tls.insecureSkipVerify
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided"
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided
         - displayName: Cert
           path: processor.metrics.server.tls.provided
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided"
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided
         - displayName: CA
           path: processor.metrics.server.tls.providedCaFile
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided"
-        - displayName: Include list
-          path: processor.metrics.includeList
-        - displayName: Disable alerts
-          path: processor.metrics.disableAlerts
-        - displayName: Kafka consumer replicas
-          path: processor.kafkaConsumerReplicas
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided
+        - path: processor.kafkaConsumerReplicas
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka"
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
             - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: kafka consumer autoscaler
           path: processor.kafkaConsumerAutoscaler
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka"
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
             - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Kafka consumer queue capacity
-          path: processor.kafkaConsumerQueueCapacity
+        - path: processor.kafkaConsumerQueueCapacity
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka"
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
             - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Kafka consumer batch size
-          path: processor.kafkaConsumerBatchSize
+        - path: processor.kafkaConsumerBatchSize
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka"
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
             - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Log level
-          path: processor.logLevel
+        - path: processor.logLevel
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Image pull policy
-          path: processor.imagePullPolicy
+        - path: processor.imagePullPolicy
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:imagePullPolicy"
+            - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
             - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Resource Requirements
           path: processor.resources
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+            - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
         # LOKI
         - description: for the flow store.
           displayName: Loki client settings
           path: loki
-        - displayName: Enable
-          path: loki.enable
+        - path: loki.enable
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-        - displayName: Mode
-          path: loki.mode
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - path: loki.mode
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-        - displayName: Loki Stack
-          path: loki.lokiStack
+        - path: loki.lokiStack
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:LokiStack
-        - displayName: Monolithic
-          path: loki.monolithic
+        - path: loki.monolithic
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Monolithic
-        - displayName: Microservices
-          path: loki.microservices
+        - path: loki.microservices
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Microservices
-        - displayName: Manual
-          path: loki.manual
+        - path: loki.manual
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Manual
-        - displayName: Write batch timeout
-          path: loki.writeBatchWait
+        - path: loki.writeBatchWait
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
             - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Write batch size
-          path: loki.writeBatchSize
+        - path: loki.writeBatchSize
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
             - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Write timeout
-          path: loki.writeTimeout
+        - path: loki.writeTimeout
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
             - urn:alm:descriptor:com.tectonic.ui:advanced
         - path: loki.advanced
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:hidden
-        # - displayName: TLS configuration
-        #   path: loki.tls
-        #   x-descriptors:
-        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        # - displayName: Enable
-        #   path: loki.tls.enable
-        #   x-descriptors:
-        #     - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        # - displayName: Insecure
-        #   path: loki.tls.insecureSkipVerify
-        #   x-descriptors:
-        #     - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true"
-        # - displayName: User cert
-        #   path: loki.tls.userCert
-        #   x-descriptors:
-        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true"
-        # - displayName: CA cert
-        #   path: loki.tls.caCert
-        #   x-descriptors:
-        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true"
-        # - displayName: Status TLS configuration
-        #   path: loki.statusTls
-        #   x-descriptors:
-        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        # - displayName: Enable
-        #   path: loki.statusTls.enable
-        #   x-descriptors:
-        #     - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        # - displayName: Insecure
-        #   path: loki.statusTls.insecureSkipVerify
-        #   x-descriptors:
-        #     - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true"
-        # - displayName: User cert
-        #   path: loki.statusTls.userCert
-        #   x-descriptors:
-        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true"
-        # - displayName: CA cert
-        #   path: loki.statusTls.caCert
-        #   x-descriptors:
-        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true"
-        # - displayName: Tenant ID
-        #   path: loki.tenantID
-        #   x-descriptors:
-        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        # - displayName: Authentication Token
-        #   path: loki.authToken
-        #   x-descriptors:
-        #     - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
         # CONSOLE PLUGIN
         - description: related to the OpenShift Console integration.
           displayName: Console plugin configuration
           path: consolePlugin
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
-        - displayName: Enable
-          path: consolePlugin.enable
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+        - path: consolePlugin.enable
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-        - displayName: Port naming
-          path: consolePlugin.portNaming
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - path: consolePlugin.portNaming
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
-        - displayName: Quick filters
-          path: consolePlugin.quickFilters
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+        - path: consolePlugin.quickFilters
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
-        - displayName: Replicas
-          path: consolePlugin.replicas
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+        - path: consolePlugin.replicas
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
             - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Horizontal pod autoscaler
           path: consolePlugin.autoscaler
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
             - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Log level
-          path: consolePlugin.logLevel
+        - path: consolePlugin.logLevel
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
             - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Image pull policy
-          path: consolePlugin.imagePullPolicy
+        - path: consolePlugin.imagePullPolicy
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:imagePullPolicy"
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+            - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy"
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
             - urn:alm:descriptor:com.tectonic.ui:advanced
         - displayName: Resource Requirements
           path: consolePlugin.resources
           x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+            - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
         - path: consolePlugin.advanced
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:hidden
         # EXPORTERS
         - description: additional optional exporters for custom consumption or storage.
-          displayName: Exporters
           path: exporters
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:advanced

--- a/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
@@ -41,6 +41,369 @@ spec:
       kind: FlowCollector
       name: flowcollectors.flows.netobserv.io
       version: v1beta2
+      specDescriptors:
+        - displayName: Namespace
+          path: namespace
+        - description: defines the desired type of deployment for flow processing.
+          displayName: Deployment model
+          path: deploymentModel
+        - description: for flows extraction.
+          displayName: Agent configuration
+          path: agent
+        - description: >-
+            Flows tracing agent. EBPF (default) is recommended as it offers
+            better performances and should work regardless of the CNI
+            installed on the cluster. `IPFIX` works with OVN-Kubernetes CNI
+            (other CNIs could work if they support exporting IPFIX,
+          displayName: Agent type
+          path: agent.type
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:select:EBPF"
+            - "urn:alm:descriptor:com.tectonic.ui:select:IPFIX"
+        - description: Deprecated - Settings related to the IPFIX-based flow reporter.
+          displayName: IPFIX Agent configuration
+          path: agent.ipfix
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:IPFIX"
+        - displayName: Sampling
+          path: agent.ipfix.sampling
+        - displayName: Cache timeout
+          path: agent.ipfix.cacheActiveTimeout
+        - displayName: Cache max flows
+          path: agent.ipfix.cacheMaxFlows
+        - displayName: Force sample ALL
+          path: agent.ipfix.forceSampleAll
+        - displayName: OpenShift Cluster Network Operator settings
+          path: agent.ipfix.clusterNetworkOperator
+        - displayName: Namespace
+          path: agent.ipfix.clusterNetworkOperator.namespace
+        - displayName: OVN-Kubernetes settings
+          path: agent.ipfix.ovnKubernetes
+        - displayName: Namespace
+          path: agent.ipfix.ovnKubernetes.namespace
+        - displayName: DaemonSet name
+          path: agent.ipfix.ovnKubernetes.daemonSetName
+        - displayName: Container name
+          path: agent.ipfix.ovnKubernetes.containerName
+        - description: Settings related to the eBPF-based flow reporter.
+          displayName: eBPF Agent configuration
+          path: agent.ebpf
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:EBPF"
+        - displayName: Sampling
+          path: agent.ebpf.sampling
+        - displayName: Privileged mode
+          path: agent.ebpf.privileged
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+        - displayName: Features
+          path: agent.ebpf.features
+        - displayName: Cache timeout
+          path: agent.ebpf.cacheActiveTimeout
+        - displayName: Cache max flows
+          path: agent.ebpf.cacheMaxFlows
+        - displayName: Kafka maximum request size
+          path: agent.ebpf.kafkaBatchSize
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA"
+        - displayName: Interfaces
+          path: agent.ebpf.interfaces
+        - displayName: Exclude interfaces
+          path: agent.ebpf.excludeInterfaces
+        - displayName: Log level
+          path: agent.ebpf.logLevel
+        - displayName: Image pull policy
+          path: agent.ebpf.imagePullPolicy
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:imagePullPolicy"
+        - displayName: Resource Requirements
+          path: agent.ebpf.resources
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+        - description: to use Kafka as a broker as part of the flow collection pipeline.
+          displayName: Kafka configuration
+          path: kafka
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA"
+        - displayName: Address
+          path: kafka.address
+        - displayName: Topic
+          path: kafka.topic
+        - displayName: TLS configuration
+          path: kafka.tls
+        - displayName: Enable
+          path: kafka.tls.enable
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+        - displayName: Insecure
+          path: kafka.tls.insecureSkipVerify
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true"
+        - displayName: User cert
+          path: kafka.tls.userCert
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true"
+        - displayName: CA cert
+          path: kafka.tls.caCert
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true"
+        - displayName: SASL configuration
+          path: kafka.sasl
+        - displayName: Type
+          path: kafka.sasl.type
+        - displayName: Client ID
+          path: kafka.sasl.clientIDReference
+        - displayName: Client secret
+          path: kafka.sasl.clientSecretReference
+        - description: of the component that receives the flows from the agent, enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.
+          displayName: Processor configuration
+          path: processor
+        - displayName: ClusterName
+          path: processor.clusterName
+        - displayName: Log types
+          path: processor.logTypes
+        - displayName: Conversation heartbeat interval
+          path: processor.conversationHeartbeatInterval
+        - displayName: Conversation terminating timeout
+          path: processor.conversationTerminatingTimeout
+        - displayName: Conversation end timeout
+          path: processor.conversationEndTimeout
+        - displayName: Enable kubernetes probes
+          path: processor.enableKubeProbes
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+        - displayName: Metrics configuration
+          path: processor.metrics
+        - displayName: Server configuration
+          path: processor.metrics.server
+        - displayName: Port
+          path: processor.metrics.server.port
+        - displayName: TLS configuration
+          path: processor.metrics.server.tls
+        - displayName: Type
+          path: processor.metrics.server.tls.type
+        - displayName: Insecure
+          path: processor.metrics.server.tls.insecureSkipVerify
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:PROVIDED"
+        - displayName: Cert
+          path: processor.metrics.server.tls.provided
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:PROVIDED"
+        - displayName: CA
+          path: processor.metrics.server.tls.providedCaFile
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:PROVIDED"
+        - displayName: Ignore tags
+          path: processor.metrics.ignoreTags
+        - displayName: Disable alerts
+          path: processor.metrics.disableAlerts
+        - displayName: Drop unused fields
+          path: processor.dropUnusedFields
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+        - displayName: Port
+          path: processor.port
+        - displayName: Health port
+          path: processor.healthPort
+        - displayName: ProfilePort
+          path: processor.profilePort
+        - displayName: Kafka consumer replicas
+          path: processor.kafkaConsumerReplicas
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA"
+        - displayName: kafka consumer autoscaler
+          path: processor.kafkaConsumerAutoscaler
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA"
+        - displayName: Kafka consumer queue capacity
+          path: processor.kafkaConsumerQueueCapacity
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA"
+        - displayName: Kafka consumer batch size
+          path: processor.kafkaConsumerBatchSize
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:KAFKA"
+        - displayName: Log level
+          path: processor.logLevel
+        - displayName: Image pull policy
+          path: processor.imagePullPolicy
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:imagePullPolicy"
+        - displayName: Resource Requirements
+          path: processor.resources
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+        - description: for the flow store.
+          displayName: Loki client settings
+          path: loki
+        - displayName: Enable
+          path: loki.enable
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+        - displayName: URL
+          path: loki.url
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: TLS configuration
+          path: loki.tls
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Enable
+          path: loki.tls.enable
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Insecure
+          path: loki.tls.insecureSkipVerify
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true"
+        - displayName: User cert
+          path: loki.tls.userCert
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true"
+        - displayName: CA cert
+          path: loki.tls.caCert
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.tls.enable:true"
+        - displayName: Querier URL
+          path: loki.querierUrl
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Status URL
+          path: loki.statusUrl
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Status TLS configuration
+          path: loki.statusTls
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Enable
+          path: loki.statusTls.enable
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Insecure
+          path: loki.statusTls.insecureSkipVerify
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true"
+        - displayName: User cert
+          path: loki.statusTls.userCert
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true"
+        - displayName: CA cert
+          path: loki.statusTls.caCert
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.statusTls.enable:true"
+        - displayName: Tenant ID
+          path: loki.tenantID
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Authentication Token
+          path: loki.authToken
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Batch wait
+          path: loki.batchWait
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Batch size
+          path: loki.batchSize
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Min backoff
+          path: loki.minBackoff
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Max backoff
+          path: loki.maxBackoff
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Max retries
+          path: loki.maxRetries
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Timeout
+          path: loki.timeout
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - description: related to the OpenShift Console integration.
+          displayName: Console plugin configuration
+          path: consolePlugin
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true"
+        - displayName: Enable
+          path: consolePlugin.enable
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+        - displayName: Register
+          path: consolePlugin.register
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+        - displayName: Port
+          path: consolePlugin.port
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+        - displayName: Port naming
+          path: consolePlugin.portNaming
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+        - displayName: Quick filters
+          path: consolePlugin.quickFilters
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+        - displayName: Replicas
+          path: consolePlugin.replicas
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+        - displayName: Horizontal pod autoscaler
+          path: consolePlugin.autoscaler
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+        - displayName: Log level
+          path: consolePlugin.logLevel
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+        - displayName: Image pull policy
+          path: consolePlugin.imagePullPolicy
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:imagePullPolicy"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+        - displayName: Resource Requirements
+          path: consolePlugin.resources
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true"
+        - description: additional optional exporters for custom consumption or storage.
+          displayName: Exporters
+          path: exporters
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:advanced
+        - displayName: Type
+          path: exporters[0].type
+        - displayName: IPFIX configuration
+          path: exporters[0].ipfix
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:IPFIX"
+        - displayName: Kafka configuration
+          path: exporters[0].kafka
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:KAFKA"
+      statusDescriptors:
+        - displayName: Namespace
+          description: Namespace where console plugin and flowlogs-pipeline have been deployed.
+          path: namespace
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Conditions of the FlowCollector instance health.
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+            - urn:alm:descriptor:io.kubernetes.conditions
     - description: '`FlowMetric` is the schema for the custom metrics API,
         which allows to generate more metrics out of flow logs.
         It is at an early stage of development (dev preview)

--- a/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
@@ -10,6 +10,8 @@ metadata:
     createdAt: ':created-at:'
     description: Network flows collector and monitoring solution
     operatorframework.io/suggested-namespace: openshift-netobserv-operator
+    operatorframework.io/initialization-resource: '{"apiVersion":"flowcollectors.flows.netobserv.io/v1beta2",
+      "kind":"FlowCollector","metadata":{"name":"cluster"},"spec": {}}'
     repository: https://github.com/netobserv/network-observability-operator
   labels:
     operatorframework.io/arch.amd64: supported

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -4599,7 +4599,7 @@ Agent configuration for flows extraction.
         <td><b>privileged</b></td>
         <td>boolean</td>
         <td>
-          Privileged mode for the eBPF Agent container. In general this setting can be ignored or set to `false`: in that case, the operator sets granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container, to enable its correct operation. If for some reason these capabilities cannot be set, such as if an old kernel version not knowing CAP_BPF is in use, then you can turn on this mode for more global privileges.<br/>
+          Privileged mode for the eBPF Agent container. When ignored or set to `false`, the operator sets granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container. If for some reason these capabilities cannot be set, such as if an old kernel version not knowing CAP_BPF is in use, then you can turn on this mode for more global privileges. Some agent features require the privileged mode, such as packet drops tracking (see `features`).<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9243,7 +9243,7 @@ Agent configuration for flows extraction.
         <td><b>privileged</b></td>
         <td>boolean</td>
         <td>
-          Privileged mode for the eBPF Agent container. In general this setting can be ignored or set to `false`: in that case, the operator sets granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container, to enable its correct operation. If for some reason these capabilities cannot be set, such as if an old kernel version not knowing CAP_BPF is in use, then you can turn on this mode for more global privileges.<br/>
+          Privileged mode for the eBPF Agent container. When ignored or set to `false`, the operator sets granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container. If for some reason these capabilities cannot be set, such as if an old kernel version not knowing CAP_BPF is in use, then you can turn on this mode for more global privileges. Some agent features require the privileged mode, such as packet drops tracking (see `features`).<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/hack/cloned.flows.netobserv.io_flowcollectors.yaml
+++ b/hack/cloned.flows.netobserv.io_flowcollectors.yaml
@@ -1808,7 +1808,7 @@ spec:
                             - panic
                           type: string
                         privileged:
-                          description: 'Privileged mode for the eBPF Agent container. In general this setting can be ignored or set to `false`: in that case, the operator sets granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container, to enable its correct operation. If for some reason these capabilities cannot be set, such as if an old kernel version not knowing CAP_BPF is in use, then you can turn on this mode for more global privileges.'
+                          description: Privileged mode for the eBPF Agent container. When ignored or set to `false`, the operator sets granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container. If for some reason these capabilities cannot be set, such as if an old kernel version not knowing CAP_BPF is in use, then you can turn on this mode for more global privileges. Some agent features require the privileged mode, such as packet drops tracking (see `features`).
                           type: boolean
                         resources:
                           default:
@@ -3665,7 +3665,7 @@ spec:
                             - panic
                           type: string
                         privileged:
-                          description: 'Privileged mode for the eBPF Agent container. In general this setting can be ignored or set to `false`: in that case, the operator sets granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container, to enable its correct operation. If for some reason these capabilities cannot be set, such as if an old kernel version not knowing CAP_BPF is in use, then you can turn on this mode for more global privileges.'
+                          description: Privileged mode for the eBPF Agent container. When ignored or set to `false`, the operator sets granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container. If for some reason these capabilities cannot be set, such as if an old kernel version not knowing CAP_BPF is in use, then you can turn on this mode for more global privileges. Some agent features require the privileged mode, such as packet drops tracking (see `features`).
                           type: boolean
                         resources:
                           default:

--- a/hack/crd2csvSpecDesc.sh
+++ b/hack/crd2csvSpecDesc.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+version="$1"
+
+if [[ $version == "" ]]; then
+  echo "Missing CRD version."
+  exit 1
+fi
+
+crd="./config/crd/bases/flows.netobserv.io_flowcollectors.yaml"
+csv="./config/csv/bases/netobserv-operator.clusterserviceversion.yaml"
+
+crdRoot=".spec.versions[] | select(.name==\"$version\").schema.openAPIV3Schema.properties.spec.properties"
+csvRoot=".spec.customresourcedefinitions.owned[] | select(.version==\"$version\").specDescriptors"
+
+process_property() {
+  local yamlPath=$1
+  local logicPath=$2
+  # Ignore some patterns
+  if [[ $logicPath == *"utoscaler" ]] || [[ $logicPath == *".resources" ]] || [[ $logicPath == *".tls" ]] || [[ $logicPath == *".statusTls" ]] ; then
+    # echo "Ignoring entry" >&2
+    false
+    return
+  fi
+  # Lookup in CSV
+  local xDescs=$(cat $csv | yq "$csvRoot[] | select(.path==\"$logicPath\").x-descriptors")
+  if [[ $xDescs == *":hidden" ]]; then
+    # echo "Hidden property; ignoring" >&2
+    false
+    return
+  fi
+  local displayName=$(echo $logicPath | sed 's/.*\.//' | sed 's/\([A-Z]\)\([a-z]\)/ \L\1\2/g' | sed 's/.*/\u&/' )
+#  local description=$(cat $crd | yq "$yamlPath.description" | sed 's/`/"/g' | sed 's/<br>//g')
+  if [[ $(cat $csv | yq "$csvRoot[] | select(.path==\"$logicPath\")") != "" ]]; then
+    if [[ $(cat $csv | yq "$csvRoot[] | select(.path==\"$logicPath\") | has(\"displayName\")") == false ]]; then
+      # echo "Set display name: $displayName" >&2
+      yq -i "($csvRoot[] | select(.path==\"$logicPath\").displayName) = \"$displayName\"" $csv
+    fi
+    # if [[ $(cat $csv | yq "$csvRoot[] | select(.path==\"$logicPath\") | has(\"description\")") == false ]]; then
+    #   echo "Set description: $description" >&2
+    #   # yq -i "$csvRoot[] | select(.path==\"$logicPath\").description = \"$description\"" $csv
+    # fi
+  else
+    # echo "Creating entry for $displayName" >&2
+    yq -i "($csvRoot) += {\"path\":\"$logicPath\",\"displayName\":\"$displayName\"}" $csv
+  fi
+}
+
+process_properties() {
+  local yamlPath=$1
+  local logicPath=$2
+  local props=$(cat $crd | yq "$yamlPath | keys | @tsv")
+  for prop in $props; do
+    if [[ $logicPath != "" ]]; then
+      local propLogicPath="$logicPath.$prop"
+    else
+      local propLogicPath="$prop"
+    fi
+    # echo "Checking property $propLogicPath" >&2
+    if process_property "$yamlPath.$prop" $propLogicPath; then
+      local type=$(cat $crd | yq "$yamlPath.$prop.type")
+      if [[ "$type" == "object" ]]; then
+        # echo "it's an object" >&2
+        if [[ $(cat $crd | yq "$yamlPath.$prop | has(\"properties\")") == true ]]; then
+          process_properties "$yamlPath.$prop.properties" $propLogicPath
+        # else
+          # echo "Skipping: no properties." >&2
+        fi
+      # else
+      #   if [[ "$type" == "array" ]]; then
+      #     echo "it's an array" >&2
+      #   # else
+      #     # echo "it's a leaf" >&2
+      #   fi
+      fi
+    fi
+  done
+}
+
+process_properties "$crdRoot" ""


### PR DESCRIPTION
## Description

Added to CSV:
- [X] specDescriptors
  - [x] simplify names and descriptions
  - [x] dynamic display according to previous selections (enable, kafka, etc)
  - [x] force switches instead of checkboxes
  - [ ] ordering not respected
This is [made using a complex mechanism](https://github.com/openshift/console/blob/d2fbe0a4ddaa6dca4f93d4c0c521943ceb277e19/frontend/packages/console-shared/src/components/dynamic-form/utils.ts#L91-L109) relying on required fields / dependencies between fields and falling back on the number of subfields. I would suggest to keep it as is.
- [X] statusDescriptors
  - [ ] will need an update of OCP console to manage cluster wide CR
  see [related discussion](https://redhat-internal.slack.com/archives/C6A3NV5J9/p1695139049459949?thread_ts=1695116635.617689&cid=C6A3NV5J9) and https://github.com/openshift/console/pull/13181

These will make the CSV harder to maintain but the UX is way better in the console.

---

![image](https://github.com/netobserv/network-observability-operator/assets/91894519/5f9f2f6a-88fb-4186-b5d5-5ad29545478b)

![image](https://github.com/netobserv/network-observability-operator/assets/91894519/6173652c-c476-410a-adad-47303d7a1d88)

![image](https://github.com/netobserv/network-observability-operator/assets/91894519/c56c398c-2ef6-4947-a7bf-deb6ad97b27f)

![image](https://github.com/netobserv/network-observability-operator/assets/91894519/bdacdba7-6299-4d44-9370-66c53dd5bc07)

![image](https://github.com/netobserv/network-observability-operator/assets/91894519/14063387-ad8e-4224-84fc-3fe2756b7b0e)

![image](https://github.com/netobserv/network-observability-operator/assets/91894519/c3fe8bd1-8edc-4e46-a672-768c878462d8)

---
![image](https://github.com/netobserv/network-observability-operator/assets/91894519/3ad24243-823a-48b6-8fb5-6c26b353e6c5)

![image](https://github.com/netobserv/network-observability-operator/assets/91894519/ee9796ea-bd92-4d6a-8c4b-69aeee5feab0)

![image](https://github.com/netobserv/network-observability-operator/assets/91894519/3037e986-e1f2-442d-b107-57fe2d887e9e)

---

## Dependencies
https://github.com/netobserv/network-observability-operator/pull/329 
https://github.com/netobserv/network-observability-operator/pull/467 
https://github.com/netobserv/network-observability-operator/pull/522  
Will need update for `v1beta2` API

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
