### PR TITLE
NETOBSERV-1326: Add metrics for packets drop

### DIFF
--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -347,9 +347,9 @@ type FLPMetrics struct {
 	Server MetricsServerConfig `json:"server,omitempty"`
 
 	// `ignoreTags` is a list of tags to specify which metrics to ignore. Each metric is associated with a list of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions .
-	// Available tags are: `egress`, `ingress`, `flows`, `bytes`, `packets`, `namespaces`, `nodes`, `workloads`, `nodes-flows`, `namespaces-flows`, `workloads-flows`.
+	// Available tags are: `egress`, `ingress`, `flows`, `bytes`, `packets`, `namespaces`, `nodes`, `workloads`, `nodes-flows`, `namespaces-flows`, `workloads-flows`, `drop-bytes`, `drop-packets`.
 	// Namespace-based metrics are covered by both `workloads` and `namespaces` tags, hence it is recommended to always ignore one of them (`workloads` offering a finer granularity).
-	//+kubebuilder:default:={"egress","packets","nodes-flows","namespaces-flows","workloads-flows","namespaces"}
+	//+kubebuilder:default:={"egress","packets","nodes-flows","namespaces-flows","workloads-flows","namespaces", "drop-bytes", "drop-packets"}
 	// +optional
 	IgnoreTags []string `json:"ignoreTags"`
 

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -4647,15 +4647,17 @@ spec:
                         - namespaces-flows
                         - workloads-flows
                         - namespaces
+                        - drop-bytes
+                        - drop-packets
                         description: '`ignoreTags` is a list of tags to specify which
                           metrics to ignore. Each metric is associated with a list
                           of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions
                           . Available tags are: `egress`, `ingress`, `flows`, `bytes`,
                           `packets`, `namespaces`, `nodes`, `workloads`, `nodes-flows`,
-                          `namespaces-flows`, `workloads-flows`. Namespace-based metrics
-                          are covered by both `workloads` and `namespaces` tags, hence
-                          it is recommended to always ignore one of them (`workloads`
-                          offering a finer granularity).'
+                          `namespaces-flows`, `workloads-flows`, `drop-bytes`, `drop-packets`.
+                          Namespace-based metrics are covered by both `workloads`
+                          and `namespaces` tags, hence it is recommended to always
+                          ignore one of them (`workloads` offering a finer granularity).'
                         items:
                           type: string
                         type: array

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -331,7 +331,9 @@ metadata:
                   "nodes-flows",
                   "namespaces-flows",
                   "workloads-flows",
-                  "namespaces"
+                  "namespaces",
+                  "drop-bytes",
+                  "drop-packets"
                 ],
                 "server": {
                   "port": 9102

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -4634,15 +4634,17 @@ spec:
                         - namespaces-flows
                         - workloads-flows
                         - namespaces
+                        - drop-bytes
+                        - drop-packets
                         description: '`ignoreTags` is a list of tags to specify which
                           metrics to ignore. Each metric is associated with a list
                           of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions
                           . Available tags are: `egress`, `ingress`, `flows`, `bytes`,
                           `packets`, `namespaces`, `nodes`, `workloads`, `nodes-flows`,
-                          `namespaces-flows`, `workloads-flows`. Namespace-based metrics
-                          are covered by both `workloads` and `namespaces` tags, hence
-                          it is recommended to always ignore one of them (`workloads`
-                          offering a finer granularity).'
+                          `namespaces-flows`, `workloads-flows`, `drop-bytes`, `drop-packets`.
+                          Namespace-based metrics are covered by both `workloads`
+                          and `namespaces` tags, hence it is recommended to always
+                          ignore one of them (`workloads` offering a finer granularity).'
                         items:
                           type: string
                         type: array

--- a/config/samples/flows_v1beta1_flowcollector.yaml
+++ b/config/samples/flows_v1beta1_flowcollector.yaml
@@ -44,6 +44,8 @@ spec:
         # Ignoring eihter "namespaces" or "workloads", as namespaces metrics are included in workload metrics
         # This helps reduce total cardinality
         - namespaces
+        - drop-bytes
+        - drop-packets
       disableAlerts: []
     dropUnusedFields: true
     resources:

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -824,22 +824,33 @@ func TestMergeMetricsConfigurationNoIgnore(t *testing.T) {
 	assert.True(validatePipelineConfig(stages, parameters))
 	jsonStages, _ := json.Marshal(stages)
 	assert.Equal(`[{"name":"ipfix"},{"name":"extract_conntrack","follows":"ipfix"},{"name":"enrich","follows":"extract_conntrack"},{"name":"loki","follows":"enrich"},{"name":"stdout","follows":"enrich"},{"name":"prometheus","follows":"enrich"}]`, string(jsonStages))
-	assert.Len(parameters[5].Encode.Prom.Metrics, 15)
-	assert.Equal("namespace_egress_bytes_total", parameters[5].Encode.Prom.Metrics[0].Name)
-	assert.Equal("namespace_egress_packets_total", parameters[5].Encode.Prom.Metrics[1].Name)
-	assert.Equal("namespace_flows_total", parameters[5].Encode.Prom.Metrics[2].Name)
-	assert.Equal("namespace_ingress_bytes_total", parameters[5].Encode.Prom.Metrics[3].Name)
-	assert.Equal("namespace_ingress_packets_total", parameters[5].Encode.Prom.Metrics[4].Name)
-	assert.Equal("node_egress_bytes_total", parameters[5].Encode.Prom.Metrics[5].Name)
-	assert.Equal("node_egress_packets_total", parameters[5].Encode.Prom.Metrics[6].Name)
-	assert.Equal("node_flows_total", parameters[5].Encode.Prom.Metrics[7].Name)
-	assert.Equal("node_ingress_bytes_total", parameters[5].Encode.Prom.Metrics[8].Name)
-	assert.Equal("node_ingress_packets_total", parameters[5].Encode.Prom.Metrics[9].Name)
-	assert.Equal("workload_egress_bytes_total", parameters[5].Encode.Prom.Metrics[10].Name)
-	assert.Equal("workload_egress_packets_total", parameters[5].Encode.Prom.Metrics[11].Name)
-	assert.Equal("workload_flows_total", parameters[5].Encode.Prom.Metrics[12].Name)
-	assert.Equal("workload_ingress_bytes_total", parameters[5].Encode.Prom.Metrics[13].Name)
-	assert.Equal("workload_ingress_packets_total", parameters[5].Encode.Prom.Metrics[14].Name)
+	assert.Len(parameters[5].Encode.Prom.Metrics, 21)
+	definitions := []string{
+		"namespace_drop_bytes_total",
+		"namespace_drop_packets_total",
+		"namespace_egress_bytes_total",
+		"namespace_egress_packets_total",
+		"namespace_flows_total",
+		"namespace_ingress_bytes_total",
+		"namespace_ingress_packets_total",
+		"node_drop_bytes_total",
+		"node_drop_packets_total",
+		"node_egress_bytes_total",
+		"node_egress_packets_total",
+		"node_flows_total",
+		"node_ingress_bytes_total",
+		"node_ingress_packets_total",
+		"workload_drop_bytes_total",
+		"workload_drop_packets_total",
+		"workload_egress_bytes_total",
+		"workload_egress_packets_total",
+		"workload_flows_total",
+		"workload_ingress_bytes_total",
+		"workload_ingress_packets_total",
+	}
+	for i, def := range definitions {
+		assert.Equal(def, parameters[5].Encode.Prom.Metrics[i].Name)
+	}
 	assert.Equal("netobserv_", parameters[5].Encode.Prom.Prefix)
 }
 
@@ -855,8 +866,8 @@ func TestMergeMetricsConfigurationWithIgnore(t *testing.T) {
 	assert.True(validatePipelineConfig(stages, parameters))
 	jsonStages, _ := json.Marshal(stages)
 	assert.Equal(`[{"name":"ipfix"},{"name":"extract_conntrack","follows":"ipfix"},{"name":"enrich","follows":"extract_conntrack"},{"name":"loki","follows":"enrich"},{"name":"stdout","follows":"enrich"},{"name":"prometheus","follows":"enrich"}]`, string(jsonStages))
-	assert.Len(parameters[5].Encode.Prom.Metrics, 10)
-	assert.Equal("namespace_egress_bytes_total", parameters[5].Encode.Prom.Metrics[0].Name)
+	assert.Len(parameters[5].Encode.Prom.Metrics, 14)
+	assert.Equal("namespace_egress_bytes_total", parameters[5].Encode.Prom.Metrics[2].Name)
 	assert.Equal("netobserv_", parameters[5].Encode.Prom.Prefix)
 }
 

--- a/controllers/flowlogspipeline/metrics_definitions/namespace_drop_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/namespace_drop_bytes_total.yaml
@@ -1,0 +1,25 @@
+#flp_confgen
+description:
+  This metric observes drop packets
+details:
+  Sum bytes for dropped traffic
+usage:
+  Evaluate packets drop breakdown per source and destination namespaces
+tags:
+  - drop-bytes
+  - namespaces
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: namespace_drop_bytes_total
+        type: counter
+        valuekey: PktDropBytes
+        filters:
+        - key: Duplicate
+          value: "false"
+        - key: PktDropBytes
+          value: "!nil"
+        labels:
+          - SrcK8S_Namespace
+          - DstK8S_Namespace

--- a/controllers/flowlogspipeline/metrics_definitions/namespace_drop_packets_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/namespace_drop_packets_total.yaml
@@ -1,0 +1,25 @@
+#flp_confgen
+description:
+  This metric observes drop packets
+details:
+  Sum Packets for dropped traffic
+usage:
+  Evaluate packets drop breakdown per source and destination namespaces
+tags:
+  - drop-packets
+  - namespaces
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: namespace_drop_packets_total
+        type: counter
+        valuekey: PktDropPackets
+        filters:
+        - key: Duplicate
+          value: "false"
+        - key: PktDropPackets
+          value: "!nil"
+        labels:
+          - SrcK8S_Namespace
+          - DstK8S_Namespace

--- a/controllers/flowlogspipeline/metrics_definitions/node_drop_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/node_drop_bytes_total.yaml
@@ -1,0 +1,25 @@
+#flp_confgen
+description:
+  This metric observes drop packets
+details:
+  Sum bytes for dropped traffic
+usage:
+  Evaluate packets drop breakdown per source and destination nodes
+tags:
+  - drop-bytes
+  - nodes
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: node_drop_bytes_total
+        type: counter
+        valuekey: PktDropBytes
+        filters:
+        - key: Duplicate
+          value: "false"
+        - key: PktDropBytes
+          value: "!nil"
+        labels:
+          - SrcK8S_HostName
+          - DstK8S_HostName

--- a/controllers/flowlogspipeline/metrics_definitions/node_drop_packets_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/node_drop_packets_total.yaml
@@ -1,0 +1,25 @@
+#flp_confgen
+description:
+  This metric observes drop packets
+details:
+  Sum Packets for dropped traffic
+usage:
+  Evaluate packets drop breakdown per source and destination nodes
+tags:
+  - drop-packets
+  - nodes
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: node_drop_packets_total
+        type: counter
+        valuekey: PktDropPackets
+        filters:
+        - key: Duplicate
+          value: "false"
+        - key: PktDropPackets
+          value: "!nil"
+        labels:
+          - SrcK8S_HostName
+          - DstK8S_HostName

--- a/controllers/flowlogspipeline/metrics_definitions/workload_drop_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_drop_bytes_total.yaml
@@ -1,0 +1,29 @@
+#flp_confgen
+description:
+  This metric observes packets drop
+details:
+  Sum bytes for packets drop per source and destination namespaces and owners
+usage:
+  Evaluate packets drop usage breakdown per source and destination namespaces and owners
+tags:
+  - drop-bytes
+  - workloads
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: workload_drop_bytes_total
+        type: counter
+        valuekey: PktDropBytes
+        filters:
+        - key: Duplicate
+          value: "false"
+        - key: PktDropBytes
+          value: "!nil"
+        labels:
+          - SrcK8S_Namespace
+          - DstK8S_Namespace
+          - SrcK8S_OwnerName
+          - DstK8S_OwnerName
+          - SrcK8S_OwnerType
+          - DstK8S_OwnerType

--- a/controllers/flowlogspipeline/metrics_definitions/workload_drop_packets_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_drop_packets_total.yaml
@@ -1,0 +1,29 @@
+#flp_confgen
+description:
+  This metric observes drop packets
+details:
+  Sum packet drops number per source and destination namespaces and owners
+usage:
+  Evaluate packets drop usage breakdown per source and destination namespaces and owners
+tags:
+  - drop-packets
+  - workloads
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: workload_drop_packets_total
+        type: counter
+        valuekey: PktDropPackets
+        filters:
+        - key: Duplicate
+          value: "false"
+        - key: PktDropPackets
+          value: "!nil"
+        labels:
+          - SrcK8S_Namespace
+          - DstK8S_Namespace
+          - SrcK8S_OwnerName
+          - DstK8S_OwnerName
+          - SrcK8S_OwnerType
+          - DstK8S_OwnerType

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -8183,9 +8183,9 @@ target specifies the target value for the given metric
         <td><b>ignoreTags</b></td>
         <td>[]string</td>
         <td>
-          `ignoreTags` is a list of tags to specify which metrics to ignore. Each metric is associated with a list of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions . Available tags are: `egress`, `ingress`, `flows`, `bytes`, `packets`, `namespaces`, `nodes`, `workloads`, `nodes-flows`, `namespaces-flows`, `workloads-flows`. Namespace-based metrics are covered by both `workloads` and `namespaces` tags, hence it is recommended to always ignore one of them (`workloads` offering a finer granularity).<br/>
+          `ignoreTags` is a list of tags to specify which metrics to ignore. Each metric is associated with a list of tags. More details in https://github.com/netobserv/network-observability-operator/tree/main/controllers/flowlogspipeline/metrics_definitions . Available tags are: `egress`, `ingress`, `flows`, `bytes`, `packets`, `namespaces`, `nodes`, `workloads`, `nodes-flows`, `namespaces-flows`, `workloads-flows`, `drop-bytes`, `drop-packets`. Namespace-based metrics are covered by both `workloads` and `namespaces` tags, hence it is recommended to always ignore one of them (`workloads` offering a finer granularity).<br/>
           <br/>
-            <i>Default</i>: [egress packets nodes-flows namespaces-flows workloads-flows namespaces]<br/>
+            <i>Default</i>: [egress packets nodes-flows namespaces-flows workloads-flows namespaces drop-bytes drop-packets]<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/helper/dashboard.go
+++ b/pkg/helper/dashboard.go
@@ -17,19 +17,21 @@ type rowInfo struct {
 
 // Queries
 const (
-	layerApps           = "Applications"
-	layerInfra          = "Infrastructure"
-	appsFilters1        = `SrcK8S_Namespace!~"|$NETOBSERV_NS|openshift.*"`
-	appsFilters2        = `SrcK8S_Namespace=~"$NETOBSERV_NS|openshift.*",DstK8S_Namespace!~"|$NETOBSERV_NS|openshift.*"`
-	infraFilters1       = `SrcK8S_Namespace=~"$NETOBSERV_NS|openshift.*"`
-	infraFilters2       = `SrcK8S_Namespace!~"$NETOBSERV_NS|openshift.*",DstK8S_Namespace=~"$NETOBSERV_NS|openshift.*"`
-	metricTagNamespaces = "namespaces"
-	metricTagNodes      = "nodes"
-	metricTagWorkloads  = "workloads"
-	metricTagIngress    = "ingress"
-	metricTagEgress     = "egress"
-	metricTagBytes      = "bytes"
-	metricTagPackets    = "packets"
+	layerApps                = "Applications"
+	layerInfra               = "Infrastructure"
+	appsFilters1             = `SrcK8S_Namespace!~"|$NETOBSERV_NS|openshift.*"`
+	appsFilters2             = `SrcK8S_Namespace=~"$NETOBSERV_NS|openshift.*",DstK8S_Namespace!~"|$NETOBSERV_NS|openshift.*"`
+	infraFilters1            = `SrcK8S_Namespace=~"$NETOBSERV_NS|openshift.*"`
+	infraFilters2            = `SrcK8S_Namespace!~"$NETOBSERV_NS|openshift.*",DstK8S_Namespace=~"$NETOBSERV_NS|openshift.*"`
+	metricTagNamespaces      = "namespaces"
+	metricTagNodes           = "nodes"
+	metricTagWorkloads       = "workloads"
+	metricTagIngress         = "ingress"
+	metricTagEgress          = "egress"
+	metricTagBytes           = "bytes"
+	metricTagPackets         = "packets"
+	metricTagPktsDropBytes   = "drop_bytes"
+	metricTagPktsDropPackets = "drop_packets"
 )
 
 var (
@@ -95,6 +97,13 @@ func init() {
 					valueType: vt,
 				})
 			}
+		}
+		for _, vt := range []string{metricTagPktsDropBytes, metricTagPktsDropPackets} {
+			rowsInfo = append(rowsInfo, rowInfo{
+				metric:    fmt.Sprintf("netobserv_%s_%s_total", groupTrimmed, vt),
+				group:     group,
+				valueType: vt,
+			})
 		}
 	}
 }
