### PR TITLE
NETOBSERV-1314: cleanup old objects after upgrade

### DIFF
--- a/controllers/ebpf/internal/permissions/permissions.go
+++ b/controllers/ebpf/internal/permissions/permissions.go
@@ -3,7 +3,6 @@ package permissions
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	flowslatest "github.com/netobserv/network-observability-operator/api/v1beta1"
 	"github.com/netobserv/network-observability-operator/controllers/constants"
@@ -210,7 +209,7 @@ func (c *Reconciler) cleanupPreviousNamespace(ctx context.Context) error {
 		return fmt.Errorf("can't retrieve previous namespace: %w", err)
 	}
 	// Make sure we own that namespace
-	if len(previous.OwnerReferences) > 0 && strings.HasPrefix(previous.OwnerReferences[0].APIVersion, flowslatest.GroupVersion.Group) {
+	if helper.IsOwned(previous) {
 		rlog.Info("Owning previous privileged namespace: deleting it")
 		if err := c.Delete(ctx, previous); err != nil {
 			if errors.IsNotFound(err) {

--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/netobserv/network-observability-operator/controllers/operator"
 	"github.com/netobserv/network-observability-operator/controllers/ovs"
 	"github.com/netobserv/network-observability-operator/controllers/reconcilers"
+	"github.com/netobserv/network-observability-operator/pkg/cleanup"
 	"github.com/netobserv/network-observability-operator/pkg/conditions"
 	"github.com/netobserv/network-observability-operator/pkg/discover"
 	"github.com/netobserv/network-observability-operator/pkg/helper"
@@ -98,6 +99,9 @@ func (r *FlowCollectorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 	}
 
 	ns := getNamespaceName(desired)
+	if err := cleanup.CleanPastReferences(ctx, r.Client, ns); err != nil {
+		return ctrl.Result{}, err
+	}
 	r.watcher.Reset(ns)
 
 	var didChange, isInProgress bool

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -1,0 +1,58 @@
+package cleanup
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var (
+	// Add to this list any object that we used to generate in past versions, and stopped doing so.
+	// For instance, any object that was renamed between two releases of the operator and that could therefore
+	// remain on the cluster after an upgrade.
+	cleanupList = []cleanupItem{
+		{
+			ref:         client.ObjectKey{Name: "grafana-dashboard-netobserv", Namespace: "openshift-config-managed"},
+			placeholder: &corev1.ConfigMap{},
+		},
+	}
+	// Need to run only once, at operator startup, this is not part of the reconcile loop
+	didRun = false
+)
+
+type cleanupItem struct {
+	ref         client.ObjectKey
+	placeholder client.Object
+}
+
+func CleanPastReferences(ctx context.Context, cl client.Client, defaultNamespace string) error {
+	if didRun {
+		return nil
+	}
+	log := log.FromContext(ctx)
+	log.Info("Check and clean old objects")
+	// Search for all past references to clean up. If one is found, delete it.
+	for _, item := range cleanupList {
+		if item.ref.Namespace == "" {
+			item.ref.Namespace = defaultNamespace
+		}
+		if err := cl.Get(ctx, item.ref, item.placeholder); err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+		log.
+			WithValues("name", item.ref.Name).
+			WithValues("namespace", item.ref.Namespace).
+			Info("Deleting old object")
+		if err := cl.Delete(ctx, item.placeholder); err != nil {
+			return err
+		}
+	}
+	didRun = true
+	return nil
+}

--- a/pkg/cleanup/cleanup_test.go
+++ b/pkg/cleanup/cleanup_test.go
@@ -1,0 +1,58 @@
+package cleanup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/netobserv/network-observability-operator/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var oldDashboard = corev1.ConfigMap{
+	ObjectMeta: v1.ObjectMeta{
+		Name:      "grafana-dashboard-netobserv",
+		Namespace: "openshift-config-managed",
+	},
+	Data: map[string]string{},
+}
+
+func TestCleanPastReferences(t *testing.T) {
+	assert := assert.New(t)
+	clientMock := test.ClientMock{}
+	clientMock.MockConfigMap(&oldDashboard)
+	assert.Equal(1, clientMock.Len())
+	didRun = false
+
+	err := CleanPastReferences(context.Background(), &clientMock, "netobserv")
+	assert.NoError(err)
+	clientMock.AssertCalled(t,
+		"Get",
+		mock.Anything,
+		types.NamespacedName{Name: "grafana-dashboard-netobserv", Namespace: "openshift-config-managed"},
+		mock.Anything,
+		mock.Anything)
+	clientMock.AssertCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything)
+	assert.Equal(0, clientMock.Len())
+}
+
+func TestCleanPastReferences_Empty(t *testing.T) {
+	assert := assert.New(t)
+	clientMock := test.ClientMock{}
+	clientMock.MockNonExisting(types.NamespacedName{Name: "grafana-dashboard-netobserv", Namespace: "openshift-config-managed"})
+	assert.Equal(0, clientMock.Len())
+	didRun = false
+
+	err := CleanPastReferences(context.Background(), &clientMock, "netobserv")
+	assert.NoError(err)
+	clientMock.AssertCalled(t,
+		"Get",
+		mock.Anything,
+		types.NamespacedName{Name: "grafana-dashboard-netobserv", Namespace: "openshift-config-managed"},
+		mock.Anything,
+		mock.Anything)
+	clientMock.AssertNotCalled(t, "Delete")
+}

--- a/pkg/helper/flowcollector.go
+++ b/pkg/helper/flowcollector.go
@@ -1,8 +1,11 @@
 package helper
 
 import (
+	"strings"
+
 	flowslatest "github.com/netobserv/network-observability-operator/api/v1beta1"
 	"github.com/netobserv/network-observability-operator/controllers/constants"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func GetSampling(spec *flowslatest.FlowCollectorSpec) int {
@@ -145,4 +148,9 @@ func PtrInt32(i *int32) int32 {
 		return 0
 	}
 	return *i
+}
+
+func IsOwned(obj client.Object) bool {
+	refs := obj.GetOwnerReferences()
+	return len(refs) > 0 && strings.HasPrefix(refs[0].APIVersion, flowslatest.GroupVersion.Group)
 }

--- a/pkg/test/kube_mock.go
+++ b/pkg/test/kube_mock.go
@@ -3,6 +3,7 @@ package test
 import (
 	"context"
 	"errors"
+	"testing"
 
 	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/core/v1"
@@ -31,6 +32,10 @@ func (o *ClientMock) Get(ctx context.Context, nsname types.NamespacedName, obj c
 	return args.Error(0)
 }
 
+func (o *ClientMock) AssertGetCalledWith(t *testing.T, nsname types.NamespacedName) {
+	o.AssertCalled(t, "Get", mock.Anything, nsname, mock.Anything, mock.Anything)
+}
+
 func (o *ClientMock) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 	k := key(obj)
 	if _, exists := o.objs[k]; exists {
@@ -39,6 +44,15 @@ func (o *ClientMock) Create(ctx context.Context, obj client.Object, opts ...clie
 	o.objs[k] = obj
 	args := o.Called(ctx, obj, opts)
 	return args.Error(0)
+}
+
+func (o *ClientMock) AssertCreateCalled(t *testing.T) {
+	o.AssertCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func (o *ClientMock) AssertCreateNotCalled(t *testing.T) {
+	o.AssertNotCalled(t, "Create", mock.Anything, mock.Anything)
+	o.AssertNotCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func (o *ClientMock) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
@@ -51,6 +65,15 @@ func (o *ClientMock) Update(ctx context.Context, obj client.Object, opts ...clie
 	return args.Error(0)
 }
 
+func (o *ClientMock) AssertUpdateCalled(t *testing.T) {
+	o.AssertCalled(t, "Update", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func (o *ClientMock) AssertUpdateNotCalled(t *testing.T) {
+	o.AssertNotCalled(t, "Update", mock.Anything, mock.Anything)
+	o.AssertNotCalled(t, "Update", mock.Anything, mock.Anything, mock.Anything)
+}
+
 func (o *ClientMock) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
 	k := key(obj)
 	if _, exists := o.objs[k]; !exists {
@@ -59,6 +82,15 @@ func (o *ClientMock) Delete(ctx context.Context, obj client.Object, opts ...clie
 	delete(o.objs, k)
 	args := o.Called(ctx, obj, opts)
 	return args.Error(0)
+}
+
+func (o *ClientMock) AssertDeleteCalled(t *testing.T) {
+	o.AssertCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func (o *ClientMock) AssertDeleteNotCalled(t *testing.T) {
+	o.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything)
+	o.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func (o *ClientMock) MockSecret(obj *v1.Secret) {
@@ -70,6 +102,7 @@ func (o *ClientMock) MockSecret(obj *v1.Secret) {
 		arg := args.Get(2).(*v1.Secret)
 		arg.SetName(obj.GetName())
 		arg.SetNamespace(obj.GetNamespace())
+		arg.SetOwnerReferences(obj.GetOwnerReferences())
 		arg.Data = obj.Data
 	}).Return(nil)
 	o.On("Delete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -84,6 +117,7 @@ func (o *ClientMock) MockConfigMap(obj *v1.ConfigMap) {
 		arg := args.Get(2).(*v1.ConfigMap)
 		arg.SetName(obj.GetName())
 		arg.SetNamespace(obj.GetNamespace())
+		arg.SetOwnerReferences(obj.GetOwnerReferences())
 		arg.Data = obj.Data
 	}).Return(nil)
 	o.On("Delete", mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/pkg/watchers/watcher_test.go
+++ b/pkg/watchers/watcher_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/netobserv/network-observability-operator/pkg/helper"
 	"github.com/netobserv/network-observability-operator/pkg/test"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -190,9 +189,9 @@ func TestNoCopy(t *testing.T) {
 
 	_, _, err := watcher.ProcessMTLSCerts(context.Background(), cl, &lokiTLS, baseNamespace)
 	assert.NoError(err)
-	clientMock.AssertCalled(t, "Get", mock.Anything, types.NamespacedName{Name: lokiCA.Name, Namespace: lokiCA.Namespace}, mock.Anything, mock.Anything)
-	clientMock.AssertNotCalled(t, "Create")
-	clientMock.AssertNotCalled(t, "Update")
+	clientMock.AssertGetCalledWith(t, types.NamespacedName{Name: lokiCA.Name, Namespace: lokiCA.Namespace})
+	clientMock.AssertCreateNotCalled(t)
+	clientMock.AssertUpdateNotCalled(t)
 }
 
 func TestCopyCertificate(t *testing.T) {
@@ -209,10 +208,10 @@ func TestCopyCertificate(t *testing.T) {
 
 	_, _, err := watcher.ProcessMTLSCerts(context.Background(), cl, &otherLokiTLS, baseNamespace)
 	assert.NoError(err)
-	clientMock.AssertCalled(t, "Get", mock.Anything, types.NamespacedName{Name: otherLokiCA.Name, Namespace: otherLokiCA.Namespace}, mock.Anything, mock.Anything)
-	clientMock.AssertCalled(t, "Get", mock.Anything, types.NamespacedName{Name: otherLokiCA.Name, Namespace: baseNamespace}, mock.Anything, mock.Anything)
-	clientMock.AssertCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything)
-	clientMock.AssertNotCalled(t, "Update")
+	clientMock.AssertGetCalledWith(t, types.NamespacedName{Name: otherLokiCA.Name, Namespace: otherLokiCA.Namespace})
+	clientMock.AssertGetCalledWith(t, types.NamespacedName{Name: otherLokiCA.Name, Namespace: baseNamespace})
+	clientMock.AssertCreateCalled(t)
+	clientMock.AssertUpdateNotCalled(t)
 }
 
 func TestUpdateCertificate(t *testing.T) {
@@ -236,10 +235,10 @@ func TestUpdateCertificate(t *testing.T) {
 
 	_, _, err := watcher.ProcessMTLSCerts(context.Background(), cl, &otherLokiTLS, baseNamespace)
 	assert.NoError(err)
-	clientMock.AssertCalled(t, "Get", mock.Anything, types.NamespacedName{Name: otherLokiCA.Name, Namespace: otherLokiCA.Namespace}, mock.Anything, mock.Anything)
-	clientMock.AssertCalled(t, "Get", mock.Anything, types.NamespacedName{Name: otherLokiCA.Name, Namespace: baseNamespace}, mock.Anything, mock.Anything)
-	clientMock.AssertNotCalled(t, "Create")
-	clientMock.AssertCalled(t, "Update", mock.Anything, mock.Anything, mock.Anything)
+	clientMock.AssertGetCalledWith(t, types.NamespacedName{Name: otherLokiCA.Name, Namespace: otherLokiCA.Namespace})
+	clientMock.AssertGetCalledWith(t, types.NamespacedName{Name: otherLokiCA.Name, Namespace: baseNamespace})
+	clientMock.AssertCreateNotCalled(t)
+	clientMock.AssertUpdateCalled(t)
 }
 
 func TestNoUpdateCertificate(t *testing.T) {
@@ -262,8 +261,8 @@ func TestNoUpdateCertificate(t *testing.T) {
 
 	_, _, err := watcher.ProcessMTLSCerts(context.Background(), cl, &otherLokiTLS, baseNamespace)
 	assert.NoError(err)
-	clientMock.AssertCalled(t, "Get", mock.Anything, types.NamespacedName{Name: otherLokiCA.Name, Namespace: otherLokiCA.Namespace}, mock.Anything, mock.Anything)
-	clientMock.AssertCalled(t, "Get", mock.Anything, types.NamespacedName{Name: otherLokiCA.Name, Namespace: baseNamespace}, mock.Anything, mock.Anything)
-	clientMock.AssertNotCalled(t, "Create")
-	clientMock.AssertNotCalled(t, "Update")
+	clientMock.AssertGetCalledWith(t, types.NamespacedName{Name: otherLokiCA.Name, Namespace: otherLokiCA.Namespace})
+	clientMock.AssertGetCalledWith(t, types.NamespacedName{Name: otherLokiCA.Name, Namespace: baseNamespace})
+	clientMock.AssertCreateNotCalled(t)
+	clientMock.AssertUpdateNotCalled(t)
 }


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
