### PR TITLE
NETOBSERV-1344: include inner traffic in metrics [1.4 backport]

### DIFF
--- a/controllers/flowlogspipeline/metrics_definitions/namespace_egress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/namespace_egress_bytes_total.yaml
@@ -18,7 +18,7 @@ encode:
         valuekey: Bytes
         filters:
         - key: FlowDirection
-          value: "1"
+          value: "1|2"
         - key: Duplicate
           value: "false"
         labels:

--- a/controllers/flowlogspipeline/metrics_definitions/namespace_egress_packets_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/namespace_egress_packets_total.yaml
@@ -18,7 +18,7 @@ encode:
         valuekey: Packets
         filters:
         - key: FlowDirection
-          value: "1"
+          value: "1|2"
         - key: Duplicate
           value: "false"
         labels:

--- a/controllers/flowlogspipeline/metrics_definitions/namespace_ingress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/namespace_ingress_bytes_total.yaml
@@ -18,7 +18,7 @@ encode:
         valuekey: Bytes
         filters:
         - key: FlowDirection
-          value: "0"
+          value: "0|2"
         - key: Duplicate
           value: "false"
         labels:

--- a/controllers/flowlogspipeline/metrics_definitions/namespace_ingress_packets_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/namespace_ingress_packets_total.yaml
@@ -18,7 +18,7 @@ encode:
         valuekey: Packets
         filters:
         - key: FlowDirection
-          value: "0"
+          value: "0|2"
         - key: Duplicate
           value: "false"
         labels:

--- a/controllers/flowlogspipeline/metrics_definitions/node_egress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/node_egress_bytes_total.yaml
@@ -18,7 +18,7 @@ encode:
         valuekey: Bytes
         filters:
         - key: FlowDirection
-          value: "1"
+          value: "1|2"
         - key: Duplicate
           value: "false"
         labels:

--- a/controllers/flowlogspipeline/metrics_definitions/node_egress_packets_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/node_egress_packets_total.yaml
@@ -18,7 +18,7 @@ encode:
         valuekey: Packets
         filters:
         - key: FlowDirection
-          value: "1"
+          value: "1|2"
         - key: Duplicate
           value: "false"
         labels:

--- a/controllers/flowlogspipeline/metrics_definitions/node_ingress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/node_ingress_bytes_total.yaml
@@ -18,7 +18,7 @@ encode:
         valuekey: Bytes
         filters:
         - key: FlowDirection
-          value: "0"
+          value: "0|2"
         - key: Duplicate
           value: "false"
         labels:

--- a/controllers/flowlogspipeline/metrics_definitions/node_ingress_packets_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/node_ingress_packets_total.yaml
@@ -18,7 +18,7 @@ encode:
         valuekey: Packets
         filters:
         - key: FlowDirection
-          value: "0"
+          value: "0|2"
         - key: Duplicate
           value: "false"
         labels:

--- a/controllers/flowlogspipeline/metrics_definitions/workload_egress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_egress_bytes_total.yaml
@@ -18,7 +18,7 @@ encode:
         valuekey: Bytes
         filters:
         - key: FlowDirection
-          value: "1"
+          value: "1|2"
         - key: Duplicate
           value: "false"
         labels:

--- a/controllers/flowlogspipeline/metrics_definitions/workload_egress_packets_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_egress_packets_total.yaml
@@ -18,7 +18,7 @@ encode:
         valuekey: Packets
         filters:
         - key: FlowDirection
-          value: "1"
+          value: "1|2"
         - key: Duplicate
           value: "false"
         labels:

--- a/controllers/flowlogspipeline/metrics_definitions/workload_ingress_bytes_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_ingress_bytes_total.yaml
@@ -18,7 +18,7 @@ encode:
         valuekey: Bytes
         filters:
         - key: FlowDirection
-          value: "0"
+          value: "0|2"
         - key: Duplicate
           value: "false"
         labels:

--- a/controllers/flowlogspipeline/metrics_definitions/workload_ingress_packets_total.yaml
+++ b/controllers/flowlogspipeline/metrics_definitions/workload_ingress_packets_total.yaml
@@ -18,7 +18,7 @@ encode:
         valuekey: Packets
         filters:
         - key: FlowDirection
-          value: "0"
+          value: "0|2"
         - key: Duplicate
           value: "false"
         labels:


### PR DESCRIPTION
Backport of https://github.com/netobserv/network-observability-operator/pull/452

Previously, "inner" traffic (ie. traffic between pods running on the same node) wasn't included in the metrics

## Dependencies

Requires https://github.com/netobserv/flowlogs-pipeline/pull/519

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
