### PR TITLE
NETOBSERV-1293: Fix status oscillation

### DIFF
--- a/pkg/helper/client_helper.go
+++ b/pkg/helper/client_helper.go
@@ -77,13 +77,13 @@ func (c *Client) UpdateOwned(ctx context.Context, old, obj client.Object) error 
 }
 
 func (c *Client) CheckDeploymentInProgress(d *appsv1.Deployment) {
-	if d.Status.AvailableReplicas < d.Status.Replicas {
+	if d.Status.UpdatedReplicas < d.Status.Replicas {
 		c.SetInProgress(true)
 	}
 }
 
 func (c *Client) CheckDaemonSetInProgress(ds *appsv1.DaemonSet) {
-	if ds.Status.NumberAvailable < ds.Status.DesiredNumberScheduled {
+	if ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled {
 		c.SetInProgress(true)
 	}
 }


### PR DESCRIPTION
## Description

Fix status oscillation by only counting Updated pods in pods count

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
