### PR TITLE
Fix loki manual params doc

### DIFF
--- a/api/v1beta2/flowcollector_types.go
+++ b/api/v1beta2/flowcollector_types.go
@@ -521,16 +521,15 @@ type LokiManualParams struct {
 	// https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.
 	IngesterURL string `json:"ingesterUrl,omitempty"`
 
-	//+kubebuilder:validation:optional
-	// `querierURL` specifies the address of the Loki querier service, in case it is different from the
-	// Loki ingester URL. If empty, the URL value is used (assuming that the Loki ingester
-	// and querier are in the same server). When using the Loki Operator, do not set it, since
-	// ingestion and queries use the Loki gateway.
+	//+kubebuilder:default:="http://loki:3100/"
+	// `querierUrl` specifies the address of the Loki querier service.
+	// When using the Loki Operator, set it to the Loki gateway service with the `network` tenant set in path, for example
+	// https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.
 	QuerierURL string `json:"querierUrl,omitempty"`
 
 	//+kubebuilder:validation:optional
-	// `statusURL` specifies the address of the Loki `/ready`, `/metrics` and `/config` endpoints, in case it is different from the
-	// Loki querier URL. If empty, the `querierURL` value is used.
+	// `statusUrl` specifies the address of the Loki `/ready`, `/metrics` and `/config` endpoints, in case it is different from the
+	// Loki querier URL. If empty, the `querierUrl` value is used.
 	// This is useful to show error messages and some context in the frontend.
 	// When using the Loki Operator, set it to the Loki HTTP query frontend service, for example
 	// https://loki-query-frontend-http.netobserv.svc:3100/.

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -6566,12 +6566,11 @@ spec:
                           `network` tenant set in path, for example https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.'
                         type: string
                       querierUrl:
-                        description: '`querierURL` specifies the address of the Loki
-                          querier service, in case it is different from the Loki ingester
-                          URL. If empty, the URL value is used (assuming that the
-                          Loki ingester and querier are in the same server). When
-                          using the Loki Operator, do not set it, since ingestion
-                          and queries use the Loki gateway.'
+                        default: http://loki:3100/
+                        description: '`querierUrl` specifies the address of the Loki
+                          querier service. When using the Loki Operator, set it to
+                          the Loki gateway service with the `network` tenant set in
+                          path, for example https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.'
                         type: string
                       statusTls:
                         description: TLS client configuration for Loki status URL.
@@ -6657,9 +6656,9 @@ spec:
                             type: object
                         type: object
                       statusUrl:
-                        description: '`statusURL` specifies the address of the Loki
+                        description: '`statusUrl` specifies the address of the Loki
                           `/ready`, `/metrics` and `/config` endpoints, in case it
-                          is different from the Loki querier URL. If empty, the `querierURL`
+                          is different from the Loki querier URL. If empty, the `querierUrl`
                           value is used. This is useful to show error messages and
                           some context in the frontend. When using the Loki Operator,
                           set it to the Loki HTTP query frontend service, for example

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -6552,12 +6552,11 @@ spec:
                           `network` tenant set in path, for example https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.'
                         type: string
                       querierUrl:
-                        description: '`querierURL` specifies the address of the Loki
-                          querier service, in case it is different from the Loki ingester
-                          URL. If empty, the URL value is used (assuming that the
-                          Loki ingester and querier are in the same server). When
-                          using the Loki Operator, do not set it, since ingestion
-                          and queries use the Loki gateway.'
+                        default: http://loki:3100/
+                        description: '`querierUrl` specifies the address of the Loki
+                          querier service. When using the Loki Operator, set it to
+                          the Loki gateway service with the `network` tenant set in
+                          path, for example https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.'
                         type: string
                       statusTls:
                         description: TLS client configuration for Loki status URL.
@@ -6643,9 +6642,9 @@ spec:
                             type: object
                         type: object
                       statusUrl:
-                        description: '`statusURL` specifies the address of the Loki
+                        description: '`statusUrl` specifies the address of the Loki
                           `/ready`, `/metrics` and `/config` endpoints, in case it
-                          is different from the Loki querier URL. If empty, the `querierURL`
+                          is different from the Loki querier URL. If empty, the `querierUrl`
                           value is used. This is useful to show error messages and
                           some context in the frontend. When using the Loki Operator,
                           set it to the Loki HTTP query frontend service, for example

--- a/controllers/flowcollector_controller_iso_test.go
+++ b/controllers/flowcollector_controller_iso_test.go
@@ -138,7 +138,7 @@ func flowCollectorIsoSpecs() {
 				Mode:   flowslatest.LokiModeManual,
 				Manual: flowslatest.LokiManualParams{
 					IngesterURL: "http://loki",
-					QuerierURL:  "",
+					QuerierURL:  "http://loki",
 					StatusURL:   "",
 					TenantID:    "test",
 					AuthToken:   "DISABLED",

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -11720,7 +11720,9 @@ Loki configuration for "Manual" mode. This is the most flexible configuration. I
         <td><b>querierUrl</b></td>
         <td>string</td>
         <td>
-          `querierURL` specifies the address of the Loki querier service, in case it is different from the Loki ingester URL. If empty, the URL value is used (assuming that the Loki ingester and querier are in the same server). When using the Loki Operator, do not set it, since ingestion and queries use the Loki gateway.<br/>
+          `querierUrl` specifies the address of the Loki querier service. When using the Loki Operator, set it to the Loki gateway service with the `network` tenant set in path, for example https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.<br/>
+          <br/>
+            <i>Default</i>: http://loki:3100/<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -11734,7 +11736,7 @@ Loki configuration for "Manual" mode. This is the most flexible configuration. I
         <td><b>statusUrl</b></td>
         <td>string</td>
         <td>
-          `statusURL` specifies the address of the Loki `/ready`, `/metrics` and `/config` endpoints, in case it is different from the Loki querier URL. If empty, the `querierURL` value is used. This is useful to show error messages and some context in the frontend. When using the Loki Operator, set it to the Loki HTTP query frontend service, for example https://loki-query-frontend-http.netobserv.svc:3100/. `statusTLS` configuration is used when `statusUrl` is set.<br/>
+          `statusUrl` specifies the address of the Loki `/ready`, `/metrics` and `/config` endpoints, in case it is different from the Loki querier URL. If empty, the `querierUrl` value is used. This is useful to show error messages and some context in the frontend. When using the Loki Operator, set it to the Loki HTTP query frontend service, for example https://loki-query-frontend-http.netobserv.svc:3100/. `statusTLS` configuration is used when `statusUrl` is set.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/hack/cloned.flows.netobserv.io_flowcollectors.yaml
+++ b/hack/cloned.flows.netobserv.io_flowcollectors.yaml
@@ -4560,7 +4560,8 @@ spec:
                           description: '`ingesterUrl` is the address of an existing Loki ingester service to push the flows to. When using the Loki Operator, set it to the Loki gateway service with the `network` tenant set in path, for example https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.'
                           type: string
                         querierUrl:
-                          description: '`querierURL` specifies the address of the Loki querier service, in case it is different from the Loki ingester URL. If empty, the URL value is used (assuming that the Loki ingester and querier are in the same server). When using the Loki Operator, do not set it, since ingestion and queries use the Loki gateway.'
+                          default: http://loki:3100/
+                          description: '`querierUrl` specifies the address of the Loki querier service. When using the Loki Operator, set it to the Loki gateway service with the `network` tenant set in path, for example https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.'
                           type: string
                         statusTls:
                           description: TLS client configuration for Loki status URL.
@@ -4621,7 +4622,7 @@ spec:
                               type: object
                           type: object
                         statusUrl:
-                          description: '`statusURL` specifies the address of the Loki `/ready`, `/metrics` and `/config` endpoints, in case it is different from the Loki querier URL. If empty, the `querierURL` value is used. This is useful to show error messages and some context in the frontend. When using the Loki Operator, set it to the Loki HTTP query frontend service, for example https://loki-query-frontend-http.netobserv.svc:3100/. `statusTLS` configuration is used when `statusUrl` is set.'
+                          description: '`statusUrl` specifies the address of the Loki `/ready`, `/metrics` and `/config` endpoints, in case it is different from the Loki querier URL. If empty, the `querierUrl` value is used. This is useful to show error messages and some context in the frontend. When using the Loki Operator, set it to the Loki HTTP query frontend service, for example https://loki-query-frontend-http.netobserv.svc:3100/. `statusTLS` configuration is used when `statusUrl` is set.'
                           type: string
                         tenantID:
                           default: netobserv


### PR DESCRIPTION
## Description

CRD doc fixes for loki manual params (explicit urls)

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
