### PR TITLE
NETOBSERV-1406 Remove RTT unsupported mentions

### DIFF
--- a/api/v1beta2/flowcollector_types.go
+++ b/api/v1beta2/flowcollector_types.go
@@ -147,7 +147,7 @@ type FlowCollectorIPFIX struct {
 // Agent feature, can be one of:<br>
 // - `PacketDrop`, to track packet drops.<br>
 // - `DNSTracking`, to track specific information on DNS traffic.<br>
-// - `FlowRTT`, to track TCP latency. [Unsupported (*)].<br>
+// - `FlowRTT`, to track TCP latency.<br>
 // +kubebuilder:validation:Enum:="PacketDrop";"DNSTracking";"FlowRTT"
 type AgentFeature string
 
@@ -235,7 +235,7 @@ type FlowCollectorEBPF struct {
 	// the kernel debug filesystem, so the eBPF pod has to run as privileged.
 	// If the `spec.agent.eBPF.privileged` parameter is not set, an error is reported.<br>
 	// - `DNSTracking`: enable the DNS tracking feature.<br>
-	// - `FlowRTT` [unsupported (*)]: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br>
+	// - `FlowRTT`: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br>
 	// +optional
 	Features []AgentFeature `json:"features,omitempty"`
 }

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -5239,15 +5239,15 @@ spec:
                           This feature requires mounting the kernel debug filesystem,
                           so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged`
                           parameter is not set, an error is reported.<br> - `DNSTracking`:
-                          enable the DNS tracking feature.<br> - `FlowRTT` [unsupported
-                          (*)]: enable flow latency (RTT) calculations in the eBPF
-                          agent during TCP handshakes. This feature better works with
-                          `sampling` set to 1.<br>'
+                          enable the DNS tracking feature.<br> - `FlowRTT`: enable
+                          flow latency (RTT) calculations in the eBPF agent during
+                          TCP handshakes. This feature better works with `sampling`
+                          set to 1.<br>'
                         items:
                           description: Agent feature, can be one of:<br> - `PacketDrop`,
                             to track packet drops.<br> - `DNSTracking`, to track specific
                             information on DNS traffic.<br> - `FlowRTT`, to track
-                            TCP latency. [Unsupported (*)].<br>
+                            TCP latency.<br>
                           enum:
                           - PacketDrop
                           - DNSTracking

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -5225,15 +5225,15 @@ spec:
                           This feature requires mounting the kernel debug filesystem,
                           so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged`
                           parameter is not set, an error is reported.<br> - `DNSTracking`:
-                          enable the DNS tracking feature.<br> - `FlowRTT` [unsupported
-                          (*)]: enable flow latency (RTT) calculations in the eBPF
-                          agent during TCP handshakes. This feature better works with
-                          `sampling` set to 1.<br>'
+                          enable the DNS tracking feature.<br> - `FlowRTT`: enable
+                          flow latency (RTT) calculations in the eBPF agent during
+                          TCP handshakes. This feature better works with `sampling`
+                          set to 1.<br>'
                         items:
                           description: Agent feature, can be one of:<br> - `PacketDrop`,
                             to track packet drops.<br> - `DNSTracking`, to track specific
                             information on DNS traffic.<br> - `FlowRTT`, to track
-                            TCP latency. [Unsupported (*)].<br>
+                            TCP latency.<br>
                           enum:
                           - PacketDrop
                           - DNSTracking

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -9200,7 +9200,7 @@ Agent configuration for flows extraction.
         <td><b>features</b></td>
         <td>[]enum</td>
         <td>
-          List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are:<br> - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting the kernel debug filesystem, so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged` parameter is not set, an error is reported.<br> - `DNSTracking`: enable the DNS tracking feature.<br> - `FlowRTT` [unsupported (*)]: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br><br/>
+          List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are:<br> - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting the kernel debug filesystem, so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged` parameter is not set, an error is reported.<br> - `DNSTracking`: enable the DNS tracking feature.<br> - `FlowRTT`: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br><br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/hack/cloned.flows.netobserv.io_flowcollectors.yaml
+++ b/hack/cloned.flows.netobserv.io_flowcollectors.yaml
@@ -3626,9 +3626,9 @@ spec:
                             type: string
                           type: array
                         features:
-                          description: 'List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are:<br> - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting the kernel debug filesystem, so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged` parameter is not set, an error is reported.<br> - `DNSTracking`: enable the DNS tracking feature.<br> - `FlowRTT` [unsupported (*)]: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br>'
+                          description: 'List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are:<br> - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting the kernel debug filesystem, so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged` parameter is not set, an error is reported.<br> - `DNSTracking`: enable the DNS tracking feature.<br> - `FlowRTT`: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br>'
                           items:
-                            description: Agent feature, can be one of:<br> - `PacketDrop`, to track packet drops.<br> - `DNSTracking`, to track specific information on DNS traffic.<br> - `FlowRTT`, to track TCP latency. [Unsupported (*)].<br>
+                            description: Agent feature, can be one of:<br> - `PacketDrop`, to track packet drops.<br> - `DNSTracking`, to track specific information on DNS traffic.<br> - `FlowRTT`, to track TCP latency.<br>
                             enum:
                               - PacketDrop
                               - DNSTracking


### PR DESCRIPTION
## Description

Remove RTT unsupported mentions.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [X] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
