### PR TITLE
NETOBSERV-1298: Add netobserv operator changes to support dup list

### DIFF
--- a/controllers/consoleplugin/config/config.go
+++ b/controllers/consoleplugin/config/config.go
@@ -62,11 +62,17 @@ type FilterConfig struct {
 	Placeholder            string `yaml:"placeholder,omitempty" json:"placeholder,omitempty"`
 }
 
+type Deduper struct {
+	Mark  bool `yaml:"mark" json:"mark"`
+	Merge bool `yaml:"merge" json:"merge"`
+}
+
 type FrontendConfig struct {
 	RecordTypes []string       `yaml:"recordTypes" json:"recordTypes"`
 	Columns     []ColumnConfig `yaml:"columns" json:"columns"`
 	Sampling    int            `yaml:"sampling" json:"sampling"`
 	Features    []string       `yaml:"features" json:"features"`
+	Deduper     Deduper        `yaml:"deduper" json:"deduper"`
 
 	PortNaming      flowslatest.ConsolePluginPortConfig `yaml:"portNaming,omitempty" json:"portNaming,omitempty"`
 	Filters         []FilterConfig                      `yaml:"filters,omitempty" json:"filters,omitempty"`

--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -357,6 +357,12 @@ columns:
     filter: direction
     default: false
     width: 10
+  - id: FlowDirections
+    name: Directions
+    tooltip: All the direction of the Flow observed at the Node observation point.
+    field: FlowDirections
+    default: false
+    width: 15
   - id: Interface
     name: Interface
     tooltip: The network interface of the Flow.
@@ -364,6 +370,12 @@ columns:
     filter: interface
     default: false
     width: 10
+  - id: Interfaces
+    name: Interfaces
+    tooltip: The network interfaces of the Flow.
+    field: Interfaces
+    default: false
+    width: 15
   - id: Bytes
     name: Bytes
     tooltip: The total aggregated number of bytes.

--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -357,12 +357,6 @@ columns:
     filter: direction
     default: false
     width: 10
-  - id: FlowDirections
-    name: Directions
-    tooltip: All the direction of the Flow observed at the Node observation point.
-    field: FlowDirections
-    default: false
-    width: 15
   - id: Interface
     name: Interface
     tooltip: The network interface of the Flow.
@@ -370,10 +364,10 @@ columns:
     filter: interface
     default: false
     width: 10
-  - id: Interfaces
-    name: Interfaces
-    tooltip: The network interfaces of the Flow.
-    field: Interfaces
+  - id: FlowDirInts
+    name: Interfaces and Directions
+    tooltip: Pairs of network interface and direction of the Flow observed at the Node observation point.
+    field: FlowDirection
     default: false
     width: 15
   - id: Bytes

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -51,10 +51,6 @@ const (
 	envLogLevel                   = "LOG_LEVEL"
 	envDedupe                     = "DEDUPER"
 	dedupeDefault                 = "firstCome"
-	envDedupeJustMark             = "DEDUPER_JUST_MARK"
-	envDedupeMerge                = "DEDUPER_MERGE"
-	dedupeJustMarkDefault         = "true"
-	dedupeMergeDefault            = "false"
 	envGoMemLimit                 = "GOMEMLIMIT"
 	envEnablePktDrop              = "ENABLE_PKT_DROPS"
 	envEnableDNSTracking          = "ENABLE_DNS_TRACKING"
@@ -71,6 +67,13 @@ const (
 	bpfTraceMountPath  = "/sys/kernel/debug"
 	bpfNetNSMountName  = "var-run-netns"
 	bpfNetNSMountPath  = "/var/run/netns"
+)
+
+const (
+	EnvDedupeJustMark     = "DEDUPER_JUST_MARK"
+	EnvDedupeMerge        = "DEDUPER_MERGE"
+	DedupeJustMarkDefault = "true"
+	DedupeMergeDefault    = "false"
 )
 
 type reconcileAction int
@@ -462,24 +465,24 @@ func (c *AgentController) setEnvConfig(coll *flowslatest.FlowCollector) []corev1
 	}
 
 	dedup := dedupeDefault
-	dedupJustMark := dedupeJustMarkDefault
-	dedupMerge := dedupeMergeDefault
+	dedupJustMark := DedupeJustMarkDefault
+	dedupMerge := DedupeMergeDefault
 	// we need to sort env map to keep idempotency,
 	// as equal maps could be iterated in different order
 	for _, pair := range helper.KeySorted(coll.Spec.Agent.EBPF.Debug.Env) {
 		k, v := pair[0], pair[1]
 		if k == envDedupe {
 			dedup = v
-		} else if k == envDedupeJustMark {
+		} else if k == EnvDedupeJustMark {
 			dedupJustMark = v
-		} else if k == envDedupeMerge {
+		} else if k == EnvDedupeMerge {
 			dedupMerge = v
 		} else {
 			config = append(config, corev1.EnvVar{Name: k, Value: v})
 		}
 	}
 	config = append(config, corev1.EnvVar{Name: envDedupe, Value: dedup})
-	config = append(config, corev1.EnvVar{Name: envDedupeJustMark, Value: dedupJustMark})
+	config = append(config, corev1.EnvVar{Name: EnvDedupeJustMark, Value: dedupJustMark})
 	config = append(config, corev1.EnvVar{
 		Name: envAgentIP,
 		ValueFrom: &corev1.EnvVarSource{
@@ -490,7 +493,7 @@ func (c *AgentController) setEnvConfig(coll *flowslatest.FlowCollector) []corev1
 		},
 	},
 	)
-	config = append(config, corev1.EnvVar{Name: envDedupeMerge, Value: dedupMerge})
+	config = append(config, corev1.EnvVar{Name: EnvDedupeMerge, Value: dedupMerge})
 
 	return config
 }

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -52,7 +52,9 @@ const (
 	envDedupe                     = "DEDUPER"
 	dedupeDefault                 = "firstCome"
 	envDedupeJustMark             = "DEDUPER_JUST_MARK"
+	envDedupeMerge                = "DEDUPER_MERGE"
 	dedupeJustMarkDefault         = "true"
+	dedupeMergeDefault            = "false"
 	envGoMemLimit                 = "GOMEMLIMIT"
 	envEnablePktDrop              = "ENABLE_PKT_DROPS"
 	envEnableDNSTracking          = "ENABLE_DNS_TRACKING"
@@ -461,6 +463,7 @@ func (c *AgentController) setEnvConfig(coll *flowslatest.FlowCollector) []corev1
 
 	dedup := dedupeDefault
 	dedupJustMark := dedupeJustMarkDefault
+	dedupMerge := dedupeMergeDefault
 	// we need to sort env map to keep idempotency,
 	// as equal maps could be iterated in different order
 	for _, pair := range helper.KeySorted(coll.Spec.Agent.EBPF.Debug.Env) {
@@ -469,6 +472,8 @@ func (c *AgentController) setEnvConfig(coll *flowslatest.FlowCollector) []corev1
 			dedup = v
 		} else if k == envDedupeJustMark {
 			dedupJustMark = v
+		} else if k == envDedupeMerge {
+			dedupMerge = v
 		} else {
 			config = append(config, corev1.EnvVar{Name: k, Value: v})
 		}
@@ -485,6 +490,7 @@ func (c *AgentController) setEnvConfig(coll *flowslatest.FlowCollector) []corev1
 		},
 	},
 	)
+	config = append(config, corev1.EnvVar{Name: envDedupeMerge, Value: dedupMerge})
 
 	return config
 }


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
