### PR TITLE
NETOBSERV-764: conversion fallback on ingester url

### DIFF
--- a/api/v1alpha1/flowcollector_webhook.go
+++ b/api/v1alpha1/flowcollector_webhook.go
@@ -142,6 +142,10 @@ func Convert_v1alpha1_FlowCollectorLoki_To_v1beta2_FlowCollectorLoki(in *FlowCol
 		TenantID:    in.TenantID,
 		AuthToken:   in.AuthToken,
 	}
+	// fallback on ingester url if querier is not set
+	if len(out.Manual.QuerierURL) == 0 {
+		out.Manual.QuerierURL = out.Manual.IngesterURL
+	}
 	if err := Convert_v1alpha1_ClientTLS_To_v1beta2_ClientTLS(&in.TLS, &out.Manual.TLS, nil); err != nil {
 		return fmt.Errorf("copying v1alpha1.Loki.TLS into v1beta2.Loki.Manual.TLS: %w", err)
 	}

--- a/api/v1beta1/flowcollector_webhook.go
+++ b/api/v1beta1/flowcollector_webhook.go
@@ -117,6 +117,10 @@ func Convert_v1beta1_FlowCollectorLoki_To_v1beta2_FlowCollectorLoki(in *FlowColl
 		TenantID:    in.TenantID,
 		AuthToken:   in.AuthToken,
 	}
+	// fallback on ingester url if querier is not set
+	if len(out.Manual.QuerierURL) == 0 {
+		out.Manual.QuerierURL = out.Manual.IngesterURL
+	}
 	if err := Convert_v1beta1_ClientTLS_To_v1beta2_ClientTLS(&in.TLS, &out.Manual.TLS, nil); err != nil {
 		return fmt.Errorf("copying v1beta1.Loki.TLS into v1beta2.Loki.Manual.TLS: %w", err)
 	}

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -466,13 +466,26 @@ metadata:
             "loki": {
               "batchSize": 10485760,
               "batchWait": "1s",
+              "enable": true,
               "lokiStack": {
                 "name": "loki"
               },
               "maxBackoff": "5s",
               "maxRetries": 2,
               "minBackoff": "1s",
-              "mode": "Monolithic"
+              "mode": "Monolithic",
+              "monolith": {
+                "tenantID": "netobserv",
+                "tls": {
+                  "caCert": {
+                    "certFile": "service-ca.crt",
+                    "name": "loki-gateway-ca-bundle",
+                    "type": "configmap"
+                  },
+                  "enable": false
+                },
+                "url": "http://loki.netobserv.svc:3100/"
+              }
             },
             "namespace": "netobserv",
             "processor": {

--- a/config/samples/flows_v1beta2_flowcollector.yaml
+++ b/config/samples/flows_v1beta2_flowcollector.yaml
@@ -77,10 +77,22 @@ spec:
         certFile: user.crt
         certKey: user.key
   loki:
+    enable: true
     # Change mode to "LokiStack" to use with the loki operator
     mode: Monolithic
+    monolith:
+      url: 'http://loki.netobserv.svc:3100/'
+      tenantID: netobserv 
+      tls:
+        enable: false
+        caCert:
+          type: configmap
+          name: loki-gateway-ca-bundle
+          certFile: service-ca.crt
     lokiStack:
       name: loki
+      # Change loki operator instance namespace
+      # namespace: loki-operator
     batchWait: 1s
     batchSize: 10485760
     minBackoff: 1s


### PR DESCRIPTION
## Description

This PR fix the empty loki querier url issue in conversion webhook

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
