### PR TITLE
NETOBSERV-1369: Disable http/2

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -930,9 +930,10 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
+                - --http2-disable
                 - --tls-cert-file=/etc/tls/private/tls.crt
                 - --tls-private-key-file=/etc/tls/private/tls.key
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.4
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -932,7 +932,7 @@ spec:
                 - --v=10
                 - --tls-cert-file=/etc/tls/private/tls.crt
                 - --tls-private-key-file=/etc/tls/private/tls.key
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.4
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -18,7 +18,7 @@ spec:
         - "--flowlogs-pipeline-image=$(RELATED_IMAGE_FLOWLOGS_PIPELINE)"
         - "--console-plugin-image=$(RELATED_IMAGE_CONSOLE_PLUGIN)"
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.4
         args:
           - "--secure-listen-address=0.0.0.0:8443"
           - "--upstream=http://127.0.0.1:8080/"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -18,12 +18,13 @@ spec:
         - "--flowlogs-pipeline-image=$(RELATED_IMAGE_FLOWLOGS_PIPELINE)"
         - "--console-plugin-image=$(RELATED_IMAGE_CONSOLE_PLUGIN)"
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.4
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
           - "--secure-listen-address=0.0.0.0:8443"
           - "--upstream=http://127.0.0.1:8080/"
           - "--logtostderr=true"
           - "--v=10"
+          - "--http2-disable"
         ports:
           - containerPort: 8443
             protocol: TCP

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,7 +64,7 @@ spec:
             cpu: 100m
             memory: 100Mi
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.4
         args:
           - "--secure-listen-address=0.0.0.0:8443"
           - "--upstream=http://127.0.0.1:8080/"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,12 +64,13 @@ spec:
             cpu: 100m
             memory: 100Mi
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.4
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
           - "--secure-listen-address=0.0.0.0:8443"
           - "--upstream=http://127.0.0.1:8080/"
           - "--logtostderr=true"
           - "--v=10"
+          - "--http2-disable"
         ports:
           - containerPort: 8443
             protocol: TCP

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -271,6 +271,7 @@ func (b *builder) podTemplate(cmDigest string) *corev1.PodTemplateSpec {
 				Resources:       *b.desired.ConsolePlugin.Resources.DeepCopy(),
 				VolumeMounts:    b.volumes.AppendMounts(volumeMounts),
 				Args:            args,
+				Env:             []corev1.EnvVar{constants.EnvNoHTTP2},
 			}},
 			Volumes:            b.volumes.AppendVolumes(volumes),
 			ServiceAccountName: constants.PluginName,

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -1,7 +1,10 @@
 // Package constants defines some values that are shared across multiple packages
 package constants
 
-import "k8s.io/apimachinery/pkg/types"
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
 
 const (
 	DefaultOperatorNamespace = "netobserv"
@@ -40,3 +43,7 @@ const (
 var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstK8S_Type", "FlowDirection", "Duplicate"}
 var LokiConnectionIndexFields = []string{"_RecordType"}
 var FlowCollectorName = types.NamespacedName{Name: "cluster"}
+var EnvNoHTTP2 = corev1.EnvVar{
+	Name:  "GODEBUG",
+	Value: "http2server=0",
+}

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -335,7 +335,7 @@ func flowCollectorControllerSpecs() {
 					Protocol:      "UDP",
 				}))
 				Expect(cnt.Env).To(Equal([]v1.EnvVar{
-					{Name: "GOGC", Value: "400"}, {Name: "GOMAXPROCS", Value: "33"},
+					{Name: "GOGC", Value: "400"}, {Name: "GOMAXPROCS", Value: "33"}, {Name: "GODEBUG", Value: "http2server=0"},
 				}))
 			})
 

--- a/controllers/flowlogspipeline/flp_common_objects.go
+++ b/controllers/flowlogspipeline/flp_common_objects.go
@@ -178,6 +178,7 @@ func (b *builder) podTemplate(hasHostPort, hostNetwork bool, annotations map[str
 	for _, pair := range helper.KeySorted(b.desired.Processor.Debug.Env) {
 		envs = append(envs, corev1.EnvVar{Name: pair[0], Value: pair[1]})
 	}
+	envs = append(envs, constants.EnvNoHTTP2)
 
 	container := corev1.Container{
 		Name:            constants.FLPName,


### PR DESCRIPTION
Additional remediations for CVE-2023-39325 CVE-2023-44487: Disable HTTP/2 on:

- Webhook server
- Metrics server
- FLP and Console plugin via env GODEBUG
- Update kube-rbac-proxy to v0.14.4

Also bump all k8s / contorller-runtime dependencies Stop support for go1.19, add support for go1.21 (still uses 1.20 for builds)

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
