### PR TITLE
NETOBSERV-1217: Added flag to enable multiCluster configuration

### DIFF
--- a/api/v1alpha1/flowcollector_webhook.go
+++ b/api/v1alpha1/flowcollector_webhook.go
@@ -65,6 +65,13 @@ func (r *FlowCollector) ConvertTo(dstRaw conversion.Hub) error {
 	if restored.Spec.Processor.Metrics.DisableAlerts != nil {
 		dst.Spec.Processor.Metrics.DisableAlerts = restored.Spec.Processor.Metrics.DisableAlerts
 	}
+	if restored.Spec.Processor.ClusterName != "" {
+		dst.Spec.Processor.ClusterName = restored.Spec.Processor.ClusterName
+	}
+	if restored.Spec.Processor.MultiClusterDeployment != nil {
+		dst.Spec.Processor.MultiClusterDeployment = restored.Spec.Processor.MultiClusterDeployment
+	}
+
 	dst.Spec.Processor.Metrics.Server.TLS.InsecureSkipVerify = restored.Spec.Processor.Metrics.Server.TLS.InsecureSkipVerify
 	dst.Spec.Processor.Metrics.Server.TLS.ProvidedCaFile = restored.Spec.Processor.Metrics.Server.TLS.ProvidedCaFile
 

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -720,6 +720,7 @@ func autoConvert_v1beta2_FlowCollectorFLP_To_v1alpha1_FlowCollectorFLP(in *v1bet
 	// WARNING: in.ConversationEndTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.ConversationTerminatingTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.ClusterName requires manual conversion: does not exist in peer-type
+	// WARNING: in.MultiClusterDeployment requires manual conversion: does not exist in peer-type
 	if err := Convert_v1beta2_DebugConfig_To_v1alpha1_DebugConfig(&in.Debug, &out.Debug, s); err != nil {
 		return err
 	}

--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -480,6 +480,10 @@ type FlowCollectorFLP struct {
 	// `clusterName` is the name of the cluster to appear in the flows data. This is useful in a multi-cluster context. When using OpenShift, leave empty to make it automatically determined.
 	ClusterName string `json:"clusterName,omitempty"`
 
+	//+kubebuilder:default:=false
+	// Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data
+	MultiClusterDeployment *bool `json:"multiClusterDeployment,omitempty"`
+
 	// `debug` allows setting some aspects of the internal configuration of the flow processor.
 	// This section is aimed exclusively for debugging and fine-grained performance optimizations,
 	// such as `GOGC` and `GOMAXPROCS` env vars. Users setting its values do it at their own risk.

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -681,6 +681,7 @@ func autoConvert_v1beta1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(in *FlowCo
 	out.ConversationEndTimeout = (*v1.Duration)(unsafe.Pointer(in.ConversationEndTimeout))
 	out.ConversationTerminatingTimeout = (*v1.Duration)(unsafe.Pointer(in.ConversationTerminatingTimeout))
 	out.ClusterName = in.ClusterName
+	out.MultiClusterDeployment = (*bool)(unsafe.Pointer(in.MultiClusterDeployment))
 	if err := Convert_v1beta1_DebugConfig_To_v1beta2_DebugConfig(&in.Debug, &out.Debug, s); err != nil {
 		return err
 	}
@@ -715,6 +716,7 @@ func autoConvert_v1beta2_FlowCollectorFLP_To_v1beta1_FlowCollectorFLP(in *v1beta
 	out.ConversationEndTimeout = (*v1.Duration)(unsafe.Pointer(in.ConversationEndTimeout))
 	out.ConversationTerminatingTimeout = (*v1.Duration)(unsafe.Pointer(in.ConversationTerminatingTimeout))
 	out.ClusterName = in.ClusterName
+	out.MultiClusterDeployment = (*bool)(unsafe.Pointer(in.MultiClusterDeployment))
 	if err := Convert_v1beta2_DebugConfig_To_v1beta1_DebugConfig(&in.Debug, &out.Debug, s); err != nil {
 		return err
 	}

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -352,6 +352,11 @@ func (in *FlowCollectorFLP) DeepCopyInto(out *FlowCollectorFLP) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.MultiClusterDeployment != nil {
+		in, out := &in.MultiClusterDeployment, &out.MultiClusterDeployment
+		*out = new(bool)
+		**out = **in
+	}
 	in.Debug.DeepCopyInto(&out.Debug)
 }
 

--- a/api/v1beta2/flowcollector_types.go
+++ b/api/v1beta2/flowcollector_types.go
@@ -472,6 +472,10 @@ type FlowCollectorFLP struct {
 	// `clusterName` is the name of the cluster to appear in the flows data. This is useful in a multi-cluster context. When using OpenShift, leave empty to make it automatically determined.
 	ClusterName string `json:"clusterName,omitempty"`
 
+	//+kubebuilder:default:=false
+	// Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data
+	MultiClusterDeployment *bool `json:"multiClusterDeployment,omitempty"`
+
 	// `debug` allows setting some aspects of the internal configuration of the flow processor.
 	// This section is aimed exclusively for debugging and fine-grained performance optimizations,
 	// such as `GOGC` and `GOMAXPROCS` env vars. Users setting its values do it at their own risk.

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -347,6 +347,11 @@ func (in *FlowCollectorFLP) DeepCopyInto(out *FlowCollectorFLP) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.MultiClusterDeployment != nil {
+		in, out := &in.MultiClusterDeployment, &out.MultiClusterDeployment
+		*out = new(bool)
+		**out = **in
+	}
 	in.Debug.DeepCopyInto(&out.Debug)
 }
 

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -4941,6 +4941,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  multiClusterDeployment:
+                    default: false
+                    description: Set `multiClusterDeployment` to `true` to enable
+                      multi clusters feature. This will add clusterName label to flows
+                      data
+                    type: boolean
                   port:
                     default: 2055
                     description: Port of the flow collector (host port). By convention,
@@ -7817,6 +7823,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  multiClusterDeployment:
+                    default: false
+                    description: Set `multiClusterDeployment` to `true` to enable
+                      multi clusters feature. This will add clusterName label to flows
+                      data
+                    type: boolean
                   port:
                     default: 2055
                     description: Port of the flow collector (host port). By convention,

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -4927,6 +4927,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  multiClusterDeployment:
+                    default: false
+                    description: Set `multiClusterDeployment` to `true` to enable
+                      multi clusters feature. This will add clusterName label to flows
+                      data
+                    type: boolean
                   port:
                     default: 2055
                     description: Port of the flow collector (host port). By convention,
@@ -7803,6 +7809,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  multiClusterDeployment:
+                    default: false
+                    description: Set `multiClusterDeployment` to `true` to enable
+                      multi clusters feature. This will add clusterName label to flows
+                      data
+                    type: boolean
                   port:
                     default: 2055
                     description: Port of the flow collector (host port). By convention,

--- a/controllers/flowcollector_controller_iso_test.go
+++ b/controllers/flowcollector_controller_iso_test.go
@@ -70,6 +70,7 @@ func flowCollectorIsoSpecs() {
 				ConversationHeartbeatInterval:  &metav1.Duration{Duration: time.Second},
 				ConversationEndTimeout:         &metav1.Duration{Duration: time.Second},
 				ConversationTerminatingTimeout: &metav1.Duration{Duration: time.Second},
+				MultiClusterDeployment:         ptr.To(true),
 				ClusterName:                    "testCluster",
 				Debug:                          flowslatest.DebugConfig{},
 				LogTypes:                       &outputRecordTypes,

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -7538,6 +7538,15 @@ TLS client configuration for Loki URL.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>multiClusterDeployment</b></td>
+        <td>boolean</td>
+        <td>
+          Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>port</b></td>
         <td>integer</td>
         <td>
@@ -12705,6 +12714,15 @@ TLS client configuration for Loki URL.
         <td>object</td>
         <td>
           `Metrics` define the processor configuration regarding metrics<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>multiClusterDeployment</b></td>
+        <td>boolean</td>
+        <td>
+          Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data<br/>
+          <br/>
+            <i>Default</i>: false<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/hack/cloned.flows.netobserv.io_flowcollectors.yaml
+++ b/hack/cloned.flows.netobserv.io_flowcollectors.yaml
@@ -3414,6 +3414,10 @@ spec:
                               type: object
                           type: object
                       type: object
+                    multiClusterDeployment:
+                      default: false
+                      description: Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data
+                      type: boolean
                     port:
                       default: 2055
                       description: Port of the flow collector (host port). By convention, some values are forbidden. It must be greater than 1024 and different from 4500, 4789 and 6081.
@@ -5395,6 +5399,10 @@ spec:
                               type: object
                           type: object
                       type: object
+                    multiClusterDeployment:
+                      default: false
+                      description: Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data
+                      type: boolean
                     port:
                       default: 2055
                       description: Port of the flow collector (host port). By convention, some values are forbidden. It must be greater than 1024 and different from 4500, 4789 and 6081.


### PR DESCRIPTION
## Description

- ensure cluster id is Loki label
- don't append it if not in multicluster environment


## Dependencies
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
