### PR TITLE
NETOBSERV-1400 Feature filters are observed even though they are not enabled

### DIFF
--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -305,17 +305,17 @@ columns:
     width: 15
   - id: K8S_Object
     name: Kubernetes Objects
-    calculated: '[getConcatenatedValue(SrcAddr,SrcPort,SrcK8S_Type,SrcK8S_Namespace,SrcK8S_Name),getConcatenatedValue(DstAddr,DstPort,DstK8S_Type,DstK8S_Namespace,DstK8S_Name)]'
+    calculated: '[column.SrcK8S_Object,column.DstK8S_Object]'
     default: false
     width: 15
   - id: K8S_OwnerObject
     name: Owner Kubernetes Objects
-    calculated: '[getConcatenatedValue(SrcAddr,SrcPort,SrcK8S_OwnerType,SrcK8S_Namespace,SrcK8S_OwnerName),getConcatenatedValue(DstAddr,DstPort,DstK8S_OwnerType,DstK8S_Namespace,DstK8S_OwnerName)]'
+    calculated: '[column.SrcK8S_OwnerObject,column.DstK8S_OwnerObject]'
     default: false
     width: 15
   - id: AddrPort
     name: IPs & Ports
-    calculated: '[getConcatenatedValue(SrcAddr,SrcPort),getConcatenatedValue(DstAddr,DstPort)]'
+    calculated: '[column.SrcAddrPort,column.DstAddrPort]'
     default: false
     width: 15
   - id: Proto
@@ -340,15 +340,15 @@ columns:
     tooltip: The type of the ICMP message
     field: IcmpType
     filter: icmp_type
-    default: true
+    default: false
     width: 10
   - id: IcmpCode
     group: ICMP
     name: Code
     tooltip: The code of the ICMP message
     field: IcmpCode
-    quickFilter: icmp_code
-    default: true
+    filter: icmp_code
+    default: false
     width: 10
   - id: FlowDirection
     name: Direction
@@ -380,24 +380,20 @@ columns:
   - id: FlowDuration
     name: Duration
     tooltip: Time elapsed between Start Time and End Time.
+    calculated: substract(TimeFlowEndMs,TimeFlowStartMs)
     default: false
-    width: 5
-  - id: TimeFlowRttMs
-    name: Flow RTT
-    tooltip: TCP handshake Round Trip Time
-    field: TimeFlowRttNs
-    filter: time_flow_rtt
-    default: true
     width: 5
   - id: CollectionTime
     name: Collection Time
     tooltip: Reception time of the record by the collector.
+    calculated: multiply(TimeReceived,1000),
     field: TimeReceived
     default: false
     width: 15
   - id: CollectionLatency
     name: Collection Latency
     tooltip: Time elapsed between End Time and Collection Time.
+    calculated: substract(column.CollectionTime,TimeFlowEndMs)
     default: false
     width: 5
   - id: DNSId
@@ -412,6 +408,8 @@ columns:
     group: DNS
     name: DNS Latency
     tooltip: Time elapsed between DNS request and response.
+    field: DnsLatencyMs
+    filter: dns_latency
     default: true
     width: 5
   - id: DNSResponseCode
@@ -429,6 +427,13 @@ columns:
     field: DnsErrno
     filter: dns_errno
     default: false
+    width: 5
+  - id: TimeFlowRttMs
+    name: Flow RTT
+    tooltip: TCP handshake Round Trip Time
+    field: TimeFlowRttNs
+    filter: time_flow_rtt
+    default: true
     width: 5
 filters:
   - id: src_namespace
@@ -703,10 +708,6 @@ filters:
     component: text
     placeholder: 'E.g: br-ex, ovn-k8s-mp0'
     hint: Specify a network interface.
-  - id: dscp
-    name: DSCP value
-    component: number
-    hint: Specify a Differentiated Services Code Point value as integer number.
   - id: id
     name: Conversation Id
     component: text


### PR DESCRIPTION
## Description

- remove duplicate DSCP field
- fix fields :
  - DNSLatency 
  - Duration
  - Collection time
  - Collection latency
- ICMP removed from default
- fix ICMP code filter

## Dependencies

https://github.com/netobserv/network-observability-console-plugin/pull/427/files

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