@@ -218,6 +227,10 @@ func flowMetricsRow(netobsNs string, rowInfo rowInfo) string {
 		vt = "byte"
 	case metricTagPackets:
 		vt = "packet"
+	case metricTagPktsDropBytes:
+		vt = "drop bytes"
+	case metricTagPktsDropPackets:
+		vt = "drop packets"
 	}
 	title := fmt.Sprintf("Top %s rates %s per source and destination %s", vt, verb, rowInfo.group)
 	var panels string

--- a/pkg/helper/dashboard.go
+++ b/pkg/helper/dashboard.go
@@ -17,21 +17,21 @@ type rowInfo struct {
 
 // Queries
 const (
-	layerApps                = "Applications"
-	layerInfra               = "Infrastructure"
-	appsFilters1             = `SrcK8S_Namespace!~"|$NETOBSERV_NS|openshift.*"`
-	appsFilters2             = `SrcK8S_Namespace=~"$NETOBSERV_NS|openshift.*",DstK8S_Namespace!~"|$NETOBSERV_NS|openshift.*"`
-	infraFilters1            = `SrcK8S_Namespace=~"$NETOBSERV_NS|openshift.*"`
-	infraFilters2            = `SrcK8S_Namespace!~"$NETOBSERV_NS|openshift.*",DstK8S_Namespace=~"$NETOBSERV_NS|openshift.*"`
-	metricTagNamespaces      = "namespaces"
-	metricTagNodes           = "nodes"
-	metricTagWorkloads       = "workloads"
-	metricTagIngress         = "ingress"
-	metricTagEgress          = "egress"
-	metricTagBytes           = "bytes"
-	metricTagPackets         = "packets"
-	metricTagPktsDropBytes   = "drop_bytes"
-	metricTagPktsDropPackets = "drop_packets"
+	layerApps            = "Applications"
+	layerInfra           = "Infrastructure"
+	appsFilters1         = `SrcK8S_Namespace!~"|$NETOBSERV_NS|openshift.*"`
+	appsFilters2         = `SrcK8S_Namespace=~"$NETOBSERV_NS|openshift.*",DstK8S_Namespace!~"|$NETOBSERV_NS|openshift.*"`
+	infraFilters1        = `SrcK8S_Namespace=~"$NETOBSERV_NS|openshift.*"`
+	infraFilters2        = `SrcK8S_Namespace!~"$NETOBSERV_NS|openshift.*",DstK8S_Namespace=~"$NETOBSERV_NS|openshift.*"`
+	metricTagNamespaces  = "namespaces"
+	metricTagNodes       = "nodes"
+	metricTagWorkloads   = "workloads"
+	metricTagIngress     = "ingress"
+	metricTagEgress      = "egress"
+	metricTagBytes       = "bytes"
+	metricTagPackets     = "packets"
+	metricTagDropBytes   = "drop_bytes"
+	metricTagDropPackets = "drop_packets"
 )
 
 var (
@@ -98,7 +98,7 @@ func init() {
 				})
 			}
 		}
