### PR TITLE
NETOBSERV-1398: fix loki url when same namespace

### DIFF
--- a/api/v1alpha1/flowcollector_webhook.go
+++ b/api/v1alpha1/flowcollector_webhook.go
@@ -118,7 +118,8 @@ func Convert_v1beta2_FLPMetrics_To_v1alpha1_FLPMetrics(in *v1beta2.FLPMetrics, o
 // we have new defined fields in v1beta2 not in v1alpha1
 // nolint:golint,stylecheck,revive
 func Convert_v1beta2_FlowCollectorLoki_To_v1alpha1_FlowCollectorLoki(in *v1beta2.FlowCollectorLoki, out *FlowCollectorLoki, s apiconversion.Scope) error {
-	manual := helper.NewLokiConfig(in)
+	// Note that, despite we loose namespace info here, this isn't an issue because it's going to be restored from annotations
+	manual := helper.NewLokiConfig(in, "")
 	out.URL = manual.IngesterURL
 	out.QuerierURL = manual.QuerierURL
 	out.StatusURL = manual.StatusURL

--- a/api/v1beta1/flowcollector_webhook.go
+++ b/api/v1beta1/flowcollector_webhook.go
@@ -90,7 +90,8 @@ func Convert_v1beta2_FLPMetrics_To_v1beta1_FLPMetrics(in *v1beta2.FLPMetrics, ou
 // we have new defined fields in v1beta2 not in v1beta1
 // nolint:golint,stylecheck,revive
 func Convert_v1beta2_FlowCollectorLoki_To_v1beta1_FlowCollectorLoki(in *v1beta2.FlowCollectorLoki, out *FlowCollectorLoki, s apiconversion.Scope) error {
-	manual := helper.NewLokiConfig(in)
+	// Note that, despite we loose namespace info here, this isn't an issue because it's going to be restored from annotations
+	manual := helper.NewLokiConfig(in, "")
 	out.URL = manual.IngesterURL
 	out.QuerierURL = manual.QuerierURL
 	out.StatusURL = manual.StatusURL

--- a/controllers/consoleplugin/consoleplugin_test.go
+++ b/controllers/consoleplugin/consoleplugin_test.go
@@ -238,7 +238,7 @@ func TestContainerUpdateWithLokistackMode(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "lokistack", Namespace: "ls-namespace"},
 	}
-	loki := helper.NewLokiConfig(&lokiSpec)
+	loki := helper.NewLokiConfig(&lokiSpec, "any")
 	spec := flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: lokiSpec}
 	builder := newBuilder(testNamespace, testImage, &spec, &loki)
 	old := builder.deployment("digest")
@@ -249,7 +249,7 @@ func TestContainerUpdateWithLokistackMode(t *testing.T) {
 
 	//update lokistack name
 	lokiSpec.LokiStack.Name = "lokistack-updated"
-	loki = helper.NewLokiConfig(&lokiSpec)
+	loki = helper.NewLokiConfig(&lokiSpec, "any")
 
 	spec = flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: lokiSpec}
 	builder = newBuilder(testNamespace, testImage, &spec, &loki)
@@ -261,7 +261,7 @@ func TestContainerUpdateWithLokistackMode(t *testing.T) {
 
 	//update lokistack namespace
 	lokiSpec.LokiStack.Namespace = "ls-namespace-updated"
-	loki = helper.NewLokiConfig(&lokiSpec)
+	loki = helper.NewLokiConfig(&lokiSpec, "any")
 
 	spec = flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: lokiSpec}
 	builder = newBuilder(testNamespace, testImage, &spec, &loki)

--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -119,7 +119,7 @@ func (r *FlowCollectorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 		}
 	}
 
-	loki := helper.NewLokiConfig(&desired.Spec.Loki)
+	loki := helper.NewLokiConfig(&desired.Spec.Loki, ns)
 	reconcilersInfo := r.newCommonInfo(ctx, desired, ns, previousNamespace, &loki, func(b bool) { didChange = b }, func(b bool) { isInProgress = b })
 
 	err = r.reconcileOperator(ctx, &reconcilersInfo, desired)

--- a/controllers/flowlogspipeline/flp_test.go
+++ b/controllers/flowlogspipeline/flp_test.go
@@ -185,14 +185,14 @@ func getAutoScalerSpecs() (ascv2.HorizontalPodAutoscaler, flowslatest.FlowCollec
 }
 
 func monoBuilder(ns string, cfg *flowslatest.FlowCollectorSpec) monolithBuilder {
-	loki := helper.NewLokiConfig(&cfg.Loki)
+	loki := helper.NewLokiConfig(&cfg.Loki, "any")
 	info := reconcilers.Common{Namespace: ns, Loki: &loki}
 	b, _ := newMonolithBuilder(info.NewInstance(image), cfg)
 	return b
 }
 
 func transfBuilder(ns string, cfg *flowslatest.FlowCollectorSpec) transfoBuilder {
-	loki := helper.NewLokiConfig(&cfg.Loki)
+	loki := helper.NewLokiConfig(&cfg.Loki, "any")
 	info := reconcilers.Common{Namespace: ns, Loki: &loki}
 	b, _ := newTransfoBuilder(info.NewInstance(image), cfg)
 	return b

--- a/pkg/helper/loki_config.go
+++ b/pkg/helper/loki_config.go
@@ -19,7 +19,7 @@ type LokiConfig struct {
 	StaticLabels map[string]string
 }
 
-func NewLokiConfig(spec *flowslatest.FlowCollectorLoki) LokiConfig {
+func NewLokiConfig(spec *flowslatest.FlowCollectorLoki, namespace string) LokiConfig {
 	loki := LokiConfig{
 		BatchWait:    spec.BatchWait,
 		BatchSize:    spec.BatchSize,
@@ -31,15 +31,15 @@ func NewLokiConfig(spec *flowslatest.FlowCollectorLoki) LokiConfig {
 	}
 	switch spec.Mode {
 	case flowslatest.LokiModeLokiStack:
-		dotNamespace := ""
+		ns := namespace
 		if len(spec.LokiStack.Namespace) > 0 {
-			dotNamespace = "." + spec.LokiStack.Namespace
+			ns = spec.LokiStack.Namespace
 		}
-		gatewayURL := fmt.Sprintf("https://%s-gateway-http%s.svc:8080/api/logs/v1/network/", spec.LokiStack.Name, dotNamespace)
+		gatewayURL := fmt.Sprintf("https://%s-gateway-http.%s.svc:8080/api/logs/v1/network/", spec.LokiStack.Name, ns)
 		loki.LokiManualParams = flowslatest.LokiManualParams{
 			QuerierURL:  gatewayURL,
 			IngesterURL: gatewayURL,
-			StatusURL:   fmt.Sprintf("https://%s-query-frontend-http%s.svc:3100/", spec.LokiStack.Name, dotNamespace),
+			StatusURL:   fmt.Sprintf("https://%s-query-frontend-http.%s.svc:3100/", spec.LokiStack.Name, ns),
 			TenantID:    "network",
 			AuthToken:   flowslatest.LokiAuthForwardUserToken,
 			TLS: flowslatest.ClientTLS{


### PR DESCRIPTION
## Description

Host like "loki-gateway-http.svc" seem invalid

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
