### PR TITLE
Remove unsupported mention on IPFIX doc

### DIFF
--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -815,7 +815,7 @@ const (
 
 // `FlowCollectorExporter` defines an additional exporter to send enriched flows to.
 type FlowCollectorExporter struct {
-	// `type` selects the type of exporters. The available options are `KAFKA` and `IPFIX`. `IPFIX` is unsupported (*).
+	// `type` selects the type of exporters. The available options are `KAFKA` and `IPFIX`.
 	// +unionDiscriminator
 	// +kubebuilder:validation:Enum:="KAFKA";"IPFIX"
 	// +kubebuilder:validation:Required
@@ -825,7 +825,7 @@ type FlowCollectorExporter struct {
 	// +optional
 	Kafka FlowCollectorKafka `json:"kafka,omitempty"`
 
-	// IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. [Unsupported (*)].
+	// IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to.
 	// +optional
 	IPFIX FlowCollectorIPFIXReceiver `json:"ipfix,omitempty"`
 }

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -3330,7 +3330,7 @@ spec:
                   properties:
                     ipfix:
                       description: IPFIX configuration, such as the IP address and
-                        port to send enriched IPFIX flows to. [Unsupported (*)].
+                        port to send enriched IPFIX flows to.
                       properties:
                         targetHost:
                           default: ""
@@ -3528,7 +3528,7 @@ spec:
                       type: object
                     type:
                       description: '`type` selects the type of exporters. The available
-                        options are `KAFKA` and `IPFIX`. `IPFIX` is unsupported (*).'
+                        options are `KAFKA` and `IPFIX`.'
                       enum:
                       - KAFKA
                       - IPFIX

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -3317,7 +3317,7 @@ spec:
                   properties:
                     ipfix:
                       description: IPFIX configuration, such as the IP address and
-                        port to send enriched IPFIX flows to. [Unsupported (*)].
+                        port to send enriched IPFIX flows to.
                       properties:
                         targetHost:
                           default: ""
@@ -3515,7 +3515,7 @@ spec:
                       type: object
                     type:
                       description: '`type` selects the type of exporters. The available
-                        options are `KAFKA` and `IPFIX`. `IPFIX` is unsupported (*).'
+                        options are `KAFKA` and `IPFIX`.'
                       enum:
                       - KAFKA
                       - IPFIX

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -5711,7 +5711,7 @@ ResourceClaim references one entry in PodSpec.ResourceClaims.
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          `type` selects the type of exporters. The available options are `KAFKA` and `IPFIX`. `IPFIX` is unsupported (*).<br/>
+          `type` selects the type of exporters. The available options are `KAFKA` and `IPFIX`.<br/>
           <br/>
             <i>Enum</i>: KAFKA, IPFIX<br/>
         </td>
@@ -5720,7 +5720,7 @@ ResourceClaim references one entry in PodSpec.ResourceClaims.
         <td><b><a href="#flowcollectorspecexportersindexipfix">ipfix</a></b></td>
         <td>object</td>
         <td>
-          IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. [Unsupported (*)].<br/>
+          IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5739,7 +5739,7 @@ ResourceClaim references one entry in PodSpec.ResourceClaims.
 
 
 
-IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. [Unsupported (*)].
+IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to.
 
 <table>
     <thead>

--- a/docs/flowcollector-flows-netobserv-io-v1beta1.adoc
+++ b/docs/flowcollector-flows-netobserv-io-v1beta1.adoc
@@ -250,12 +250,6 @@ Type::
 |===
 | Property | Type | Description
 
-| `claims`
-| `array`
-| Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
- This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
- This field is immutable. It can only be set for containers.
-
 | `limits`
 | `integer-or-string`
 | Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -263,45 +257,6 @@ Type::
 | `requests`
 | `integer-or-string`
 | Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-
-|===
-== .spec.agent.ebpf.resources.claims
-Description::
-+
---
-Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
- This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
- This field is immutable. It can only be set for containers.
---
-
-Type::
-  `array`
-
-
-
-
-== .spec.agent.ebpf.resources.claims[]
-Description::
-+
---
-ResourceClaim references one entry in PodSpec.ResourceClaims.
---
-
-Type::
-  `object`
-
-Required::
-  - `name`
-
-
-
-[cols="1,1,1",options="header"]
-|===
-| Property | Type | Description
-
-| `name`
-| `string`
-| Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
 
 |===
 == .spec.agent.ipfix
@@ -558,12 +513,6 @@ Type::
 |===
 | Property | Type | Description
 
-| `claims`
-| `array`
-| Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
- This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
- This field is immutable. It can only be set for containers.
-
 | `limits`
 | `integer-or-string`
 | Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -571,45 +520,6 @@ Type::
 | `requests`
 | `integer-or-string`
 | Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-
-|===
-== .spec.consolePlugin.resources.claims
-Description::
-+
---
-Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
- This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
- This field is immutable. It can only be set for containers.
---
-
-Type::
-  `array`
-
-
-
-
-== .spec.consolePlugin.resources.claims[]
-Description::
-+
---
-ResourceClaim references one entry in PodSpec.ResourceClaims.
---
-
-Type::
-  `object`
-
-Required::
-  - `name`
-
-
-
-[cols="1,1,1",options="header"]
-|===
-| Property | Type | Description
-
-| `name`
-| `string`
-| Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
 
 |===
 == .spec.exporters
@@ -1799,12 +1709,6 @@ Type::
 |===
 | Property | Type | Description
 
-| `claims`
-| `array`
-| Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
- This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
- This field is immutable. It can only be set for containers.
-
 | `limits`
 | `integer-or-string`
 | Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -1812,45 +1716,6 @@ Type::
 | `requests`
 | `integer-or-string`
 | Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-
-|===
-== .spec.processor.resources.claims
-Description::
-+
---
-Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
- This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
- This field is immutable. It can only be set for containers.
---
-
-Type::
-  `array`
-
-
-
-
-== .spec.processor.resources.claims[]
-Description::
-+
---
-ResourceClaim references one entry in PodSpec.ResourceClaims.
---
-
-Type::
-  `object`
-
-Required::
-  - `name`
-
-
-
-[cols="1,1,1",options="header"]
-|===
-| Property | Type | Description
-
-| `name`
-| `string`
-| Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
 
 |===
 

--- a/docs/flowcollector-flows-netobserv-io-v1beta1.adoc
+++ b/docs/flowcollector-flows-netobserv-io-v1beta1.adoc
@@ -250,13 +250,58 @@ Type::
 |===
 | Property | Type | Description
 
+| `claims`
+| `array`
+| Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
+ This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
+ This field is immutable. It can only be set for containers.
+
 | `limits`
 | `integer-or-string`
 | Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 | `requests`
 | `integer-or-string`
-| Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+| Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+|===
+== .spec.agent.ebpf.resources.claims
+Description::
++
+--
+Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
+ This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
+ This field is immutable. It can only be set for containers.
+--
+
+Type::
+  `array`
+
+
+
+
+== .spec.agent.ebpf.resources.claims[]
+Description::
++
+--
+ResourceClaim references one entry in PodSpec.ResourceClaims.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
 
 |===
 == .spec.agent.ipfix
@@ -513,13 +558,58 @@ Type::
 |===
 | Property | Type | Description
 
+| `claims`
+| `array`
+| Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
+ This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
+ This field is immutable. It can only be set for containers.
+
 | `limits`
 | `integer-or-string`
 | Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 | `requests`
 | `integer-or-string`
-| Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+| Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+|===
+== .spec.consolePlugin.resources.claims
+Description::
++
+--
+Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
+ This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
+ This field is immutable. It can only be set for containers.
+--
+
+Type::
+  `array`
+
+
+
+
+== .spec.consolePlugin.resources.claims[]
+Description::
++
+--
+ResourceClaim references one entry in PodSpec.ResourceClaims.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
 
 |===
 == .spec.exporters
@@ -556,7 +646,7 @@ Required::
 
 | `ipfix`
 | `object`
-| IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. [Unsupported (*)].
+| IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to.
 
 | `kafka`
 | `object`
@@ -564,14 +654,14 @@ Required::
 
 | `type`
 | `string`
-| `type` selects the type of exporters. The available options are `KAFKA` and `IPFIX`. `IPFIX` is unsupported (*).
+| `type` selects the type of exporters. The available options are `KAFKA` and `IPFIX`.
 
 |===
 == .spec.exporters[].ipfix
 Description::
 +
 --
-IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to. [Unsupported (*)].
+IPFIX configuration, such as the IP address and port to send enriched IPFIX flows to.
 --
 
 Type::
@@ -1709,13 +1799,58 @@ Type::
 |===
 | Property | Type | Description
 
+| `claims`
+| `array`
+| Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
+ This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
+ This field is immutable. It can only be set for containers.
+
 | `limits`
 | `integer-or-string`
 | Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 | `requests`
 | `integer-or-string`
-| Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+| Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+|===
+== .spec.processor.resources.claims
+Description::
++
+--
+Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
+ This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
+ This field is immutable. It can only be set for containers.
+--
+
+Type::
+  `array`
+
+
+
+
+== .spec.processor.resources.claims[]
+Description::
++
+--
+ResourceClaim references one entry in PodSpec.ResourceClaims.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
 
 |===
 

--- a/hack/asciidoc-gen.sh
+++ b/hack/asciidoc-gen.sh
@@ -9,6 +9,9 @@ jq '.definitions |= ({"io.netobserv.flows.v1beta1.FlowCollector"})
   | del(.definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.status)
   | del(.definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.metadata."$ref")
   | .definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.metadata += {type:"object"}
+  | del(.definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.spec.properties.agent.properties.ebpf.properties.resources.properties.claims)
+  | del(.definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.spec.properties.processor.properties.resources.properties.claims)
+  | del(.definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.spec.properties.consolePlugin.properties.resources.properties.claims)
   | del(.definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.spec.properties.consolePlugin.properties.autoscaler.properties)
   | del(.definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.spec.properties.processor.properties.kafkaConsumerAutoscaler.properties)
   | .definitions."io.netobserv.flows.v1beta1.FlowCollector".properties.spec.properties.consolePlugin.properties.autoscaler.description |= . + " Refer to HorizontalPodAutoscaler documentation (autoscaling/v2)."


### PR DESCRIPTION
## Description

IPFIX exporter is now supported.
regen docs / bundle

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
