### PR TITLE
NETOBSERV-1340: Add operator to "Observability" category in OperatorHub

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -353,7 +353,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    categories: Monitoring
+    categories: Monitoring, Observability
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: quay.io/netobserv/network-observability-operator:1.0.4
     createdAt: ':created-at:'

--- a/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
-    categories: Monitoring
+    categories: Monitoring, Observability
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: ':container-image:'
     createdAt: ':created-at:'


### PR DESCRIPTION
The name says it all.  This adds the "Observability" category if it doesn't exist and adds Network Observability to this category.

![observability_category](https://github.com/netobserv/network-observability-operator/assets/84493651/e1e4776d-5796-41e2-a665-237daeeff83d)