-		for _, vt := range []string{metricTagPktsDropBytes, metricTagPktsDropPackets} {
+		for _, vt := range []string{metricTagDropBytes, metricTagDropPackets} {
 			rowsInfo = append(rowsInfo, rowInfo{
 				metric:    fmt.Sprintf("netobserv_%s_%s_total", groupTrimmed, vt),
 				group:     group,
@@ -227,9 +227,9 @@ func flowMetricsRow(netobsNs string, rowInfo rowInfo) string {
 		vt = "byte"
 	case metricTagPackets:
 		vt = "packet"
-	case metricTagPktsDropBytes:
+	case metricTagDropBytes:
 		vt = "drop bytes"
-	case metricTagPktsDropPackets:
+	case metricTagDropPackets:
 		vt = "drop packets"
 	}
 	title := fmt.Sprintf("Top %s rates %s per source and destination %s", vt, verb, rowInfo.group)

--- a/pkg/helper/dashboard_test.go
+++ b/pkg/helper/dashboard_test.go
@@ -32,8 +32,7 @@ func TestCreateFlowMetricsDashboard_All(t *testing.T) {
 	assert.NoError(err)
 
 	assert.Equal("NetObserv", d.Title)
-	assert.Len(d.Rows, 12)
-
+	assert.Len(d.Rows, 18)
 	// First row
 	row := 0
 	assert.Equal("Top byte rates sent per source and destination nodes", d.Rows[row].Title)
@@ -42,8 +41,8 @@ func TestCreateFlowMetricsDashboard_All(t *testing.T) {
 	assert.Len(d.Rows[row].Panels[0].Targets, 1)
 	assert.Contains(d.Rows[row].Panels[0].Targets[0].Expr, "label_replace(label_replace(topk(10,sum(rate(netobserv_node_egress_bytes_total[1m])) by (SrcK8S_HostName, DstK8S_HostName))")
 
-	// 6th row
-	row = 5
+	// 8th row
+	row = 7
 	assert.Equal("Top byte rates received per source and destination namespaces", d.Rows[row].Title)
 	assert.Len(d.Rows[row].Panels, 2)
 	assert.Equal("Applications", d.Rows[row].Panels[0].Title)
@@ -56,8 +55,8 @@ func TestCreateFlowMetricsDashboard_All(t *testing.T) {
 		`label_replace(label_replace(topk(10,sum(rate(netobserv_namespace_ingress_bytes_total{SrcK8S_Namespace=~"netobserv|openshift.*"}[1m]) or rate(netobserv_namespace_ingress_bytes_total{SrcK8S_Namespace!~"netobserv|openshift.*",DstK8S_Namespace=~"netobserv|openshift.*"}[1m])) by (SrcK8S_Namespace, DstK8S_Namespace))`,
 	)
 
-	// 12th row
-	row = 11
+	// 16th row
+	row = 15
 	assert.Equal("Top packet rates received per source and destination workloads", d.Rows[row].Title)
 	assert.Len(d.Rows[row].Panels, 2)
 	assert.Equal("Applications", d.Rows[row].Panels[0].Title)
@@ -74,7 +73,13 @@ func TestCreateFlowMetricsDashboard_All(t *testing.T) {
 func TestCreateFlowMetricsDashboard_OnlyNodeIngressBytes(t *testing.T) {
 	assert := assert.New(t)
 
-	js, err := CreateFlowMetricsDashboard("netobserv", []string{metricTagNamespaces, metricTagWorkloads, metricTagEgress, metricTagPackets})
+	js, err := CreateFlowMetricsDashboard("netobserv", []string{
+		metricTagNamespaces,
+		metricTagWorkloads,
+		metricTagEgress,
+		metricTagPackets,
+		metricTagPktsDropBytes,
+		metricTagPktsDropPackets})
 	assert.NoError(err)
 
 	var d dashboard
@@ -102,6 +107,8 @@ func TestCreateFlowMetricsDashboard_RemoveByMetricName(t *testing.T) {
 		"netobserv_node_egress_packets_total",
 		"netobserv_node_ingress_packets_total",
 		"netobserv_node_egress_bytes_total",
+		metricTagPktsDropBytes,
+		metricTagPktsDropPackets,
 	})
 	assert.NoError(err)
 
@@ -124,7 +131,7 @@ func TestCreateFlowMetricsDashboard_RemoveByMetricName(t *testing.T) {
 func TestCreateFlowMetricsDashboard_DefaultIgnoreTags(t *testing.T) {
 	assert := assert.New(t)
 
-	js, err := CreateFlowMetricsDashboard("netobserv", []string{"egress", "packets", "namespaces"})
+	js, err := CreateFlowMetricsDashboard("netobserv", []string{"egress", "packets", "namespaces", metricTagPktsDropBytes, metricTagPktsDropPackets})
 	assert.NoError(err)
 
 	var d dashboard

--- a/pkg/helper/dashboard_test.go
+++ b/pkg/helper/dashboard_test.go
@@ -78,8 +78,8 @@ func TestCreateFlowMetricsDashboard_OnlyNodeIngressBytes(t *testing.T) {
 		metricTagWorkloads,
 		metricTagEgress,
 		metricTagPackets,
-		metricTagPktsDropBytes,
-		metricTagPktsDropPackets})
+		metricTagDropBytes,
+		metricTagDropPackets})
 	assert.NoError(err)
 
 	var d dashboard
@@ -107,8 +107,8 @@ func TestCreateFlowMetricsDashboard_RemoveByMetricName(t *testing.T) {
 		"netobserv_node_egress_packets_total",
 		"netobserv_node_ingress_packets_total",
 		"netobserv_node_egress_bytes_total",
-		metricTagPktsDropBytes,
-		metricTagPktsDropPackets,
+		metricTagDropBytes,
+		metricTagDropPackets,
 	})
 	assert.NoError(err)
 
@@ -131,7 +131,7 @@ func TestCreateFlowMetricsDashboard_RemoveByMetricName(t *testing.T) {
 func TestCreateFlowMetricsDashboard_DefaultIgnoreTags(t *testing.T) {
 	assert := assert.New(t)
 
-	js, err := CreateFlowMetricsDashboard("netobserv", []string{"egress", "packets", "namespaces", metricTagPktsDropBytes, metricTagPktsDropPackets})
+	js, err := CreateFlowMetricsDashboard("netobserv", []string{"egress", "packets", "namespaces", metricTagDropBytes, metricTagDropPackets})
 	assert.NoError(err)
 
 	var d dashboard


### PR DESCRIPTION
## Description

add metrics for packets drop feature, using same strategy as in #408 

testing with `cluster-bot` using OCP cluster

1- enable metrics
```sh
oc get cm -n openshift-monitoring  cluster-monitoring-config -o yaml
apiVersion: v1
data:
  config.yaml: |-
    enableUserWorkload: true <<<<
    prometheusK8s:

      volumeClaimTemplate:
        metadata:
          name: prometheus-data
          annotations:
            openshift.io/cluster-monitoring-drop-pvc: "yes"
        spec:
          resources:
            requests:
              storage: 20Gi
kind: ConfigMap
metadata:
  creationTimestamp: "2023-10-02T10:31:37Z"
  name: cluster-monitoring-config
  namespace: openshift-monitoring
  resourceVersion: "72651"
  uid: 5bc8c0a3-1b13-4dbd-9746-e485e5ee15da
```
2- enable pktdrop feature and enable all tags
```sh
 agent:
       type: EBPF
       ebpf:
         privileged: true  <<<
         features:  
           - "PacketDrop"   <<<
     processor:
         ignoreTags: []

```
## Dependencies
https://github.com/netobserv/flowlogs-pipeline/pull/478

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [X] Does this PR require product documentation?
  * [X] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [X] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
