### PR TITLE
WIP: DNM: hacking operator to test optel instrumentation to ebpf agent ds

### DIFF
--- a/config/samples/flows_v1beta2_flowcollector.yaml
+++ b/config/samples/flows_v1beta2_flowcollector.yaml
@@ -12,7 +12,7 @@ spec:
       sampling: 50
       cacheActiveTimeout: 5s
       cacheMaxFlows: 100000
-      privileged: false
+      privileged: true
       # features: 
       # - "PacketDrop"
       # - "DNSTracking"

--- a/controllers/ebpf/internal/permissions/permissions.go
+++ b/controllers/ebpf/internal/permissions/permissions.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var AllowedCapabilities = []v1.Capability{"BPF", "PERFMON", "NET_ADMIN", "SYS_RESOURCE"}
+var AllowedCapabilities = []v1.Capability{"BPF", "PERFMON", "NET_ADMIN", "SYS_RESOURCE", "SYS_PTRACE"}
 
 // Reconciler reconciles the different resources to enable the privileged operation of the
 // Netobserv Agent:


### PR DESCRIPTION
## Description
https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/520
used to track this instrumentaton process this PR just to help repro the issue

![netobserv-agent-optel drawio](https://github.com/netobserv/network-observability-operator/assets/12748167/63bb9891-5def-4ec7-96a5-0e358ddad7f0)

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
