### PR TITLE
NETOBSERV: 1374 Make enums pascal case

### DIFF
--- a/api/v1alpha1/flowcollector_types.go
+++ b/api/v1alpha1/flowcollector_types.go
@@ -76,6 +76,7 @@ type FlowCollectorSpec struct {
 
 	// exporters defines additional optional exporters for custom consumption or storage. This is an experimental feature. Currently, only KAFKA exporter is available.
 	// +optional
+	// +k8s:conversion-gen=false
 	Exporters []*FlowCollectorExporter `json:"exporters"`
 }
 

--- a/api/v1alpha1/flowcollector_webhook.go
+++ b/api/v1alpha1/flowcollector_webhook.go
@@ -138,7 +138,7 @@ func Convert_v1beta2_FlowCollectorLoki_To_v1alpha1_FlowCollectorLoki(in *v1beta2
 	out.QuerierURL = manual.QuerierURL
 	out.StatusURL = manual.StatusURL
 	out.TenantID = manual.TenantID
-	out.AuthToken = manual.AuthToken
+	out.AuthToken = utilconversion.PascalToUpper(string(manual.AuthToken), '_')
 	if err := Convert_v1beta2_ClientTLS_To_v1alpha1_ClientTLS(&manual.TLS, &out.TLS, nil); err != nil {
 		return fmt.Errorf("copying v1beta2.Loki.TLS into v1alpha1.Loki.TLS: %w", err)
 	}
@@ -155,7 +155,7 @@ func Convert_v1alpha1_FlowCollectorLoki_To_v1beta2_FlowCollectorLoki(in *FlowCol
 		QuerierURL:  in.QuerierURL,
 		StatusURL:   in.StatusURL,
 		TenantID:    in.TenantID,
-		AuthToken:   in.AuthToken,
+		AuthToken:   v1beta2.LokiAuthToken(utilconversion.UpperToPascal(in.AuthToken)),
 	}
 	// fallback on ingester url if querier is not set
 	if len(out.Manual.QuerierURL) == 0 {
@@ -181,11 +181,152 @@ func Convert_v1beta2_FlowCollectorEBPF_To_v1alpha1_FlowCollectorEBPF(in *v1beta2
 	return autoConvert_v1beta2_FlowCollectorEBPF_To_v1alpha1_FlowCollectorEBPF(in, out, s)
 }
 
-// // This function need to be manually created because conversion-gen not able to create it intentionally because
-// // we have new defined fields in v1beta2 not in v1alpha1
-// // nolint:golint,stylecheck,revive
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1alpha1
+// nolint:golint,stylecheck,revive
+func Convert_v1alpha1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(in *FlowCollectorSpec, out *v1beta2.FlowCollectorSpec, s apiconversion.Scope) error {
+	if err := autoConvert_v1alpha1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(in, out, s); err != nil {
+		return err
+	}
+	out.DeploymentModel = v1beta2.FlowCollectorDeploymentModel(utilconversion.UpperToPascal(in.DeploymentModel))
+	out.Exporters = []*v1beta2.FlowCollectorExporter{}
+	for _, inExporter := range in.Exporters {
+		outExporter := &v1beta2.FlowCollectorExporter{}
+		if err := Convert_v1alpha1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(inExporter, outExporter, s); err != nil {
+			return err
+		}
+		out.Exporters = append(out.Exporters, outExporter)
+	}
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1alpha1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta2_FlowCollectorSpec_To_v1alpha1_FlowCollectorSpec(in *v1beta2.FlowCollectorSpec, out *FlowCollectorSpec, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta2_FlowCollectorSpec_To_v1alpha1_FlowCollectorSpec(in, out, s); err != nil {
+		return err
+	}
+	out.DeploymentModel = utilconversion.PascalToUpper(string(in.DeploymentModel), '_')
+	out.Exporters = []*FlowCollectorExporter{}
+	for _, inExporter := range in.Exporters {
+		outExporter := &FlowCollectorExporter{}
+		if err := Convert_v1beta2_FlowCollectorExporter_To_v1alpha1_FlowCollectorExporter(inExporter, outExporter, s); err != nil {
+			return err
+		}
+		out.Exporters = append(out.Exporters, outExporter)
+	}
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1alpha1
+// nolint:golint,stylecheck,revive
+func Convert_v1alpha1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(in *FlowCollectorAgent, out *v1beta2.FlowCollectorAgent, s apiconversion.Scope) error {
+	if err := autoConvert_v1alpha1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(in, out, s); err != nil {
+		return err
+	}
+	out.Type = v1beta2.FlowCollectorAgentType(utilconversion.UpperToPascal(in.Type))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1alpha1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta2_FlowCollectorAgent_To_v1alpha1_FlowCollectorAgent(in *v1beta2.FlowCollectorAgent, out *FlowCollectorAgent, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta2_FlowCollectorAgent_To_v1alpha1_FlowCollectorAgent(in, out, s); err != nil {
+		return err
+	}
+	out.Type = utilconversion.PascalToUpper(string(in.Type), '_')
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1alpha1
+// nolint:golint,stylecheck,revive
+func Convert_v1alpha1_ServerTLS_To_v1beta2_ServerTLS(in *ServerTLS, out *v1beta2.ServerTLS, s apiconversion.Scope) error {
+	if err := autoConvert_v1alpha1_ServerTLS_To_v1beta2_ServerTLS(in, out, s); err != nil {
+		return err
+	}
+	out.Type = v1beta2.ServerTLSConfigType(utilconversion.UpperToPascal(string(in.Type)))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1alpha1
+// nolint:golint,stylecheck,revive
 func Convert_v1beta2_ServerTLS_To_v1alpha1_ServerTLS(in *v1beta2.ServerTLS, out *ServerTLS, s apiconversion.Scope) error {
-	return autoConvert_v1beta2_ServerTLS_To_v1alpha1_ServerTLS(in, out, s)
+	if err := autoConvert_v1beta2_ServerTLS_To_v1alpha1_ServerTLS(in, out, s); err != nil {
+		return err
+	}
+	out.Type = ServerTLSConfigType(utilconversion.PascalToUpper(string(in.Type), '_'))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1alpha1
+// nolint:golint,stylecheck,revive
+func Convert_v1alpha1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(in *FlowCollectorHPA, out *v1beta2.FlowCollectorHPA, s apiconversion.Scope) error {
+	if err := autoConvert_v1alpha1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(in, out, s); err != nil {
+		return err
+	}
+	out.Status = v1beta2.HPAStatus(utilconversion.UpperToPascal(in.Status))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1alpha1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta2_FlowCollectorHPA_To_v1alpha1_FlowCollectorHPA(in *v1beta2.FlowCollectorHPA, out *FlowCollectorHPA, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta2_FlowCollectorHPA_To_v1alpha1_FlowCollectorHPA(in, out, s); err != nil {
+		return err
+	}
+	out.Status = utilconversion.PascalToUpper(string(in.Status), '_')
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1alpha1
+// nolint:golint,stylecheck,revive
+func Convert_v1alpha1_SASLConfig_To_v1beta2_SASLConfig(in *SASLConfig, out *v1beta2.SASLConfig, s apiconversion.Scope) error {
+	if err := autoConvert_v1alpha1_SASLConfig_To_v1beta2_SASLConfig(in, out, s); err != nil {
+		return err
+	}
+	out.Type = v1beta2.SASLType(utilconversion.UpperToPascal(string(in.Type)))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1alpha1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta2_SASLConfig_To_v1alpha1_SASLConfig(in *v1beta2.SASLConfig, out *SASLConfig, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta2_SASLConfig_To_v1alpha1_SASLConfig(in, out, s); err != nil {
+		return err
+	}
+	out.Type = SASLType(utilconversion.PascalToUpper(string(in.Type), '_'))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1alpha1
+// nolint:golint,stylecheck,revive
+func Convert_v1alpha1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(in *FlowCollectorExporter, out *v1beta2.FlowCollectorExporter, s apiconversion.Scope) error {
+	if err := autoConvert_v1alpha1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(in, out, s); err != nil {
+		return err
+	}
+	out.Type = v1beta2.ExporterType(utilconversion.UpperToPascal(string(in.Type)))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1alpha1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta2_FlowCollectorExporter_To_v1alpha1_FlowCollectorExporter(in *v1beta2.FlowCollectorExporter, out *FlowCollectorExporter, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta2_FlowCollectorExporter_To_v1alpha1_FlowCollectorExporter(in, out, s); err != nil {
+		return err
+	}
+	out.Type = ExporterType(utilconversion.PascalToUpper(string(in.Type), '_'))
+	return nil
 }
 
 // This function need to be manually created because conversion-gen not able to create it intentionally because

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -108,16 +108,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*FlowCollectorAgent)(nil), (*v1beta2.FlowCollectorAgent)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(a.(*FlowCollectorAgent), b.(*v1beta2.FlowCollectorAgent), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.FlowCollectorAgent)(nil), (*FlowCollectorAgent)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_FlowCollectorAgent_To_v1alpha1_FlowCollectorAgent(a.(*v1beta2.FlowCollectorAgent), b.(*FlowCollectorAgent), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*FlowCollectorConsolePlugin)(nil), (*v1beta2.FlowCollectorConsolePlugin)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha1_FlowCollectorConsolePlugin_To_v1beta2_FlowCollectorConsolePlugin(a.(*FlowCollectorConsolePlugin), b.(*v1beta2.FlowCollectorConsolePlugin), scope)
 	}); err != nil {
@@ -128,28 +118,8 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*FlowCollectorExporter)(nil), (*v1beta2.FlowCollectorExporter)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(a.(*FlowCollectorExporter), b.(*v1beta2.FlowCollectorExporter), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.FlowCollectorExporter)(nil), (*FlowCollectorExporter)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_FlowCollectorExporter_To_v1alpha1_FlowCollectorExporter(a.(*v1beta2.FlowCollectorExporter), b.(*FlowCollectorExporter), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*FlowCollectorFLP)(nil), (*v1beta2.FlowCollectorFLP)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(a.(*FlowCollectorFLP), b.(*v1beta2.FlowCollectorFLP), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*FlowCollectorHPA)(nil), (*v1beta2.FlowCollectorHPA)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(a.(*FlowCollectorHPA), b.(*v1beta2.FlowCollectorHPA), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.FlowCollectorHPA)(nil), (*FlowCollectorHPA)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_FlowCollectorHPA_To_v1alpha1_FlowCollectorHPA(a.(*v1beta2.FlowCollectorHPA), b.(*FlowCollectorHPA), scope)
 	}); err != nil {
 		return err
 	}
@@ -193,16 +163,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*FlowCollectorSpec)(nil), (*v1beta2.FlowCollectorSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(a.(*FlowCollectorSpec), b.(*v1beta2.FlowCollectorSpec), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.FlowCollectorSpec)(nil), (*FlowCollectorSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_FlowCollectorSpec_To_v1alpha1_FlowCollectorSpec(a.(*v1beta2.FlowCollectorSpec), b.(*FlowCollectorSpec), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*FlowCollectorStatus)(nil), (*v1beta2.FlowCollectorStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha1_FlowCollectorStatus_To_v1beta2_FlowCollectorStatus(a.(*FlowCollectorStatus), b.(*v1beta2.FlowCollectorStatus), scope)
 	}); err != nil {
@@ -243,23 +203,23 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*SASLConfig)(nil), (*v1beta2.SASLConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha1_SASLConfig_To_v1beta2_SASLConfig(a.(*SASLConfig), b.(*v1beta2.SASLConfig), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.SASLConfig)(nil), (*SASLConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_SASLConfig_To_v1alpha1_SASLConfig(a.(*v1beta2.SASLConfig), b.(*SASLConfig), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*ServerTLS)(nil), (*v1beta2.ServerTLS)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha1_ServerTLS_To_v1beta2_ServerTLS(a.(*ServerTLS), b.(*v1beta2.ServerTLS), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddConversionFunc((*FLPMetrics)(nil), (*v1beta2.FLPMetrics)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha1_FLPMetrics_To_v1beta2_FLPMetrics(a.(*FLPMetrics), b.(*v1beta2.FLPMetrics), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*FlowCollectorAgent)(nil), (*v1beta2.FlowCollectorAgent)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(a.(*FlowCollectorAgent), b.(*v1beta2.FlowCollectorAgent), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*FlowCollectorExporter)(nil), (*v1beta2.FlowCollectorExporter)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(a.(*FlowCollectorExporter), b.(*v1beta2.FlowCollectorExporter), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*FlowCollectorHPA)(nil), (*v1beta2.FlowCollectorHPA)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(a.(*FlowCollectorHPA), b.(*v1beta2.FlowCollectorHPA), scope)
 	}); err != nil {
 		return err
 	}
@@ -268,8 +228,28 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*FlowCollectorSpec)(nil), (*v1beta2.FlowCollectorSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(a.(*FlowCollectorSpec), b.(*v1beta2.FlowCollectorSpec), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*SASLConfig)(nil), (*v1beta2.SASLConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha1_SASLConfig_To_v1beta2_SASLConfig(a.(*SASLConfig), b.(*v1beta2.SASLConfig), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*ServerTLS)(nil), (*v1beta2.ServerTLS)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha1_ServerTLS_To_v1beta2_ServerTLS(a.(*ServerTLS), b.(*v1beta2.ServerTLS), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*v1beta2.FLPMetrics)(nil), (*FLPMetrics)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_FLPMetrics_To_v1alpha1_FLPMetrics(a.(*v1beta2.FLPMetrics), b.(*FLPMetrics), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.FlowCollectorAgent)(nil), (*FlowCollectorAgent)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_FlowCollectorAgent_To_v1alpha1_FlowCollectorAgent(a.(*v1beta2.FlowCollectorAgent), b.(*FlowCollectorAgent), scope)
 	}); err != nil {
 		return err
 	}
@@ -283,13 +263,33 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*v1beta2.FlowCollectorExporter)(nil), (*FlowCollectorExporter)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_FlowCollectorExporter_To_v1alpha1_FlowCollectorExporter(a.(*v1beta2.FlowCollectorExporter), b.(*FlowCollectorExporter), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*v1beta2.FlowCollectorFLP)(nil), (*FlowCollectorFLP)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_FlowCollectorFLP_To_v1alpha1_FlowCollectorFLP(a.(*v1beta2.FlowCollectorFLP), b.(*FlowCollectorFLP), scope)
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*v1beta2.FlowCollectorHPA)(nil), (*FlowCollectorHPA)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_FlowCollectorHPA_To_v1alpha1_FlowCollectorHPA(a.(*v1beta2.FlowCollectorHPA), b.(*FlowCollectorHPA), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*v1beta2.FlowCollectorLoki)(nil), (*FlowCollectorLoki)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_FlowCollectorLoki_To_v1alpha1_FlowCollectorLoki(a.(*v1beta2.FlowCollectorLoki), b.(*FlowCollectorLoki), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.FlowCollectorSpec)(nil), (*FlowCollectorSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_FlowCollectorSpec_To_v1alpha1_FlowCollectorSpec(a.(*v1beta2.FlowCollectorSpec), b.(*FlowCollectorSpec), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.SASLConfig)(nil), (*SASLConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_SASLConfig_To_v1alpha1_SASLConfig(a.(*v1beta2.SASLConfig), b.(*SASLConfig), scope)
 	}); err != nil {
 		return err
 	}
@@ -505,7 +505,7 @@ func Convert_v1beta2_FlowCollector_To_v1alpha1_FlowCollector(in *v1beta2.FlowCol
 }
 
 func autoConvert_v1alpha1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(in *FlowCollectorAgent, out *v1beta2.FlowCollectorAgent, s conversion.Scope) error {
-	out.Type = in.Type
+	out.Type = v1beta2.FlowCollectorAgentType(in.Type)
 	if err := Convert_v1alpha1_FlowCollectorIPFIX_To_v1beta2_FlowCollectorIPFIX(&in.IPFIX, &out.IPFIX, s); err != nil {
 		return err
 	}
@@ -515,13 +515,8 @@ func autoConvert_v1alpha1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(in *F
 	return nil
 }
 
-// Convert_v1alpha1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent is an autogenerated conversion function.
-func Convert_v1alpha1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(in *FlowCollectorAgent, out *v1beta2.FlowCollectorAgent, s conversion.Scope) error {
-	return autoConvert_v1alpha1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(in, out, s)
-}
-
 func autoConvert_v1beta2_FlowCollectorAgent_To_v1alpha1_FlowCollectorAgent(in *v1beta2.FlowCollectorAgent, out *FlowCollectorAgent, s conversion.Scope) error {
-	out.Type = in.Type
+	out.Type = string(in.Type)
 	if err := Convert_v1beta2_FlowCollectorIPFIX_To_v1alpha1_FlowCollectorIPFIX(&in.IPFIX, &out.IPFIX, s); err != nil {
 		return err
 	}
@@ -529,11 +524,6 @@ func autoConvert_v1beta2_FlowCollectorAgent_To_v1alpha1_FlowCollectorAgent(in *v
 		return err
 	}
 	return nil
-}
-
-// Convert_v1beta2_FlowCollectorAgent_To_v1alpha1_FlowCollectorAgent is an autogenerated conversion function.
-func Convert_v1beta2_FlowCollectorAgent_To_v1alpha1_FlowCollectorAgent(in *v1beta2.FlowCollectorAgent, out *FlowCollectorAgent, s conversion.Scope) error {
-	return autoConvert_v1beta2_FlowCollectorAgent_To_v1alpha1_FlowCollectorAgent(in, out, s)
 }
 
 func autoConvert_v1alpha1_FlowCollectorConsolePlugin_To_v1beta2_FlowCollectorConsolePlugin(in *FlowCollectorConsolePlugin, out *v1beta2.FlowCollectorConsolePlugin, s conversion.Scope) error {
@@ -635,11 +625,6 @@ func autoConvert_v1alpha1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter
 	return nil
 }
 
-// Convert_v1alpha1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter is an autogenerated conversion function.
-func Convert_v1alpha1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(in *FlowCollectorExporter, out *v1beta2.FlowCollectorExporter, s conversion.Scope) error {
-	return autoConvert_v1alpha1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(in, out, s)
-}
-
 func autoConvert_v1beta2_FlowCollectorExporter_To_v1alpha1_FlowCollectorExporter(in *v1beta2.FlowCollectorExporter, out *FlowCollectorExporter, s conversion.Scope) error {
 	out.Type = ExporterType(in.Type)
 	if err := Convert_v1beta2_FlowCollectorKafka_To_v1alpha1_FlowCollectorKafka(&in.Kafka, &out.Kafka, s); err != nil {
@@ -649,11 +634,6 @@ func autoConvert_v1beta2_FlowCollectorExporter_To_v1alpha1_FlowCollectorExporter
 		return err
 	}
 	return nil
-}
-
-// Convert_v1beta2_FlowCollectorExporter_To_v1alpha1_FlowCollectorExporter is an autogenerated conversion function.
-func Convert_v1beta2_FlowCollectorExporter_To_v1alpha1_FlowCollectorExporter(in *v1beta2.FlowCollectorExporter, out *FlowCollectorExporter, s conversion.Scope) error {
-	return autoConvert_v1beta2_FlowCollectorExporter_To_v1alpha1_FlowCollectorExporter(in, out, s)
 }
 
 func autoConvert_v1alpha1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(in *FlowCollectorFLP, out *v1beta2.FlowCollectorFLP, s conversion.Scope) error {
@@ -728,29 +708,19 @@ func autoConvert_v1beta2_FlowCollectorFLP_To_v1alpha1_FlowCollectorFLP(in *v1bet
 }
 
 func autoConvert_v1alpha1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(in *FlowCollectorHPA, out *v1beta2.FlowCollectorHPA, s conversion.Scope) error {
-	out.Status = in.Status
+	out.Status = v1beta2.HPAStatus(in.Status)
 	out.MinReplicas = (*int32)(unsafe.Pointer(in.MinReplicas))
 	out.MaxReplicas = in.MaxReplicas
 	out.Metrics = *(*[]v2.MetricSpec)(unsafe.Pointer(&in.Metrics))
 	return nil
-}
-
-// Convert_v1alpha1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA is an autogenerated conversion function.
-func Convert_v1alpha1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(in *FlowCollectorHPA, out *v1beta2.FlowCollectorHPA, s conversion.Scope) error {
-	return autoConvert_v1alpha1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(in, out, s)
 }
 
 func autoConvert_v1beta2_FlowCollectorHPA_To_v1alpha1_FlowCollectorHPA(in *v1beta2.FlowCollectorHPA, out *FlowCollectorHPA, s conversion.Scope) error {
-	out.Status = in.Status
+	out.Status = string(in.Status)
 	out.MinReplicas = (*int32)(unsafe.Pointer(in.MinReplicas))
 	out.MaxReplicas = in.MaxReplicas
 	out.Metrics = *(*[]v2.MetricSpec)(unsafe.Pointer(&in.Metrics))
 	return nil
-}
-
-// Convert_v1beta2_FlowCollectorHPA_To_v1alpha1_FlowCollectorHPA is an autogenerated conversion function.
-func Convert_v1beta2_FlowCollectorHPA_To_v1alpha1_FlowCollectorHPA(in *v1beta2.FlowCollectorHPA, out *FlowCollectorHPA, s conversion.Scope) error {
-	return autoConvert_v1beta2_FlowCollectorHPA_To_v1alpha1_FlowCollectorHPA(in, out, s)
 }
 
 func autoConvert_v1alpha1_FlowCollectorIPFIX_To_v1beta2_FlowCollectorIPFIX(in *FlowCollectorIPFIX, out *v1beta2.FlowCollectorIPFIX, s conversion.Scope) error {
@@ -959,17 +929,12 @@ func autoConvert_v1alpha1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(in *Flo
 	if err := Convert_v1alpha1_FlowCollectorConsolePlugin_To_v1beta2_FlowCollectorConsolePlugin(&in.ConsolePlugin, &out.ConsolePlugin, s); err != nil {
 		return err
 	}
-	out.DeploymentModel = in.DeploymentModel
+	out.DeploymentModel = v1beta2.FlowCollectorDeploymentModel(in.DeploymentModel)
 	if err := Convert_v1alpha1_FlowCollectorKafka_To_v1beta2_FlowCollectorKafka(&in.Kafka, &out.Kafka, s); err != nil {
 		return err
 	}
-	out.Exporters = *(*[]*v1beta2.FlowCollectorExporter)(unsafe.Pointer(&in.Exporters))
+	// INFO: in.Exporters opted out of conversion generation
 	return nil
-}
-
-// Convert_v1alpha1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec is an autogenerated conversion function.
-func Convert_v1alpha1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(in *FlowCollectorSpec, out *v1beta2.FlowCollectorSpec, s conversion.Scope) error {
-	return autoConvert_v1alpha1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(in, out, s)
 }
 
 func autoConvert_v1beta2_FlowCollectorSpec_To_v1alpha1_FlowCollectorSpec(in *v1beta2.FlowCollectorSpec, out *FlowCollectorSpec, s conversion.Scope) error {
@@ -986,17 +951,12 @@ func autoConvert_v1beta2_FlowCollectorSpec_To_v1alpha1_FlowCollectorSpec(in *v1b
 	if err := Convert_v1beta2_FlowCollectorConsolePlugin_To_v1alpha1_FlowCollectorConsolePlugin(&in.ConsolePlugin, &out.ConsolePlugin, s); err != nil {
 		return err
 	}
-	out.DeploymentModel = in.DeploymentModel
+	out.DeploymentModel = string(in.DeploymentModel)
 	if err := Convert_v1beta2_FlowCollectorKafka_To_v1alpha1_FlowCollectorKafka(&in.Kafka, &out.Kafka, s); err != nil {
 		return err
 	}
-	out.Exporters = *(*[]*FlowCollectorExporter)(unsafe.Pointer(&in.Exporters))
+	// INFO: in.Exporters opted out of conversion generation
 	return nil
-}
-
-// Convert_v1beta2_FlowCollectorSpec_To_v1alpha1_FlowCollectorSpec is an autogenerated conversion function.
-func Convert_v1beta2_FlowCollectorSpec_To_v1alpha1_FlowCollectorSpec(in *v1beta2.FlowCollectorSpec, out *FlowCollectorSpec, s conversion.Scope) error {
-	return autoConvert_v1beta2_FlowCollectorSpec_To_v1alpha1_FlowCollectorSpec(in, out, s)
 }
 
 func autoConvert_v1alpha1_FlowCollectorStatus_To_v1beta2_FlowCollectorStatus(in *FlowCollectorStatus, out *v1beta2.FlowCollectorStatus, s conversion.Scope) error {
@@ -1106,11 +1066,6 @@ func autoConvert_v1alpha1_SASLConfig_To_v1beta2_SASLConfig(in *SASLConfig, out *
 	return nil
 }
 
-// Convert_v1alpha1_SASLConfig_To_v1beta2_SASLConfig is an autogenerated conversion function.
-func Convert_v1alpha1_SASLConfig_To_v1beta2_SASLConfig(in *SASLConfig, out *v1beta2.SASLConfig, s conversion.Scope) error {
-	return autoConvert_v1alpha1_SASLConfig_To_v1beta2_SASLConfig(in, out, s)
-}
-
 func autoConvert_v1beta2_SASLConfig_To_v1alpha1_SASLConfig(in *v1beta2.SASLConfig, out *SASLConfig, s conversion.Scope) error {
 	out.Type = SASLType(in.Type)
 	if err := Convert_v1beta2_FileReference_To_v1alpha1_FileReference(&in.ClientIDReference, &out.ClientIDReference, s); err != nil {
@@ -1122,20 +1077,10 @@ func autoConvert_v1beta2_SASLConfig_To_v1alpha1_SASLConfig(in *v1beta2.SASLConfi
 	return nil
 }
 
-// Convert_v1beta2_SASLConfig_To_v1alpha1_SASLConfig is an autogenerated conversion function.
-func Convert_v1beta2_SASLConfig_To_v1alpha1_SASLConfig(in *v1beta2.SASLConfig, out *SASLConfig, s conversion.Scope) error {
-	return autoConvert_v1beta2_SASLConfig_To_v1alpha1_SASLConfig(in, out, s)
-}
-
 func autoConvert_v1alpha1_ServerTLS_To_v1beta2_ServerTLS(in *ServerTLS, out *v1beta2.ServerTLS, s conversion.Scope) error {
 	out.Type = v1beta2.ServerTLSConfigType(in.Type)
 	out.Provided = (*v1beta2.CertificateReference)(unsafe.Pointer(in.Provided))
 	return nil
-}
-
-// Convert_v1alpha1_ServerTLS_To_v1beta2_ServerTLS is an autogenerated conversion function.
-func Convert_v1alpha1_ServerTLS_To_v1beta2_ServerTLS(in *ServerTLS, out *v1beta2.ServerTLS, s conversion.Scope) error {
-	return autoConvert_v1alpha1_ServerTLS_To_v1beta2_ServerTLS(in, out, s)
 }
 
 func autoConvert_v1beta2_ServerTLS_To_v1alpha1_ServerTLS(in *v1beta2.ServerTLS, out *ServerTLS, s conversion.Scope) error {

--- a/api/v1beta1/flowcollector_types.go
+++ b/api/v1beta1/flowcollector_types.go
@@ -78,6 +78,7 @@ type FlowCollectorSpec struct {
 
 	// `exporters` define additional optional exporters for custom consumption or storage.
 	// +optional
+	// +k8s:conversion-gen=false
 	Exporters []*FlowCollectorExporter `json:"exporters"`
 }
 
@@ -233,7 +234,7 @@ type FlowCollectorEBPF struct {
 	// List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are:<br>
 	// - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting
 	// the kernel debug filesystem, so the eBPF pod has to run as privileged.
-	// If the `spec.agent.eBPF.privileged` parameter is not set, an error is reported.<br>
+	// If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported.<br>
 	// - `DNSTracking`: enable the DNS tracking feature.<br>
 	// - `FlowRTT` [unsupported (*)]: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br>
 	// +optional

--- a/api/v1beta1/flowcollector_webhook.go
+++ b/api/v1beta1/flowcollector_webhook.go
@@ -76,8 +76,8 @@ func (r *FlowCollectorList) ConvertFrom(srcRaw conversion.Hub) error {
 // This function need to be manually created because conversion-gen not able to create it intentionally because
 // we have new defined fields in v1beta2 not in v1beta1
 // nolint:golint,stylecheck,revive
-func Convert_v1beta2_FlowCollectorFLP_To_v1beta1_FlowCollectorFLP(in *v1beta2.FlowCollectorFLP, out *FlowCollectorFLP, s apiconversion.Scope) error {
-	return autoConvert_v1beta2_FlowCollectorFLP_To_v1beta1_FlowCollectorFLP(in, out, s)
+func Convert_v1beta2_FLPMetrics_To_v1beta1_FLPMetrics(in *v1beta2.FLPMetrics, out *FLPMetrics, s apiconversion.Scope) error {
+	return autoConvert_v1beta2_FLPMetrics_To_v1beta1_FLPMetrics(in, out, s)
 }
 
 // This function need to be manually created because conversion-gen not able to create it intentionally because
@@ -90,7 +90,7 @@ func Convert_v1beta2_FlowCollectorLoki_To_v1beta1_FlowCollectorLoki(in *v1beta2.
 	out.QuerierURL = manual.QuerierURL
 	out.StatusURL = manual.StatusURL
 	out.TenantID = manual.TenantID
-	out.AuthToken = manual.AuthToken
+	out.AuthToken = utilconversion.PascalToUpper(string(manual.AuthToken), '_')
 	if err := Convert_v1beta2_ClientTLS_To_v1beta1_ClientTLS(&manual.TLS, &out.TLS, nil); err != nil {
 		return fmt.Errorf("copying Loki v1beta2 TLS into v1beta1 TLS: %w", err)
 	}
@@ -110,7 +110,7 @@ func Convert_v1beta1_FlowCollectorLoki_To_v1beta2_FlowCollectorLoki(in *FlowColl
 		QuerierURL:  in.QuerierURL,
 		StatusURL:   in.StatusURL,
 		TenantID:    in.TenantID,
-		AuthToken:   in.AuthToken,
+		AuthToken:   v1beta2.LokiAuthToken(utilconversion.UpperToPascal(in.AuthToken)),
 	}
 	// fallback on ingester url if querier is not set
 	if len(out.Manual.QuerierURL) == 0 {
@@ -128,18 +128,189 @@ func Convert_v1beta1_FlowCollectorLoki_To_v1beta2_FlowCollectorLoki(in *FlowColl
 // This function need to be manually created because conversion-gen not able to create it intentionally because
 // we have new defined fields in v1beta2 not in v1beta1
 // nolint:golint,stylecheck,revive
-func Convert_v1beta2_FLPMetrics_To_v1beta1_FLPMetrics(in *v1beta2.FLPMetrics, out *FLPMetrics, s apiconversion.Scope) error {
-	return autoConvert_v1beta2_FLPMetrics_To_v1beta1_FLPMetrics(in, out, s)
-}
-
-// This function need to be manually created because conversion-gen not able to create it intentionally because
-// we have new defined fields in v1beta2 not in v1beta1
-// nolint:golint,stylecheck,revive
 func Convert_v1beta1_FLPMetrics_To_v1beta2_FLPMetrics(in *FLPMetrics, out *v1beta2.FLPMetrics, s apiconversion.Scope) error {
 	err := autoConvert_v1beta1_FLPMetrics_To_v1beta2_FLPMetrics(in, out, s)
 	if err != nil {
 		return err
 	}
 	out.IncludeList = metrics.GetAsIncludeList(in.IgnoreTags, out.IncludeList)
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(in *FlowCollectorSpec, out *v1beta2.FlowCollectorSpec, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(in, out, s); err != nil {
+		return err
+	}
+	out.DeploymentModel = v1beta2.FlowCollectorDeploymentModel(utilconversion.UpperToPascal(in.DeploymentModel))
+	out.Exporters = []*v1beta2.FlowCollectorExporter{}
+	for _, inExporter := range in.Exporters {
+		outExporter := &v1beta2.FlowCollectorExporter{}
+		if err := Convert_v1beta1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(inExporter, outExporter, s); err != nil {
+			return err
+		}
+		out.Exporters = append(out.Exporters, outExporter)
+	}
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta2_FlowCollectorSpec_To_v1beta1_FlowCollectorSpec(in *v1beta2.FlowCollectorSpec, out *FlowCollectorSpec, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta2_FlowCollectorSpec_To_v1beta1_FlowCollectorSpec(in, out, s); err != nil {
+		return err
+	}
+	out.DeploymentModel = utilconversion.PascalToUpper(string(in.DeploymentModel), '_')
+	out.Exporters = []*FlowCollectorExporter{}
+	for _, inExporter := range in.Exporters {
+		outExporter := &FlowCollectorExporter{}
+		if err := Convert_v1beta2_FlowCollectorExporter_To_v1beta1_FlowCollectorExporter(inExporter, outExporter, s); err != nil {
+			return err
+		}
+		out.Exporters = append(out.Exporters, outExporter)
+	}
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(in *FlowCollectorAgent, out *v1beta2.FlowCollectorAgent, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(in, out, s); err != nil {
+		return err
+	}
+	out.Type = v1beta2.FlowCollectorAgentType(utilconversion.UpperToPascal(in.Type))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta2_FlowCollectorAgent_To_v1beta1_FlowCollectorAgent(in *v1beta2.FlowCollectorAgent, out *FlowCollectorAgent, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta2_FlowCollectorAgent_To_v1beta1_FlowCollectorAgent(in, out, s); err != nil {
+		return err
+	}
+	out.Type = utilconversion.PascalToUpper(string(in.Type), '_')
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// and new defined fields in v1beta2 not in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(in *FlowCollectorFLP, out *v1beta2.FlowCollectorFLP, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(in, out, s); err != nil {
+		return err
+	}
+	if in.LogTypes != nil {
+		logTypes := v1beta2.FLPLogTypes(utilconversion.UpperToPascal(*in.LogTypes))
+		out.LogTypes = &logTypes
+	}
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// and new defined fields in v1beta2 not in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta2_FlowCollectorFLP_To_v1beta1_FlowCollectorFLP(in *v1beta2.FlowCollectorFLP, out *FlowCollectorFLP, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta2_FlowCollectorFLP_To_v1beta1_FlowCollectorFLP(in, out, s); err != nil {
+		return err
+	}
+	if in.LogTypes != nil {
+		str := utilconversion.PascalToUpper(string(*in.LogTypes), '_')
+		out.LogTypes = &str
+	}
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta1_ServerTLS_To_v1beta2_ServerTLS(in *ServerTLS, out *v1beta2.ServerTLS, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta1_ServerTLS_To_v1beta2_ServerTLS(in, out, s); err != nil {
+		return err
+	}
+	out.Type = v1beta2.ServerTLSConfigType(utilconversion.UpperToPascal(string(in.Type)))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta2_ServerTLS_To_v1beta1_ServerTLS(in *v1beta2.ServerTLS, out *ServerTLS, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta2_ServerTLS_To_v1beta1_ServerTLS(in, out, s); err != nil {
+		return err
+	}
+	out.Type = ServerTLSConfigType(utilconversion.PascalToUpper(string(in.Type), '_'))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(in *FlowCollectorHPA, out *v1beta2.FlowCollectorHPA, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(in, out, s); err != nil {
+		return err
+	}
+	out.Status = v1beta2.HPAStatus(utilconversion.UpperToPascal(in.Status))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta2_FlowCollectorHPA_To_v1beta1_FlowCollectorHPA(in *v1beta2.FlowCollectorHPA, out *FlowCollectorHPA, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta2_FlowCollectorHPA_To_v1beta1_FlowCollectorHPA(in, out, s); err != nil {
+		return err
+	}
+	out.Status = utilconversion.PascalToUpper(string(in.Status), '_')
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta1_SASLConfig_To_v1beta2_SASLConfig(in *SASLConfig, out *v1beta2.SASLConfig, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta1_SASLConfig_To_v1beta2_SASLConfig(in, out, s); err != nil {
+		return err
+	}
+	out.Type = v1beta2.SASLType(utilconversion.UpperToPascal(string(in.Type)))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta2_SASLConfig_To_v1beta1_SASLConfig(in *v1beta2.SASLConfig, out *SASLConfig, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta2_SASLConfig_To_v1beta1_SASLConfig(in, out, s); err != nil {
+		return err
+	}
+	out.Type = SASLType(utilconversion.PascalToUpper(string(in.Type), '-'))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(in *FlowCollectorExporter, out *v1beta2.FlowCollectorExporter, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(in, out, s); err != nil {
+		return err
+	}
+	out.Type = v1beta2.ExporterType(utilconversion.UpperToPascal(string(in.Type)))
+	return nil
+}
+
+// This function need to be manually created because conversion-gen not able to create it intentionally because
+// we have camel case enum in v1beta2 which were uppercase in v1beta1
+// nolint:golint,stylecheck,revive
+func Convert_v1beta2_FlowCollectorExporter_To_v1beta1_FlowCollectorExporter(in *v1beta2.FlowCollectorExporter, out *FlowCollectorExporter, s apiconversion.Scope) error {
+	if err := autoConvert_v1beta2_FlowCollectorExporter_To_v1beta1_FlowCollectorExporter(in, out, s); err != nil {
+		return err
+	}
+	out.Type = ExporterType(utilconversion.PascalToUpper(string(in.Type), '_'))
 	return nil
 }

--- a/api/v1beta1/flowcollector_webhook_test.go
+++ b/api/v1beta1/flowcollector_webhook_test.go
@@ -44,7 +44,7 @@ func TestBeta1ConversionRoundtrip_Loki(t *testing.T) {
 	assert.Equal("http://loki/status", converted.Spec.Loki.Manual.StatusURL)
 	assert.Equal("http://loki/querier", converted.Spec.Loki.Manual.QuerierURL)
 	assert.Equal("tenant", converted.Spec.Loki.Manual.TenantID)
-	assert.Equal(LokiAuthForwardUserToken, converted.Spec.Loki.Manual.AuthToken)
+	assert.Equal(v1beta2.LokiAuthForwardUserToken, converted.Spec.Loki.Manual.AuthToken)
 	assert.True(converted.Spec.Loki.Manual.TLS.Enable)
 	assert.True(converted.Spec.Loki.Manual.TLS.InsecureSkipVerify)
 	assert.True(converted.Spec.Loki.Manual.StatusTLS.Enable)

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -108,16 +108,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*FlowCollectorAgent)(nil), (*v1beta2.FlowCollectorAgent)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(a.(*FlowCollectorAgent), b.(*v1beta2.FlowCollectorAgent), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.FlowCollectorAgent)(nil), (*FlowCollectorAgent)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_FlowCollectorAgent_To_v1beta1_FlowCollectorAgent(a.(*v1beta2.FlowCollectorAgent), b.(*FlowCollectorAgent), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*FlowCollectorConsolePlugin)(nil), (*v1beta2.FlowCollectorConsolePlugin)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta1_FlowCollectorConsolePlugin_To_v1beta2_FlowCollectorConsolePlugin(a.(*FlowCollectorConsolePlugin), b.(*v1beta2.FlowCollectorConsolePlugin), scope)
 	}); err != nil {
@@ -135,31 +125,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddGeneratedConversionFunc((*v1beta2.FlowCollectorEBPF)(nil), (*FlowCollectorEBPF)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_FlowCollectorEBPF_To_v1beta1_FlowCollectorEBPF(a.(*v1beta2.FlowCollectorEBPF), b.(*FlowCollectorEBPF), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*FlowCollectorExporter)(nil), (*v1beta2.FlowCollectorExporter)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(a.(*FlowCollectorExporter), b.(*v1beta2.FlowCollectorExporter), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.FlowCollectorExporter)(nil), (*FlowCollectorExporter)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_FlowCollectorExporter_To_v1beta1_FlowCollectorExporter(a.(*v1beta2.FlowCollectorExporter), b.(*FlowCollectorExporter), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*FlowCollectorFLP)(nil), (*v1beta2.FlowCollectorFLP)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(a.(*FlowCollectorFLP), b.(*v1beta2.FlowCollectorFLP), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*FlowCollectorHPA)(nil), (*v1beta2.FlowCollectorHPA)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(a.(*FlowCollectorHPA), b.(*v1beta2.FlowCollectorHPA), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.FlowCollectorHPA)(nil), (*FlowCollectorHPA)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_FlowCollectorHPA_To_v1beta1_FlowCollectorHPA(a.(*v1beta2.FlowCollectorHPA), b.(*FlowCollectorHPA), scope)
 	}); err != nil {
 		return err
 	}
@@ -203,16 +168,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*FlowCollectorSpec)(nil), (*v1beta2.FlowCollectorSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(a.(*FlowCollectorSpec), b.(*v1beta2.FlowCollectorSpec), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.FlowCollectorSpec)(nil), (*FlowCollectorSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_FlowCollectorSpec_To_v1beta1_FlowCollectorSpec(a.(*v1beta2.FlowCollectorSpec), b.(*FlowCollectorSpec), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*FlowCollectorStatus)(nil), (*v1beta2.FlowCollectorStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta1_FlowCollectorStatus_To_v1beta2_FlowCollectorStatus(a.(*FlowCollectorStatus), b.(*v1beta2.FlowCollectorStatus), scope)
 	}); err != nil {
@@ -253,28 +208,28 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*SASLConfig)(nil), (*v1beta2.SASLConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_SASLConfig_To_v1beta2_SASLConfig(a.(*SASLConfig), b.(*v1beta2.SASLConfig), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.SASLConfig)(nil), (*SASLConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_SASLConfig_To_v1beta1_SASLConfig(a.(*v1beta2.SASLConfig), b.(*SASLConfig), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*ServerTLS)(nil), (*v1beta2.ServerTLS)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_ServerTLS_To_v1beta2_ServerTLS(a.(*ServerTLS), b.(*v1beta2.ServerTLS), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta2.ServerTLS)(nil), (*ServerTLS)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta2_ServerTLS_To_v1beta1_ServerTLS(a.(*v1beta2.ServerTLS), b.(*ServerTLS), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddConversionFunc((*FLPMetrics)(nil), (*v1beta2.FLPMetrics)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta1_FLPMetrics_To_v1beta2_FLPMetrics(a.(*FLPMetrics), b.(*v1beta2.FLPMetrics), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*FlowCollectorAgent)(nil), (*v1beta2.FlowCollectorAgent)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(a.(*FlowCollectorAgent), b.(*v1beta2.FlowCollectorAgent), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*FlowCollectorExporter)(nil), (*v1beta2.FlowCollectorExporter)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(a.(*FlowCollectorExporter), b.(*v1beta2.FlowCollectorExporter), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*FlowCollectorFLP)(nil), (*v1beta2.FlowCollectorFLP)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(a.(*FlowCollectorFLP), b.(*v1beta2.FlowCollectorFLP), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*FlowCollectorHPA)(nil), (*v1beta2.FlowCollectorHPA)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(a.(*FlowCollectorHPA), b.(*v1beta2.FlowCollectorHPA), scope)
 	}); err != nil {
 		return err
 	}
@@ -283,8 +238,33 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*FlowCollectorSpec)(nil), (*v1beta2.FlowCollectorSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(a.(*FlowCollectorSpec), b.(*v1beta2.FlowCollectorSpec), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*SASLConfig)(nil), (*v1beta2.SASLConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta1_SASLConfig_To_v1beta2_SASLConfig(a.(*SASLConfig), b.(*v1beta2.SASLConfig), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*ServerTLS)(nil), (*v1beta2.ServerTLS)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta1_ServerTLS_To_v1beta2_ServerTLS(a.(*ServerTLS), b.(*v1beta2.ServerTLS), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*v1beta2.FLPMetrics)(nil), (*FLPMetrics)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_FLPMetrics_To_v1beta1_FLPMetrics(a.(*v1beta2.FLPMetrics), b.(*FLPMetrics), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.FlowCollectorAgent)(nil), (*FlowCollectorAgent)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_FlowCollectorAgent_To_v1beta1_FlowCollectorAgent(a.(*v1beta2.FlowCollectorAgent), b.(*FlowCollectorAgent), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.FlowCollectorExporter)(nil), (*FlowCollectorExporter)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_FlowCollectorExporter_To_v1beta1_FlowCollectorExporter(a.(*v1beta2.FlowCollectorExporter), b.(*FlowCollectorExporter), scope)
 	}); err != nil {
 		return err
 	}
@@ -293,8 +273,28 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*v1beta2.FlowCollectorHPA)(nil), (*FlowCollectorHPA)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_FlowCollectorHPA_To_v1beta1_FlowCollectorHPA(a.(*v1beta2.FlowCollectorHPA), b.(*FlowCollectorHPA), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*v1beta2.FlowCollectorLoki)(nil), (*FlowCollectorLoki)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_FlowCollectorLoki_To_v1beta1_FlowCollectorLoki(a.(*v1beta2.FlowCollectorLoki), b.(*FlowCollectorLoki), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.FlowCollectorSpec)(nil), (*FlowCollectorSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_FlowCollectorSpec_To_v1beta1_FlowCollectorSpec(a.(*v1beta2.FlowCollectorSpec), b.(*FlowCollectorSpec), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.SASLConfig)(nil), (*SASLConfig)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_SASLConfig_To_v1beta1_SASLConfig(a.(*v1beta2.SASLConfig), b.(*SASLConfig), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.ServerTLS)(nil), (*ServerTLS)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_ServerTLS_To_v1beta1_ServerTLS(a.(*v1beta2.ServerTLS), b.(*ServerTLS), scope)
 	}); err != nil {
 		return err
 	}
@@ -503,7 +503,7 @@ func Convert_v1beta2_FlowCollector_To_v1beta1_FlowCollector(in *v1beta2.FlowColl
 }
 
 func autoConvert_v1beta1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(in *FlowCollectorAgent, out *v1beta2.FlowCollectorAgent, s conversion.Scope) error {
-	out.Type = in.Type
+	out.Type = v1beta2.FlowCollectorAgentType(in.Type)
 	if err := Convert_v1beta1_FlowCollectorIPFIX_To_v1beta2_FlowCollectorIPFIX(&in.IPFIX, &out.IPFIX, s); err != nil {
 		return err
 	}
@@ -513,13 +513,8 @@ func autoConvert_v1beta1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(in *Fl
 	return nil
 }
 
-// Convert_v1beta1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent is an autogenerated conversion function.
-func Convert_v1beta1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(in *FlowCollectorAgent, out *v1beta2.FlowCollectorAgent, s conversion.Scope) error {
-	return autoConvert_v1beta1_FlowCollectorAgent_To_v1beta2_FlowCollectorAgent(in, out, s)
-}
-
 func autoConvert_v1beta2_FlowCollectorAgent_To_v1beta1_FlowCollectorAgent(in *v1beta2.FlowCollectorAgent, out *FlowCollectorAgent, s conversion.Scope) error {
-	out.Type = in.Type
+	out.Type = string(in.Type)
 	if err := Convert_v1beta2_FlowCollectorIPFIX_To_v1beta1_FlowCollectorIPFIX(&in.IPFIX, &out.IPFIX, s); err != nil {
 		return err
 	}
@@ -527,11 +522,6 @@ func autoConvert_v1beta2_FlowCollectorAgent_To_v1beta1_FlowCollectorAgent(in *v1
 		return err
 	}
 	return nil
-}
-
-// Convert_v1beta2_FlowCollectorAgent_To_v1beta1_FlowCollectorAgent is an autogenerated conversion function.
-func Convert_v1beta2_FlowCollectorAgent_To_v1beta1_FlowCollectorAgent(in *v1beta2.FlowCollectorAgent, out *FlowCollectorAgent, s conversion.Scope) error {
-	return autoConvert_v1beta2_FlowCollectorAgent_To_v1beta1_FlowCollectorAgent(in, out, s)
 }
 
 func autoConvert_v1beta1_FlowCollectorConsolePlugin_To_v1beta2_FlowCollectorConsolePlugin(in *FlowCollectorConsolePlugin, out *v1beta2.FlowCollectorConsolePlugin, s conversion.Scope) error {
@@ -637,11 +627,6 @@ func autoConvert_v1beta1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(
 	return nil
 }
 
-// Convert_v1beta1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter is an autogenerated conversion function.
-func Convert_v1beta1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(in *FlowCollectorExporter, out *v1beta2.FlowCollectorExporter, s conversion.Scope) error {
-	return autoConvert_v1beta1_FlowCollectorExporter_To_v1beta2_FlowCollectorExporter(in, out, s)
-}
-
 func autoConvert_v1beta2_FlowCollectorExporter_To_v1beta1_FlowCollectorExporter(in *v1beta2.FlowCollectorExporter, out *FlowCollectorExporter, s conversion.Scope) error {
 	out.Type = ExporterType(in.Type)
 	if err := Convert_v1beta2_FlowCollectorKafka_To_v1beta1_FlowCollectorKafka(&in.Kafka, &out.Kafka, s); err != nil {
@@ -651,11 +636,6 @@ func autoConvert_v1beta2_FlowCollectorExporter_To_v1beta1_FlowCollectorExporter(
 		return err
 	}
 	return nil
-}
-
-// Convert_v1beta2_FlowCollectorExporter_To_v1beta1_FlowCollectorExporter is an autogenerated conversion function.
-func Convert_v1beta2_FlowCollectorExporter_To_v1beta1_FlowCollectorExporter(in *v1beta2.FlowCollectorExporter, out *FlowCollectorExporter, s conversion.Scope) error {
-	return autoConvert_v1beta2_FlowCollectorExporter_To_v1beta1_FlowCollectorExporter(in, out, s)
 }
 
 func autoConvert_v1beta1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(in *FlowCollectorFLP, out *v1beta2.FlowCollectorFLP, s conversion.Scope) error {
@@ -676,7 +656,7 @@ func autoConvert_v1beta1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(in *FlowCo
 	}
 	out.KafkaConsumerQueueCapacity = in.KafkaConsumerQueueCapacity
 	out.KafkaConsumerBatchSize = in.KafkaConsumerBatchSize
-	out.LogTypes = (*string)(unsafe.Pointer(in.LogTypes))
+	out.LogTypes = (*v1beta2.FLPLogTypes)(unsafe.Pointer(in.LogTypes))
 	out.ConversationHeartbeatInterval = (*v1.Duration)(unsafe.Pointer(in.ConversationHeartbeatInterval))
 	out.ConversationEndTimeout = (*v1.Duration)(unsafe.Pointer(in.ConversationEndTimeout))
 	out.ConversationTerminatingTimeout = (*v1.Duration)(unsafe.Pointer(in.ConversationTerminatingTimeout))
@@ -686,11 +666,6 @@ func autoConvert_v1beta1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(in *FlowCo
 		return err
 	}
 	return nil
-}
-
-// Convert_v1beta1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP is an autogenerated conversion function.
-func Convert_v1beta1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(in *FlowCollectorFLP, out *v1beta2.FlowCollectorFLP, s conversion.Scope) error {
-	return autoConvert_v1beta1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(in, out, s)
 }
 
 func autoConvert_v1beta2_FlowCollectorFLP_To_v1beta1_FlowCollectorFLP(in *v1beta2.FlowCollectorFLP, out *FlowCollectorFLP, s conversion.Scope) error {
@@ -724,29 +699,19 @@ func autoConvert_v1beta2_FlowCollectorFLP_To_v1beta1_FlowCollectorFLP(in *v1beta
 }
 
 func autoConvert_v1beta1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(in *FlowCollectorHPA, out *v1beta2.FlowCollectorHPA, s conversion.Scope) error {
-	out.Status = in.Status
+	out.Status = v1beta2.HPAStatus(in.Status)
 	out.MinReplicas = (*int32)(unsafe.Pointer(in.MinReplicas))
 	out.MaxReplicas = in.MaxReplicas
 	out.Metrics = *(*[]v2.MetricSpec)(unsafe.Pointer(&in.Metrics))
 	return nil
-}
-
-// Convert_v1beta1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA is an autogenerated conversion function.
-func Convert_v1beta1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(in *FlowCollectorHPA, out *v1beta2.FlowCollectorHPA, s conversion.Scope) error {
-	return autoConvert_v1beta1_FlowCollectorHPA_To_v1beta2_FlowCollectorHPA(in, out, s)
 }
 
 func autoConvert_v1beta2_FlowCollectorHPA_To_v1beta1_FlowCollectorHPA(in *v1beta2.FlowCollectorHPA, out *FlowCollectorHPA, s conversion.Scope) error {
-	out.Status = in.Status
+	out.Status = string(in.Status)
 	out.MinReplicas = (*int32)(unsafe.Pointer(in.MinReplicas))
 	out.MaxReplicas = in.MaxReplicas
 	out.Metrics = *(*[]v2.MetricSpec)(unsafe.Pointer(&in.Metrics))
 	return nil
-}
-
-// Convert_v1beta2_FlowCollectorHPA_To_v1beta1_FlowCollectorHPA is an autogenerated conversion function.
-func Convert_v1beta2_FlowCollectorHPA_To_v1beta1_FlowCollectorHPA(in *v1beta2.FlowCollectorHPA, out *FlowCollectorHPA, s conversion.Scope) error {
-	return autoConvert_v1beta2_FlowCollectorHPA_To_v1beta1_FlowCollectorHPA(in, out, s)
 }
 
 func autoConvert_v1beta1_FlowCollectorIPFIX_To_v1beta2_FlowCollectorIPFIX(in *FlowCollectorIPFIX, out *v1beta2.FlowCollectorIPFIX, s conversion.Scope) error {
@@ -937,17 +902,12 @@ func autoConvert_v1beta1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(in *Flow
 	if err := Convert_v1beta1_FlowCollectorConsolePlugin_To_v1beta2_FlowCollectorConsolePlugin(&in.ConsolePlugin, &out.ConsolePlugin, s); err != nil {
 		return err
 	}
-	out.DeploymentModel = in.DeploymentModel
+	out.DeploymentModel = v1beta2.FlowCollectorDeploymentModel(in.DeploymentModel)
 	if err := Convert_v1beta1_FlowCollectorKafka_To_v1beta2_FlowCollectorKafka(&in.Kafka, &out.Kafka, s); err != nil {
 		return err
 	}
-	out.Exporters = *(*[]*v1beta2.FlowCollectorExporter)(unsafe.Pointer(&in.Exporters))
+	// INFO: in.Exporters opted out of conversion generation
 	return nil
-}
-
-// Convert_v1beta1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec is an autogenerated conversion function.
-func Convert_v1beta1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(in *FlowCollectorSpec, out *v1beta2.FlowCollectorSpec, s conversion.Scope) error {
-	return autoConvert_v1beta1_FlowCollectorSpec_To_v1beta2_FlowCollectorSpec(in, out, s)
 }
 
 func autoConvert_v1beta2_FlowCollectorSpec_To_v1beta1_FlowCollectorSpec(in *v1beta2.FlowCollectorSpec, out *FlowCollectorSpec, s conversion.Scope) error {
@@ -964,17 +924,12 @@ func autoConvert_v1beta2_FlowCollectorSpec_To_v1beta1_FlowCollectorSpec(in *v1be
 	if err := Convert_v1beta2_FlowCollectorConsolePlugin_To_v1beta1_FlowCollectorConsolePlugin(&in.ConsolePlugin, &out.ConsolePlugin, s); err != nil {
 		return err
 	}
-	out.DeploymentModel = in.DeploymentModel
+	out.DeploymentModel = string(in.DeploymentModel)
 	if err := Convert_v1beta2_FlowCollectorKafka_To_v1beta1_FlowCollectorKafka(&in.Kafka, &out.Kafka, s); err != nil {
 		return err
 	}
-	out.Exporters = *(*[]*FlowCollectorExporter)(unsafe.Pointer(&in.Exporters))
+	// INFO: in.Exporters opted out of conversion generation
 	return nil
-}
-
-// Convert_v1beta2_FlowCollectorSpec_To_v1beta1_FlowCollectorSpec is an autogenerated conversion function.
-func Convert_v1beta2_FlowCollectorSpec_To_v1beta1_FlowCollectorSpec(in *v1beta2.FlowCollectorSpec, out *FlowCollectorSpec, s conversion.Scope) error {
-	return autoConvert_v1beta2_FlowCollectorSpec_To_v1beta1_FlowCollectorSpec(in, out, s)
 }
 
 func autoConvert_v1beta1_FlowCollectorStatus_To_v1beta2_FlowCollectorStatus(in *FlowCollectorStatus, out *v1beta2.FlowCollectorStatus, s conversion.Scope) error {
@@ -1084,11 +1039,6 @@ func autoConvert_v1beta1_SASLConfig_To_v1beta2_SASLConfig(in *SASLConfig, out *v
 	return nil
 }
 
-// Convert_v1beta1_SASLConfig_To_v1beta2_SASLConfig is an autogenerated conversion function.
-func Convert_v1beta1_SASLConfig_To_v1beta2_SASLConfig(in *SASLConfig, out *v1beta2.SASLConfig, s conversion.Scope) error {
-	return autoConvert_v1beta1_SASLConfig_To_v1beta2_SASLConfig(in, out, s)
-}
-
 func autoConvert_v1beta2_SASLConfig_To_v1beta1_SASLConfig(in *v1beta2.SASLConfig, out *SASLConfig, s conversion.Scope) error {
 	out.Type = SASLType(in.Type)
 	if err := Convert_v1beta2_FileReference_To_v1beta1_FileReference(&in.ClientIDReference, &out.ClientIDReference, s); err != nil {
@@ -1100,11 +1050,6 @@ func autoConvert_v1beta2_SASLConfig_To_v1beta1_SASLConfig(in *v1beta2.SASLConfig
 	return nil
 }
 
-// Convert_v1beta2_SASLConfig_To_v1beta1_SASLConfig is an autogenerated conversion function.
-func Convert_v1beta2_SASLConfig_To_v1beta1_SASLConfig(in *v1beta2.SASLConfig, out *SASLConfig, s conversion.Scope) error {
-	return autoConvert_v1beta2_SASLConfig_To_v1beta1_SASLConfig(in, out, s)
-}
-
 func autoConvert_v1beta1_ServerTLS_To_v1beta2_ServerTLS(in *ServerTLS, out *v1beta2.ServerTLS, s conversion.Scope) error {
 	out.Type = v1beta2.ServerTLSConfigType(in.Type)
 	out.Provided = (*v1beta2.CertificateReference)(unsafe.Pointer(in.Provided))
@@ -1113,20 +1058,10 @@ func autoConvert_v1beta1_ServerTLS_To_v1beta2_ServerTLS(in *ServerTLS, out *v1be
 	return nil
 }
 
-// Convert_v1beta1_ServerTLS_To_v1beta2_ServerTLS is an autogenerated conversion function.
-func Convert_v1beta1_ServerTLS_To_v1beta2_ServerTLS(in *ServerTLS, out *v1beta2.ServerTLS, s conversion.Scope) error {
-	return autoConvert_v1beta1_ServerTLS_To_v1beta2_ServerTLS(in, out, s)
-}
-
 func autoConvert_v1beta2_ServerTLS_To_v1beta1_ServerTLS(in *v1beta2.ServerTLS, out *ServerTLS, s conversion.Scope) error {
 	out.Type = ServerTLSConfigType(in.Type)
 	out.Provided = (*CertificateReference)(unsafe.Pointer(in.Provided))
 	out.InsecureSkipVerify = in.InsecureSkipVerify
 	out.ProvidedCaFile = (*FileReference)(unsafe.Pointer(in.ProvidedCaFile))
 	return nil
-}
-
-// Convert_v1beta2_ServerTLS_To_v1beta1_ServerTLS is an autogenerated conversion function.
-func Convert_v1beta2_ServerTLS_To_v1beta1_ServerTLS(in *v1beta2.ServerTLS, out *ServerTLS, s conversion.Scope) error {
-	return autoConvert_v1beta2_ServerTLS_To_v1beta1_ServerTLS(in, out, s)
 }

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -329,7 +329,7 @@ func (in *FlowCollectorFLP) DeepCopyInto(out *FlowCollectorFLP) {
 	in.KafkaConsumerAutoscaler.DeepCopyInto(&out.KafkaConsumerAutoscaler)
 	if in.LogTypes != nil {
 		in, out := &in.LogTypes, &out.LogTypes
-		*out = new(string)
+		*out = new(FLPLogTypes)
 		**out = **in
 	}
 	if in.ConversationHeartbeatInterval != nil {

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -2552,7 +2552,7 @@ spec:
                           might have performance impacts. Possible values are:<br>
                           - `PacketDrop`: enable the packets drop flows logging feature.
                           This feature requires mounting the kernel debug filesystem,
-                          so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged`
+                          so the eBPF pod has to run as privileged. If the `spec.agent.ebpf.privileged`
                           parameter is not set, an error is reported.<br> - `DNSTracking`:
                           enable the DNS tracking feature.<br> - `FlowRTT` [unsupported
                           (*)]: enable flow latency (RTT) calculations in the eBPF
@@ -5180,7 +5180,7 @@ spec:
                 properties:
                   ebpf:
                     description: '`ebpf` describes the settings related to the eBPF-based
-                      flow reporter when `spec.agent.type` is set to `EBPF`.'
+                      flow reporter when `spec.agent.type` is set to `eBPF`.'
                     properties:
                       cacheActiveTimeout:
                         default: 5s
@@ -5237,7 +5237,7 @@ spec:
                           might have performance impacts. Possible values are:<br>
                           - `PacketDrop`: enable the packets drop flows logging feature.
                           This feature requires mounting the kernel debug filesystem,
-                          so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged`
+                          so the eBPF pod has to run as privileged. If the `spec.agent.ebpf.privileged`
                           parameter is not set, an error is reported.<br> - `DNSTracking`:
                           enable the DNS tracking feature.<br> - `FlowRTT`: enable
                           flow latency (RTT) calculations in the eBPF agent during
@@ -5439,16 +5439,16 @@ spec:
                         type: integer
                     type: object
                   type:
-                    default: EBPF
+                    default: eBPF
                     description: '`type` selects the flows tracing agent. Possible
-                      values are:<br> - `EBPF` (default) to use NetObserv eBPF agent.<br>
+                      values are:<br> - `eBPF` (default) to use NetObserv eBPF agent.<br>
                       - `IPFIX` [deprecated (*)] - to use the legacy IPFIX collector.<br>
-                      `EBPF` is recommended as it offers better performances and should
+                      `eBPF` is recommended as it offers better performances and should
                       work regardless of the CNI installed on the cluster. `IPFIX`
                       works with OVN-Kubernetes CNI (other CNIs could work if they
                       support exporting IPFIX, but they would require manual configuration).'
                     enum:
-                    - EBPF
+                    - eBPF
                     - IPFIX
                     type: string
                 type: object
@@ -5975,14 +5975,14 @@ spec:
                         format: int32
                         type: integer
                       status:
-                        default: DISABLED
+                        default: Disabled
                         description: '`status` describes the desired status regarding
-                          deploying an horizontal pod autoscaler.<br> - `DISABLED`
-                          does not deploy an horizontal pod autoscaler.<br> - `ENABLED`
+                          deploying an horizontal pod autoscaler.<br> - `Disabled`
+                          does not deploy an horizontal pod autoscaler.<br> - `Enabled`
                           deploys an horizontal pod autoscaler.<br>'
                         enum:
-                        - DISABLED
-                        - ENABLED
+                        - Disabled
+                        - Enabled
                         type: string
                     type: object
                   enable:
@@ -6157,16 +6157,16 @@ spec:
                     type: object
                 type: object
               deploymentModel:
-                default: DIRECT
+                default: Direct
                 description: '`deploymentModel` defines the desired type of deployment
-                  for flow processing. Possible values are:<br> - `DIRECT` (default)
+                  for flow processing. Possible values are:<br> - `Direct` (default)
                   to make the flow processor listening directly from the agents.<br>
-                  - `KAFKA` to make flows sent to a Kafka pipeline before consumption
+                  - `Kafka` to make flows sent to a Kafka pipeline before consumption
                   by the processor.<br> Kafka can provide better scalability, resiliency,
                   and high availability (for more details, see https://www.redhat.com/en/topics/integration/what-is-apache-kafka).'
                 enum:
-                - DIRECT
-                - KAFKA
+                - Direct
+                - Kafka
                 type: string
               exporters:
                 description: '`exporters` define additional optional exporters for
@@ -6268,13 +6268,13 @@ spec:
                                   type: string
                               type: object
                             type:
-                              default: DISABLED
+                              default: Disabled
                               description: Type of SASL authentication to use, or
-                                `DISABLED` if SASL is not used
+                                `Disabled` if SASL is not used
                               enum:
-                              - DISABLED
-                              - PLAIN
-                              - SCRAM-SHA512
+                              - Disabled
+                              - Plain
+                              - ScramSHA512
                               type: string
                           type: object
                         tls:
@@ -6375,9 +6375,9 @@ spec:
                       type: object
                     type:
                       description: '`type` selects the type of exporters. The available
-                        options are `KAFKA` and `IPFIX`.'
+                        options are `Kafka` and `IPFIX`.'
                       enum:
-                      - KAFKA
+                      - Kafka
                       - IPFIX
                       type: string
                   required:
@@ -6387,7 +6387,7 @@ spec:
               kafka:
                 description: Kafka configuration, allowing to use Kafka as a broker
                   as part of the flow collection pipeline. Available when the `spec.deploymentModel`
-                  is `KAFKA`.
+                  is `Kafka`.
                 properties:
                   address:
                     default: ""
@@ -6451,13 +6451,13 @@ spec:
                             type: string
                         type: object
                       type:
-                        default: DISABLED
-                        description: Type of SASL authentication to use, or `DISABLED`
+                        default: Disabled
+                        description: Type of SASL authentication to use, or `Disabled`
                           if SASL is not used
                         enum:
-                        - DISABLED
-                        - PLAIN
-                        - SCRAM-SHA512
+                        - Disabled
+                        - Plain
+                        - ScramSHA512
                         type: string
                     type: object
                   tls:
@@ -6591,18 +6591,18 @@ spec:
                       most flexible configuration. It is ignored for other modes.
                     properties:
                       authToken:
-                        default: DISABLED
+                        default: Disabled
                         description: '`authToken` describes the way to get a token
-                          to authenticate to Loki.<br> - `DISABLED` does not send
-                          any token with the request.<br> - `FORWARD` forwards the
-                          user token for authorization.<br> - `HOST` [deprecated (*)]
+                          to authenticate to Loki.<br> - `Disabled` does not send
+                          any token with the request.<br> - `Forward` forwards the
+                          user token for authorization.<br> - `Host` [deprecated (*)]
                           - uses the local pod service account to authenticate to
                           Loki.<br> When using the Loki Operator, this must be set
-                          to `FORWARD`.'
+                          to `Forward`.'
                         enum:
-                        - DISABLED
-                        - HOST
-                        - FORWARD
+                        - Disabled
+                        - Host
+                        - Forward
                         type: string
                       ingesterUrl:
                         default: http://loki:3100/
@@ -7653,14 +7653,14 @@ spec:
                         format: int32
                         type: integer
                       status:
-                        default: DISABLED
+                        default: Disabled
                         description: '`status` describes the desired status regarding
-                          deploying an horizontal pod autoscaler.<br> - `DISABLED`
-                          does not deploy an horizontal pod autoscaler.<br> - `ENABLED`
+                          deploying an horizontal pod autoscaler.<br> - `Disabled`
+                          does not deploy an horizontal pod autoscaler.<br> - `Enabled`
                           deploys an horizontal pod autoscaler.<br>'
                         enum:
-                        - DISABLED
-                        - ENABLED
+                        - Disabled
+                        - Enabled
                         type: string
                     type: object
                   kafkaConsumerBatchSize:
@@ -7696,19 +7696,19 @@ spec:
                     - panic
                     type: string
                   logTypes:
-                    default: FLOWS
+                    default: Flows
                     description: '`logTypes` defines the desired record types to generate.
-                      Possible values are:<br> - `FLOWS` (default) to export regular
-                      network flows<br> - `CONVERSATIONS` to generate events for started
+                      Possible values are:<br> - `Flows` (default) to export regular
+                      network flows<br> - `Conversations` to generate events for started
                       conversations, ended conversations as well as periodic "tick"
-                      updates<br> - `ENDED_CONVERSATIONS` to generate only ended conversations
-                      events<br> - `ALL` to generate both network flows and all conversations
+                      updates<br> - `EndedConversations` to generate only ended conversations
+                      events<br> - `All` to generate both network flows and all conversations
                       events<br>'
                     enum:
-                    - FLOWS
-                    - CONVERSATIONS
-                    - ENDED_CONVERSATIONS
-                    - ALL
+                    - Flows
+                    - Conversations
+                    - EndedConversations
+                    - All
                     type: string
                   metrics:
                     description: '`Metrics` define the processor configuration regarding
@@ -7799,7 +7799,7 @@ spec:
                                 type: boolean
                               provided:
                                 description: TLS configuration when `type` is set
-                                  to `PROVIDED`.
+                                  to `Provided`.
                                 properties:
                                   certFile:
                                     description: '`certFile` defines the path to the
@@ -7835,7 +7835,7 @@ spec:
                                 type: object
                               providedCaFile:
                                 description: Reference to the CA file when `type`
-                                  is set to `PROVIDED`.
+                                  is set to `Provided`.
                                 properties:
                                   file:
                                     description: File name within the config map or
@@ -7863,16 +7863,16 @@ spec:
                                     type: string
                                 type: object
                               type:
-                                default: DISABLED
+                                default: Disabled
                                 description: Select the type of TLS configuration:<br>
-                                  - `DISABLED` (default) to not configure TLS for
-                                  the endpoint. - `PROVIDED` to manually provide cert
-                                  file and a key file. - `AUTO` to use OpenShift auto
+                                  - `Disabled` (default) to not configure TLS for
+                                  the endpoint. - `Provided` to manually provide cert
+                                  file and a key file. - `Auto` to use OpenShift auto
                                   generated certificate using annotations.
                                 enum:
-                                - DISABLED
-                                - PROVIDED
-                                - AUTO
+                                - Disabled
+                                - Provided
+                                - Auto
                                 type: string
                             type: object
                         type: object

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -378,7 +378,7 @@ metadata:
                 },
                 "sampling": 50
               },
-              "type": "EBPF"
+              "type": "Ebpf"
             },
             "consolePlugin": {
               "autoscaler": {
@@ -396,7 +396,7 @@ metadata:
                   }
                 ],
                 "minReplicas": 1,
-                "status": "DISABLED"
+                "status": "Disabled"
               },
               "imagePullPolicy": "IfNotPresent",
               "logLevel": "info",
@@ -440,7 +440,7 @@ metadata:
               ],
               "register": true
             },
-            "deploymentModel": "DIRECT",
+            "deploymentModel": "Direct",
             "exporters": [],
             "kafka": {
               "address": "kafka-cluster-kafka-bootstrap.netobserv",
@@ -496,7 +496,7 @@ metadata:
               "kafkaConsumerQueueCapacity": 1000,
               "kafkaConsumerReplicas": 3,
               "logLevel": "info",
-              "logTypes": "FLOWS",
+              "logTypes": "Flows",
               "metrics": {
                 "disableAlerts": [],
                 "server": {

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -2538,7 +2538,7 @@ spec:
                           might have performance impacts. Possible values are:<br>
                           - `PacketDrop`: enable the packets drop flows logging feature.
                           This feature requires mounting the kernel debug filesystem,
-                          so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged`
+                          so the eBPF pod has to run as privileged. If the `spec.agent.ebpf.privileged`
                           parameter is not set, an error is reported.<br> - `DNSTracking`:
                           enable the DNS tracking feature.<br> - `FlowRTT` [unsupported
                           (*)]: enable flow latency (RTT) calculations in the eBPF
@@ -5166,7 +5166,7 @@ spec:
                 properties:
                   ebpf:
                     description: '`ebpf` describes the settings related to the eBPF-based
-                      flow reporter when `spec.agent.type` is set to `EBPF`.'
+                      flow reporter when `spec.agent.type` is set to `eBPF`.'
                     properties:
                       cacheActiveTimeout:
                         default: 5s
@@ -5223,7 +5223,7 @@ spec:
                           might have performance impacts. Possible values are:<br>
                           - `PacketDrop`: enable the packets drop flows logging feature.
                           This feature requires mounting the kernel debug filesystem,
-                          so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged`
+                          so the eBPF pod has to run as privileged. If the `spec.agent.ebpf.privileged`
                           parameter is not set, an error is reported.<br> - `DNSTracking`:
                           enable the DNS tracking feature.<br> - `FlowRTT`: enable
                           flow latency (RTT) calculations in the eBPF agent during
@@ -5425,16 +5425,16 @@ spec:
                         type: integer
                     type: object
                   type:
-                    default: EBPF
+                    default: eBPF
                     description: '`type` selects the flows tracing agent. Possible
-                      values are:<br> - `EBPF` (default) to use NetObserv eBPF agent.<br>
+                      values are:<br> - `eBPF` (default) to use NetObserv eBPF agent.<br>
                       - `IPFIX` [deprecated (*)] - to use the legacy IPFIX collector.<br>
-                      `EBPF` is recommended as it offers better performances and should
+                      `eBPF` is recommended as it offers better performances and should
                       work regardless of the CNI installed on the cluster. `IPFIX`
                       works with OVN-Kubernetes CNI (other CNIs could work if they
                       support exporting IPFIX, but they would require manual configuration).'
                     enum:
-                    - EBPF
+                    - eBPF
                     - IPFIX
                     type: string
                 type: object
@@ -5961,14 +5961,14 @@ spec:
                         format: int32
                         type: integer
                       status:
-                        default: DISABLED
+                        default: Disabled
                         description: '`status` describes the desired status regarding
-                          deploying an horizontal pod autoscaler.<br> - `DISABLED`
-                          does not deploy an horizontal pod autoscaler.<br> - `ENABLED`
+                          deploying an horizontal pod autoscaler.<br> - `Disabled`
+                          does not deploy an horizontal pod autoscaler.<br> - `Enabled`
                           deploys an horizontal pod autoscaler.<br>'
                         enum:
-                        - DISABLED
-                        - ENABLED
+                        - Disabled
+                        - Enabled
                         type: string
                     type: object
                   enable:
@@ -6143,16 +6143,16 @@ spec:
                     type: object
                 type: object
               deploymentModel:
-                default: DIRECT
+                default: Direct
                 description: '`deploymentModel` defines the desired type of deployment
-                  for flow processing. Possible values are:<br> - `DIRECT` (default)
+                  for flow processing. Possible values are:<br> - `Direct` (default)
                   to make the flow processor listening directly from the agents.<br>
-                  - `KAFKA` to make flows sent to a Kafka pipeline before consumption
+                  - `Kafka` to make flows sent to a Kafka pipeline before consumption
                   by the processor.<br> Kafka can provide better scalability, resiliency,
                   and high availability (for more details, see https://www.redhat.com/en/topics/integration/what-is-apache-kafka).'
                 enum:
-                - DIRECT
-                - KAFKA
+                - Direct
+                - Kafka
                 type: string
               exporters:
                 description: '`exporters` define additional optional exporters for
@@ -6254,13 +6254,13 @@ spec:
                                   type: string
                               type: object
                             type:
-                              default: DISABLED
+                              default: Disabled
                               description: Type of SASL authentication to use, or
-                                `DISABLED` if SASL is not used
+                                `Disabled` if SASL is not used
                               enum:
-                              - DISABLED
-                              - PLAIN
-                              - SCRAM-SHA512
+                              - Disabled
+                              - Plain
+                              - ScramSHA512
                               type: string
                           type: object
                         tls:
@@ -6361,9 +6361,9 @@ spec:
                       type: object
                     type:
                       description: '`type` selects the type of exporters. The available
-                        options are `KAFKA` and `IPFIX`.'
+                        options are `Kafka` and `IPFIX`.'
                       enum:
-                      - KAFKA
+                      - Kafka
                       - IPFIX
                       type: string
                   required:
@@ -6373,7 +6373,7 @@ spec:
               kafka:
                 description: Kafka configuration, allowing to use Kafka as a broker
                   as part of the flow collection pipeline. Available when the `spec.deploymentModel`
-                  is `KAFKA`.
+                  is `Kafka`.
                 properties:
                   address:
                     default: ""
@@ -6437,13 +6437,13 @@ spec:
                             type: string
                         type: object
                       type:
-                        default: DISABLED
-                        description: Type of SASL authentication to use, or `DISABLED`
+                        default: Disabled
+                        description: Type of SASL authentication to use, or `Disabled`
                           if SASL is not used
                         enum:
-                        - DISABLED
-                        - PLAIN
-                        - SCRAM-SHA512
+                        - Disabled
+                        - Plain
+                        - ScramSHA512
                         type: string
                     type: object
                   tls:
@@ -6577,18 +6577,18 @@ spec:
                       most flexible configuration. It is ignored for other modes.
                     properties:
                       authToken:
-                        default: DISABLED
+                        default: Disabled
                         description: '`authToken` describes the way to get a token
-                          to authenticate to Loki.<br> - `DISABLED` does not send
-                          any token with the request.<br> - `FORWARD` forwards the
-                          user token for authorization.<br> - `HOST` [deprecated (*)]
+                          to authenticate to Loki.<br> - `Disabled` does not send
+                          any token with the request.<br> - `Forward` forwards the
+                          user token for authorization.<br> - `Host` [deprecated (*)]
                           - uses the local pod service account to authenticate to
                           Loki.<br> When using the Loki Operator, this must be set
-                          to `FORWARD`.'
+                          to `Forward`.'
                         enum:
-                        - DISABLED
-                        - HOST
-                        - FORWARD
+                        - Disabled
+                        - Host
+                        - Forward
                         type: string
                       ingesterUrl:
                         default: http://loki:3100/
@@ -7639,14 +7639,14 @@ spec:
                         format: int32
                         type: integer
                       status:
-                        default: DISABLED
+                        default: Disabled
                         description: '`status` describes the desired status regarding
-                          deploying an horizontal pod autoscaler.<br> - `DISABLED`
-                          does not deploy an horizontal pod autoscaler.<br> - `ENABLED`
+                          deploying an horizontal pod autoscaler.<br> - `Disabled`
+                          does not deploy an horizontal pod autoscaler.<br> - `Enabled`
                           deploys an horizontal pod autoscaler.<br>'
                         enum:
-                        - DISABLED
-                        - ENABLED
+                        - Disabled
+                        - Enabled
                         type: string
                     type: object
                   kafkaConsumerBatchSize:
@@ -7682,19 +7682,19 @@ spec:
                     - panic
                     type: string
                   logTypes:
-                    default: FLOWS
+                    default: Flows
                     description: '`logTypes` defines the desired record types to generate.
-                      Possible values are:<br> - `FLOWS` (default) to export regular
-                      network flows<br> - `CONVERSATIONS` to generate events for started
+                      Possible values are:<br> - `Flows` (default) to export regular
+                      network flows<br> - `Conversations` to generate events for started
                       conversations, ended conversations as well as periodic "tick"
-                      updates<br> - `ENDED_CONVERSATIONS` to generate only ended conversations
-                      events<br> - `ALL` to generate both network flows and all conversations
+                      updates<br> - `EndedConversations` to generate only ended conversations
+                      events<br> - `All` to generate both network flows and all conversations
                       events<br>'
                     enum:
-                    - FLOWS
-                    - CONVERSATIONS
-                    - ENDED_CONVERSATIONS
-                    - ALL
+                    - Flows
+                    - Conversations
+                    - EndedConversations
+                    - All
                     type: string
                   metrics:
                     description: '`Metrics` define the processor configuration regarding
@@ -7785,7 +7785,7 @@ spec:
                                 type: boolean
                               provided:
                                 description: TLS configuration when `type` is set
-                                  to `PROVIDED`.
+                                  to `Provided`.
                                 properties:
                                   certFile:
                                     description: '`certFile` defines the path to the
@@ -7821,7 +7821,7 @@ spec:
                                 type: object
                               providedCaFile:
                                 description: Reference to the CA file when `type`
-                                  is set to `PROVIDED`.
+                                  is set to `Provided`.
                                 properties:
                                   file:
                                     description: File name within the config map or
@@ -7849,16 +7849,16 @@ spec:
                                     type: string
                                 type: object
                               type:
-                                default: DISABLED
+                                default: Disabled
                                 description: Select the type of TLS configuration:<br>
-                                  - `DISABLED` (default) to not configure TLS for
-                                  the endpoint. - `PROVIDED` to manually provide cert
-                                  file and a key file. - `AUTO` to use OpenShift auto
+                                  - `Disabled` (default) to not configure TLS for
+                                  the endpoint. - `Provided` to manually provide cert
+                                  file and a key file. - `Auto` to use OpenShift auto
                                   generated certificate using annotations.
                                 enum:
-                                - DISABLED
-                                - PROVIDED
-                                - AUTO
+                                - Disabled
+                                - Provided
+                                - Auto
                                 type: string
                             type: object
                         type: object

--- a/config/samples/flows_v1beta2_flowcollector.yaml
+++ b/config/samples/flows_v1beta2_flowcollector.yaml
@@ -4,9 +4,9 @@ metadata:
   name: cluster
 spec:
   namespace: netobserv
-  deploymentModel: DIRECT
+  deploymentModel: Direct
   agent:
-    type: EBPF
+    type: Ebpf
     ebpf:
       imagePullPolicy: IfNotPresent
       sampling: 50
@@ -53,7 +53,7 @@ spec:
     kafkaConsumerAutoscaler: null
     kafkaConsumerQueueCapacity: 1000
     kafkaConsumerBatchSize: 10485760
-    logTypes: FLOWS
+    logTypes: Flows
     conversationTerminatingTimeout: 5s
     conversationHeartbeatInterval: 30s
     conversationEndTimeout: 10s
@@ -101,7 +101,7 @@ spec:
     port: 9001
     logLevel: info
     autoscaler:
-      status: DISABLED
+      status: Disabled
       minReplicas: 1
       maxReplicas: 3
       metrics:
@@ -134,12 +134,12 @@ spec:
       filter:
         dst_kind: 'Service'
   exporters: []
-    # - type: KAFKA
+    # - type: Kafka
     #   kafka:
     #     address: "kafka-cluster-kafka-bootstrap.netobserv"
     #     topic: netobserv-flows-export
     # or
-    # - type: IPFIX
+    # - type: Ipfix
     #   ipfix:
     #     targetHost: "ipfix-collector.ipfix.svc.cluster.local"
     #     targetPort: 4739

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -99,7 +99,7 @@ func (c *AgentController) Reconcile(ctx context.Context, target *flowslatest.Flo
 	ctx = log.IntoContext(ctx, rlog)
 	current, err := c.current(ctx)
 	if err != nil {
-		return fmt.Errorf("fetching current EBPF Agent: %w", err)
+		return fmt.Errorf("fetching current eBPF agent: %w", err)
 	}
 	if !helper.UseEBPF(&target.Spec) || c.PreviousPrivilegedNamespace() != c.PrivilegedNamespace() {
 		if current == nil {

--- a/controllers/flowcollector_controller_certificates_test.go
+++ b/controllers/flowcollector_controller_certificates_test.go
@@ -145,7 +145,7 @@ func flowCollectorCertificatesSpecs() {
 			Namespace:       operatorNamespace,
 			DeploymentModel: flowslatest.DeploymentModelKafka,
 			Agent: flowslatest.FlowCollectorAgent{
-				Type: "EBPF",
+				Type: "eBPF",
 			},
 			Loki: flowslatest.FlowCollectorLoki{
 				Enable: ptr.To(true),
@@ -186,7 +186,7 @@ func flowCollectorCertificatesSpecs() {
 						},
 					},
 					SASL: flowslatest.SASLConfig{
-						Type: "PLAIN",
+						Type: "Plain",
 						ClientIDReference: flowslatest.FileReference{
 							Type: flowslatest.RefTypeSecret,
 							Name: kafka2Sasl.Name,

--- a/controllers/flowcollector_controller_ebpf_test.go
+++ b/controllers/flowcollector_controller_ebpf_test.go
@@ -61,7 +61,7 @@ func flowCollectorEBPFSpecs() {
 						LogLevel:        "error",
 					},
 					Agent: flowslatest.FlowCollectorAgent{
-						Type: "EBPF",
+						Type: "eBPF",
 						EBPF: flowslatest.FlowCollectorEBPF{
 							Sampling:           ptr.To(int32(123)),
 							CacheActiveTimeout: "15s",
@@ -281,7 +281,7 @@ func flowCollectorEBPFKafkaSpecs() {
 				ObjectMeta: metav1.ObjectMeta{Name: crKey.Name},
 				Spec: flowslatest.FlowCollectorSpec{
 					Namespace:       operatorNamespace,
-					Agent:           flowslatest.FlowCollectorAgent{Type: "EBPF"},
+					Agent:           flowslatest.FlowCollectorAgent{Type: "eBPF"},
 					DeploymentModel: flowslatest.DeploymentModelKafka,
 					Kafka: flowslatest.FlowCollectorKafka{
 						Address: "kafka-cluster-kafka-bootstrap",

--- a/controllers/flowcollector_controller_iso_test.go
+++ b/controllers/flowcollector_controller_iso_test.go
@@ -65,7 +65,7 @@ func flowCollectorIsoSpecs() {
 				LogLevel:                       "trace",
 				Resources:                      v1.ResourceRequirements{Limits: nil, Requests: nil},
 				KafkaConsumerReplicas:          &zero,
-				KafkaConsumerAutoscaler:        flowslatest.FlowCollectorHPA{Status: "DISABLED", MinReplicas: &zero, MaxReplicas: zero, Metrics: []ascv2.MetricSpec{}},
+				KafkaConsumerAutoscaler:        flowslatest.FlowCollectorHPA{Status: "Disabled", MinReplicas: &zero, MaxReplicas: zero, Metrics: []ascv2.MetricSpec{}},
 				KafkaConsumerQueueCapacity:     int(zero),
 				KafkaConsumerBatchSize:         int(zero),
 				ConversationHeartbeatInterval:  &metav1.Duration{Duration: time.Second},
@@ -79,7 +79,7 @@ func flowCollectorIsoSpecs() {
 					Server: flowslatest.MetricsServerConfig{
 						Port: 12347,
 						TLS: flowslatest.ServerTLS{
-							Type:     "DISABLED",
+							Type:     "Disabled",
 							Provided: nil,
 						},
 					},
@@ -89,7 +89,7 @@ func flowCollectorIsoSpecs() {
 				DropUnusedFields: ptr.To(false),
 			},
 			Agent: flowslatest.FlowCollectorAgent{
-				Type: "EBPF",
+				Type: "eBPF",
 				IPFIX: flowslatest.FlowCollectorIPFIX{
 					Sampling:           2, // 0 is forbidden here
 					CacheActiveTimeout: "5s",
@@ -127,7 +127,7 @@ func flowCollectorIsoSpecs() {
 				ImagePullPolicy: "Always",
 				Resources:       v1.ResourceRequirements{Limits: nil, Requests: nil},
 				LogLevel:        "trace",
-				Autoscaler:      flowslatest.FlowCollectorHPA{Status: "DISABLED", MinReplicas: &zero, MaxReplicas: zero, Metrics: []ascv2.MetricSpec{}},
+				Autoscaler:      flowslatest.FlowCollectorHPA{Status: "Disabled", MinReplicas: &zero, MaxReplicas: zero, Metrics: []ascv2.MetricSpec{}},
 				PortNaming: flowslatest.ConsolePluginPortConfig{
 					Enable:    ptr.To(false),
 					PortNames: map[string]string{},
@@ -142,7 +142,7 @@ func flowCollectorIsoSpecs() {
 					QuerierURL:  "http://loki",
 					StatusURL:   "",
 					TenantID:    "test",
-					AuthToken:   "DISABLED",
+					AuthToken:   "Disabled",
 					TLS:         defaultTLS,
 					StatusTLS:   defaultTLS,
 				},
@@ -174,7 +174,7 @@ func flowCollectorIsoSpecs() {
 				Topic:   "topic",
 				TLS:     defaultTLS,
 				SASL: flowslatest.SASLConfig{
-					Type: "DISABLED",
+					Type: "Disabled",
 					ClientIDReference: flowslatest.FileReference{
 						Type:      "configmap",
 						Name:      "",

--- a/controllers/flp/flp_common_objects.go
+++ b/controllers/flp/flp_common_objects.go
@@ -79,6 +79,8 @@ func NewBuilder(info *reconcilers.Instance, desired *flowslatest.FlowCollectorSp
 			CertFile: "tls.crt",
 			CertKey:  "tls.key",
 		}
+	case flowslatest.ServerTLSDisabled:
+		// nothing to do there
 	}
 	return builder{
 		info: info,
@@ -463,7 +465,7 @@ func (b *builder) prometheusRule() *monitoringv1.PrometheusRule {
 	// Not receiving flows
 	if shouldAddAlert(flowslatest.AlertNoFlows, b.desired.Processor.Metrics.DisableAlerts) {
 		rules = append(rules, monitoringv1.Rule{
-			Alert: flowslatest.AlertNoFlows,
+			Alert: string(flowslatest.AlertNoFlows),
 			Annotations: map[string]string{
 				"description": "NetObserv flowlogs-pipeline is not receiving any flow, this is either a connection issue with the agent, or an agent issue",
 				"summary":     "NetObserv flowlogs-pipeline is not receiving any flow",
@@ -480,7 +482,7 @@ func (b *builder) prometheusRule() *monitoringv1.PrometheusRule {
 	// Flows getting dropped by loki library
 	if shouldAddAlert(flowslatest.AlertLokiError, b.desired.Processor.Metrics.DisableAlerts) {
 		rules = append(rules, monitoringv1.Rule{
-			Alert: flowslatest.AlertLokiError,
+			Alert: string(flowslatest.AlertLokiError),
 			Annotations: map[string]string{
 				"description": "NetObserv flowlogs-pipeline is dropping flows because of loki errors, loki may be down or having issues ingesting every flows. Please check loki and flowlogs-pipeline logs.",
 				"summary":     "NetObserv flowlogs-pipeline is dropping flows because of loki errors",

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -4556,7 +4556,7 @@ Agent configuration for flows extraction.
         <td><b>features</b></td>
         <td>[]enum</td>
         <td>
-          List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are:<br> - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting the kernel debug filesystem, so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged` parameter is not set, an error is reported.<br> - `DNSTracking`: enable the DNS tracking feature.<br> - `FlowRTT` [unsupported (*)]: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br><br/>
+          List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are:<br> - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting the kernel debug filesystem, so the eBPF pod has to run as privileged. If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported.<br> - `DNSTracking`: enable the DNS tracking feature.<br> - `FlowRTT` [unsupported (*)]: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br><br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9053,10 +9053,10 @@ Defines the desired state of the FlowCollector resource. <br><br> *: the mention
         <td><b>deploymentModel</b></td>
         <td>enum</td>
         <td>
-          `deploymentModel` defines the desired type of deployment for flow processing. Possible values are:<br> - `DIRECT` (default) to make the flow processor listening directly from the agents.<br> - `KAFKA` to make flows sent to a Kafka pipeline before consumption by the processor.<br> Kafka can provide better scalability, resiliency, and high availability (for more details, see https://www.redhat.com/en/topics/integration/what-is-apache-kafka).<br/>
+          `deploymentModel` defines the desired type of deployment for flow processing. Possible values are:<br> - `Direct` (default) to make the flow processor listening directly from the agents.<br> - `Kafka` to make flows sent to a Kafka pipeline before consumption by the processor.<br> Kafka can provide better scalability, resiliency, and high availability (for more details, see https://www.redhat.com/en/topics/integration/what-is-apache-kafka).<br/>
           <br/>
-            <i>Enum</i>: DIRECT, KAFKA<br/>
-            <i>Default</i>: DIRECT<br/>
+            <i>Enum</i>: Direct, Kafka<br/>
+            <i>Default</i>: Direct<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9070,7 +9070,7 @@ Defines the desired state of the FlowCollector resource. <br><br> *: the mention
         <td><b><a href="#flowcollectorspeckafka-1">kafka</a></b></td>
         <td>object</td>
         <td>
-          Kafka configuration, allowing to use Kafka as a broker as part of the flow collection pipeline. Available when the `spec.deploymentModel` is `KAFKA`.<br/>
+          Kafka configuration, allowing to use Kafka as a broker as part of the flow collection pipeline. Available when the `spec.deploymentModel` is `Kafka`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9120,7 +9120,7 @@ Agent configuration for flows extraction.
         <td><b><a href="#flowcollectorspecagentebpf-1">ebpf</a></b></td>
         <td>object</td>
         <td>
-          `ebpf` describes the settings related to the eBPF-based flow reporter when `spec.agent.type` is set to `EBPF`.<br/>
+          `ebpf` describes the settings related to the eBPF-based flow reporter when `spec.agent.type` is set to `eBPF`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9134,10 +9134,10 @@ Agent configuration for flows extraction.
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          `type` selects the flows tracing agent. Possible values are:<br> - `EBPF` (default) to use NetObserv eBPF agent.<br> - `IPFIX` [deprecated (*)] - to use the legacy IPFIX collector.<br> `EBPF` is recommended as it offers better performances and should work regardless of the CNI installed on the cluster. `IPFIX` works with OVN-Kubernetes CNI (other CNIs could work if they support exporting IPFIX, but they would require manual configuration).<br/>
+          `type` selects the flows tracing agent. Possible values are:<br> - `eBPF` (default) to use NetObserv eBPF agent.<br> - `IPFIX` [deprecated (*)] - to use the legacy IPFIX collector.<br> `eBPF` is recommended as it offers better performances and should work regardless of the CNI installed on the cluster. `IPFIX` works with OVN-Kubernetes CNI (other CNIs could work if they support exporting IPFIX, but they would require manual configuration).<br/>
           <br/>
-            <i>Enum</i>: EBPF, IPFIX<br/>
-            <i>Default</i>: EBPF<br/>
+            <i>Enum</i>: eBPF, IPFIX<br/>
+            <i>Default</i>: eBPF<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -9149,7 +9149,7 @@ Agent configuration for flows extraction.
 
 
 
-`ebpf` describes the settings related to the eBPF-based flow reporter when `spec.agent.type` is set to `EBPF`.
+`ebpf` describes the settings related to the eBPF-based flow reporter when `spec.agent.type` is set to `eBPF`.
 
 <table>
     <thead>
@@ -9200,7 +9200,7 @@ Agent configuration for flows extraction.
         <td><b>features</b></td>
         <td>[]enum</td>
         <td>
-          List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are:<br> - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting the kernel debug filesystem, so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged` parameter is not set, an error is reported.<br> - `DNSTracking`: enable the DNS tracking feature.<br> - `FlowRTT`: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br><br/>
+          List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are:<br> - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting the kernel debug filesystem, so the eBPF pod has to run as privileged. If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported.<br> - `DNSTracking`: enable the DNS tracking feature.<br> - `FlowRTT`: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br><br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -9678,10 +9678,10 @@ ResourceClaim references one entry in PodSpec.ResourceClaims.
         <td><b>status</b></td>
         <td>enum</td>
         <td>
-          `status` describes the desired status regarding deploying an horizontal pod autoscaler.<br> - `DISABLED` does not deploy an horizontal pod autoscaler.<br> - `ENABLED` deploys an horizontal pod autoscaler.<br><br/>
+          `status` describes the desired status regarding deploying an horizontal pod autoscaler.<br> - `Disabled` does not deploy an horizontal pod autoscaler.<br> - `Enabled` deploys an horizontal pod autoscaler.<br><br/>
           <br/>
-            <i>Enum</i>: DISABLED, ENABLED<br/>
-            <i>Default</i>: DISABLED<br/>
+            <i>Enum</i>: Disabled, Enabled<br/>
+            <i>Default</i>: Disabled<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -10719,9 +10719,9 @@ ResourceClaim references one entry in PodSpec.ResourceClaims.
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          `type` selects the type of exporters. The available options are `KAFKA` and `IPFIX`.<br/>
+          `type` selects the type of exporters. The available options are `Kafka` and `IPFIX`.<br/>
           <br/>
-            <i>Enum</i>: KAFKA, IPFIX<br/>
+            <i>Enum</i>: Kafka, IPFIX<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -10873,10 +10873,10 @@ SASL authentication configuration. [Unsupported (*)].
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Type of SASL authentication to use, or `DISABLED` if SASL is not used<br/>
+          Type of SASL authentication to use, or `Disabled` if SASL is not used<br/>
           <br/>
-            <i>Enum</i>: DISABLED, PLAIN, SCRAM-SHA512<br/>
-            <i>Default</i>: DISABLED<br/>
+            <i>Enum</i>: Disabled, Plain, ScramSHA512<br/>
+            <i>Default</i>: Disabled<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11162,7 +11162,7 @@ TLS client configuration. When using TLS, verify that the address matches the Ka
 
 
 
-Kafka configuration, allowing to use Kafka as a broker as part of the flow collection pipeline. Available when the `spec.deploymentModel` is `KAFKA`.
+Kafka configuration, allowing to use Kafka as a broker as part of the flow collection pipeline. Available when the `spec.deploymentModel` is `Kafka`.
 
 <table>
     <thead>
@@ -11243,10 +11243,10 @@ SASL authentication configuration. [Unsupported (*)].
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Type of SASL authentication to use, or `DISABLED` if SASL is not used<br/>
+          Type of SASL authentication to use, or `Disabled` if SASL is not used<br/>
           <br/>
-            <i>Enum</i>: DISABLED, PLAIN, SCRAM-SHA512<br/>
-            <i>Default</i>: DISABLED<br/>
+            <i>Enum</i>: Disabled, Plain, ScramSHA512<br/>
+            <i>Default</i>: Disabled<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -11717,10 +11717,10 @@ Loki configuration for "Manual" mode. This is the most flexible configuration. I
         <td><b>authToken</b></td>
         <td>enum</td>
         <td>
-          `authToken` describes the way to get a token to authenticate to Loki.<br> - `DISABLED` does not send any token with the request.<br> - `FORWARD` forwards the user token for authorization.<br> - `HOST` [deprecated (*)] - uses the local pod service account to authenticate to Loki.<br> When using the Loki Operator, this must be set to `FORWARD`.<br/>
+          `authToken` describes the way to get a token to authenticate to Loki.<br> - `Disabled` does not send any token with the request.<br> - `Forward` forwards the user token for authorization.<br> - `Host` [deprecated (*)] - uses the local pod service account to authenticate to Loki.<br> When using the Loki Operator, this must be set to `Forward`.<br/>
           <br/>
-            <i>Enum</i>: DISABLED, HOST, FORWARD<br/>
-            <i>Default</i>: DISABLED<br/>
+            <i>Enum</i>: Disabled, Host, Forward<br/>
+            <i>Default</i>: Disabled<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12703,10 +12703,10 @@ TLS client configuration for Loki URL.
         <td><b>logTypes</b></td>
         <td>enum</td>
         <td>
-          `logTypes` defines the desired record types to generate. Possible values are:<br> - `FLOWS` (default) to export regular network flows<br> - `CONVERSATIONS` to generate events for started conversations, ended conversations as well as periodic "tick" updates<br> - `ENDED_CONVERSATIONS` to generate only ended conversations events<br> - `ALL` to generate both network flows and all conversations events<br><br/>
+          `logTypes` defines the desired record types to generate. Possible values are:<br> - `Flows` (default) to export regular network flows<br> - `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates<br> - `EndedConversations` to generate only ended conversations events<br> - `All` to generate both network flows and all conversations events<br><br/>
           <br/>
-            <i>Enum</i>: FLOWS, CONVERSATIONS, ENDED_CONVERSATIONS, ALL<br/>
-            <i>Default</i>: FLOWS<br/>
+            <i>Enum</i>: Flows, Conversations, EndedConversations, All<br/>
+            <i>Default</i>: Flows<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12834,10 +12834,10 @@ TLS client configuration for Loki URL.
         <td><b>status</b></td>
         <td>enum</td>
         <td>
-          `status` describes the desired status regarding deploying an horizontal pod autoscaler.<br> - `DISABLED` does not deploy an horizontal pod autoscaler.<br> - `ENABLED` deploys an horizontal pod autoscaler.<br><br/>
+          `status` describes the desired status regarding deploying an horizontal pod autoscaler.<br> - `Disabled` does not deploy an horizontal pod autoscaler.<br> - `Enabled` deploys an horizontal pod autoscaler.<br><br/>
           <br/>
-            <i>Enum</i>: DISABLED, ENABLED<br/>
-            <i>Default</i>: DISABLED<br/>
+            <i>Enum</i>: Disabled, Enabled<br/>
+            <i>Default</i>: Disabled<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13817,24 +13817,24 @@ TLS configuration.
         <td><b><a href="#flowcollectorspecprocessormetricsservertlsprovided-1">provided</a></b></td>
         <td>object</td>
         <td>
-          TLS configuration when `type` is set to `PROVIDED`.<br/>
+          TLS configuration when `type` is set to `Provided`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b><a href="#flowcollectorspecprocessormetricsservertlsprovidedcafile-1">providedCaFile</a></b></td>
         <td>object</td>
         <td>
-          Reference to the CA file when `type` is set to `PROVIDED`.<br/>
+          Reference to the CA file when `type` is set to `Provided`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Select the type of TLS configuration:<br> - `DISABLED` (default) to not configure TLS for the endpoint. - `PROVIDED` to manually provide cert file and a key file. - `AUTO` to use OpenShift auto generated certificate using annotations.<br/>
+          Select the type of TLS configuration:<br> - `Disabled` (default) to not configure TLS for the endpoint. - `Provided` to manually provide cert file and a key file. - `Auto` to use OpenShift auto generated certificate using annotations.<br/>
           <br/>
-            <i>Enum</i>: DISABLED, PROVIDED, AUTO<br/>
-            <i>Default</i>: DISABLED<br/>
+            <i>Enum</i>: Disabled, Provided, Auto<br/>
+            <i>Default</i>: Disabled<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13846,7 +13846,7 @@ TLS configuration.
 
 
 
-TLS configuration when `type` is set to `PROVIDED`.
+TLS configuration when `type` is set to `Provided`.
 
 <table>
     <thead>
@@ -13905,7 +13905,7 @@ TLS configuration when `type` is set to `PROVIDED`.
 
 
 
-Reference to the CA file when `type` is set to `PROVIDED`.
+Reference to the CA file when `type` is set to `Provided`.
 
 <table>
     <thead>

--- a/hack/cloned.flows.netobserv.io_flowcollectors.yaml
+++ b/hack/cloned.flows.netobserv.io_flowcollectors.yaml
@@ -1769,7 +1769,7 @@ spec:
                             type: string
                           type: array
                         features:
-                          description: 'List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are:<br> - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting the kernel debug filesystem, so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged` parameter is not set, an error is reported.<br> - `DNSTracking`: enable the DNS tracking feature.<br> - `FlowRTT` [unsupported (*)]: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br>'
+                          description: 'List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are:<br> - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting the kernel debug filesystem, so the eBPF pod has to run as privileged. If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported.<br> - `DNSTracking`: enable the DNS tracking feature.<br> - `FlowRTT` [unsupported (*)]: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br>'
                           items:
                             description: Agent feature, can be one of:<br> - `PacketDrop`, to track packet drops.<br> - `DNSTracking`, to track specific information on DNS traffic.<br> - `FlowRTT`, to track TCP latency. [Unsupported (*)].<br>
                             enum:
@@ -3596,7 +3596,7 @@ spec:
                   description: Agent configuration for flows extraction.
                   properties:
                     ebpf:
-                      description: '`ebpf` describes the settings related to the eBPF-based flow reporter when `spec.agent.type` is set to `EBPF`.'
+                      description: '`ebpf` describes the settings related to the eBPF-based flow reporter when `spec.agent.type` is set to `eBPF`.'
                       properties:
                         cacheActiveTimeout:
                           default: 5s
@@ -3626,7 +3626,7 @@ spec:
                             type: string
                           type: array
                         features:
-                          description: 'List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are:<br> - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting the kernel debug filesystem, so the eBPF pod has to run as privileged. If the `spec.agent.eBPF.privileged` parameter is not set, an error is reported.<br> - `DNSTracking`: enable the DNS tracking feature.<br> - `FlowRTT`: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br>'
+                          description: 'List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are:<br> - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting the kernel debug filesystem, so the eBPF pod has to run as privileged. If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported.<br> - `DNSTracking`: enable the DNS tracking feature.<br> - `FlowRTT`: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1.<br>'
                           items:
                             description: Agent feature, can be one of:<br> - `PacketDrop`, to track packet drops.<br> - `DNSTracking`, to track specific information on DNS traffic.<br> - `FlowRTT`, to track TCP latency.<br>
                             enum:
@@ -3767,10 +3767,10 @@ spec:
                           type: integer
                       type: object
                     type:
-                      default: EBPF
-                      description: '`type` selects the flows tracing agent. Possible values are:<br> - `EBPF` (default) to use NetObserv eBPF agent.<br> - `IPFIX` [deprecated (*)] - to use the legacy IPFIX collector.<br> `EBPF` is recommended as it offers better performances and should work regardless of the CNI installed on the cluster. `IPFIX` works with OVN-Kubernetes CNI (other CNIs could work if they support exporting IPFIX, but they would require manual configuration).'
+                      default: eBPF
+                      description: '`type` selects the flows tracing agent. Possible values are:<br> - `eBPF` (default) to use NetObserv eBPF agent.<br> - `IPFIX` [deprecated (*)] - to use the legacy IPFIX collector.<br> `eBPF` is recommended as it offers better performances and should work regardless of the CNI installed on the cluster. `IPFIX` works with OVN-Kubernetes CNI (other CNIs could work if they support exporting IPFIX, but they would require manual configuration).'
                       enum:
-                        - EBPF
+                        - eBPF
                         - IPFIX
                       type: string
                   type: object
@@ -4116,11 +4116,11 @@ spec:
                           format: int32
                           type: integer
                         status:
-                          default: DISABLED
-                          description: '`status` describes the desired status regarding deploying an horizontal pod autoscaler.<br> - `DISABLED` does not deploy an horizontal pod autoscaler.<br> - `ENABLED` deploys an horizontal pod autoscaler.<br>'
+                          default: Disabled
+                          description: '`status` describes the desired status regarding deploying an horizontal pod autoscaler.<br> - `Disabled` does not deploy an horizontal pod autoscaler.<br> - `Enabled` deploys an horizontal pod autoscaler.<br>'
                           enum:
-                            - DISABLED
-                            - ENABLED
+                            - Disabled
+                            - Enabled
                           type: string
                       type: object
                     enable:
@@ -4263,11 +4263,11 @@ spec:
                       type: object
                   type: object
                 deploymentModel:
-                  default: DIRECT
-                  description: '`deploymentModel` defines the desired type of deployment for flow processing. Possible values are:<br> - `DIRECT` (default) to make the flow processor listening directly from the agents.<br> - `KAFKA` to make flows sent to a Kafka pipeline before consumption by the processor.<br> Kafka can provide better scalability, resiliency, and high availability (for more details, see https://www.redhat.com/en/topics/integration/what-is-apache-kafka).'
+                  default: Direct
+                  description: '`deploymentModel` defines the desired type of deployment for flow processing. Possible values are:<br> - `Direct` (default) to make the flow processor listening directly from the agents.<br> - `Kafka` to make flows sent to a Kafka pipeline before consumption by the processor.<br> Kafka can provide better scalability, resiliency, and high availability (for more details, see https://www.redhat.com/en/topics/integration/what-is-apache-kafka).'
                   enum:
-                    - DIRECT
-                    - KAFKA
+                    - Direct
+                    - Kafka
                   type: string
                 exporters:
                   description: '`exporters` define additional optional exporters for custom consumption or storage.'
@@ -4345,12 +4345,12 @@ spec:
                                     type: string
                                 type: object
                               type:
-                                default: DISABLED
-                                description: Type of SASL authentication to use, or `DISABLED` if SASL is not used
+                                default: Disabled
+                                description: Type of SASL authentication to use, or `Disabled` if SASL is not used
                                 enum:
-                                  - DISABLED
-                                  - PLAIN
-                                  - SCRAM-SHA512
+                                  - Disabled
+                                  - Plain
+                                  - ScramSHA512
                                 type: string
                             type: object
                           tls:
@@ -4420,9 +4420,9 @@ spec:
                           - topic
                         type: object
                       type:
-                        description: '`type` selects the type of exporters. The available options are `KAFKA` and `IPFIX`.'
+                        description: '`type` selects the type of exporters. The available options are `Kafka` and `IPFIX`.'
                         enum:
-                          - KAFKA
+                          - Kafka
                           - IPFIX
                         type: string
                     required:
@@ -4430,7 +4430,7 @@ spec:
                     type: object
                   type: array
                 kafka:
-                  description: Kafka configuration, allowing to use Kafka as a broker as part of the flow collection pipeline. Available when the `spec.deploymentModel` is `KAFKA`.
+                  description: Kafka configuration, allowing to use Kafka as a broker as part of the flow collection pipeline. Available when the `spec.deploymentModel` is `Kafka`.
                   properties:
                     address:
                       default: ""
@@ -4480,12 +4480,12 @@ spec:
                               type: string
                           type: object
                         type:
-                          default: DISABLED
-                          description: Type of SASL authentication to use, or `DISABLED` if SASL is not used
+                          default: Disabled
+                          description: Type of SASL authentication to use, or `Disabled` if SASL is not used
                           enum:
-                            - DISABLED
-                            - PLAIN
-                            - SCRAM-SHA512
+                            - Disabled
+                            - Plain
+                            - ScramSHA512
                           type: string
                       type: object
                     tls:
@@ -4586,12 +4586,12 @@ spec:
                       description: Loki configuration for "Manual" mode. This is the most flexible configuration. It is ignored for other modes.
                       properties:
                         authToken:
-                          default: DISABLED
-                          description: '`authToken` describes the way to get a token to authenticate to Loki.<br> - `DISABLED` does not send any token with the request.<br> - `FORWARD` forwards the user token for authorization.<br> - `HOST` [deprecated (*)] - uses the local pod service account to authenticate to Loki.<br> When using the Loki Operator, this must be set to `FORWARD`.'
+                          default: Disabled
+                          description: '`authToken` describes the way to get a token to authenticate to Loki.<br> - `Disabled` does not send any token with the request.<br> - `Forward` forwards the user token for authorization.<br> - `Host` [deprecated (*)] - uses the local pod service account to authenticate to Loki.<br> When using the Loki Operator, this must be set to `Forward`.'
                           enum:
-                            - DISABLED
-                            - HOST
-                            - FORWARD
+                            - Disabled
+                            - Host
+                            - Forward
                           type: string
                         ingesterUrl:
                           default: http://loki:3100/
@@ -5298,11 +5298,11 @@ spec:
                           format: int32
                           type: integer
                         status:
-                          default: DISABLED
-                          description: '`status` describes the desired status regarding deploying an horizontal pod autoscaler.<br> - `DISABLED` does not deploy an horizontal pod autoscaler.<br> - `ENABLED` deploys an horizontal pod autoscaler.<br>'
+                          default: Disabled
+                          description: '`status` describes the desired status regarding deploying an horizontal pod autoscaler.<br> - `Disabled` does not deploy an horizontal pod autoscaler.<br> - `Enabled` deploys an horizontal pod autoscaler.<br>'
                           enum:
-                            - DISABLED
-                            - ENABLED
+                            - Disabled
+                            - Enabled
                           type: string
                       type: object
                     kafkaConsumerBatchSize:
@@ -5332,13 +5332,13 @@ spec:
                         - panic
                       type: string
                     logTypes:
-                      default: FLOWS
-                      description: '`logTypes` defines the desired record types to generate. Possible values are:<br> - `FLOWS` (default) to export regular network flows<br> - `CONVERSATIONS` to generate events for started conversations, ended conversations as well as periodic "tick" updates<br> - `ENDED_CONVERSATIONS` to generate only ended conversations events<br> - `ALL` to generate both network flows and all conversations events<br>'
+                      default: Flows
+                      description: '`logTypes` defines the desired record types to generate. Possible values are:<br> - `Flows` (default) to export regular network flows<br> - `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates<br> - `EndedConversations` to generate only ended conversations events<br> - `All` to generate both network flows and all conversations events<br>'
                       enum:
-                        - FLOWS
-                        - CONVERSATIONS
-                        - ENDED_CONVERSATIONS
-                        - ALL
+                        - Flows
+                        - Conversations
+                        - EndedConversations
+                        - All
                       type: string
                     metrics:
                       description: '`Metrics` define the processor configuration regarding metrics'
@@ -5404,7 +5404,7 @@ spec:
                                   description: '`insecureSkipVerify` allows skipping client-side verification of the provided certificate. If set to `true`, the `providedCaFile` field is ignored.'
                                   type: boolean
                                 provided:
-                                  description: TLS configuration when `type` is set to `PROVIDED`.
+                                  description: TLS configuration when `type` is set to `Provided`.
                                   properties:
                                     certFile:
                                       description: '`certFile` defines the path to the certificate file name within the config map or secret'
@@ -5427,7 +5427,7 @@ spec:
                                       type: string
                                   type: object
                                 providedCaFile:
-                                  description: Reference to the CA file when `type` is set to `PROVIDED`.
+                                  description: Reference to the CA file when `type` is set to `Provided`.
                                   properties:
                                     file:
                                       description: File name within the config map or secret
@@ -5447,12 +5447,12 @@ spec:
                                       type: string
                                   type: object
                                 type:
-                                  default: DISABLED
-                                  description: Select the type of TLS configuration:<br> - `DISABLED` (default) to not configure TLS for the endpoint. - `PROVIDED` to manually provide cert file and a key file. - `AUTO` to use OpenShift auto generated certificate using annotations.
+                                  default: Disabled
+                                  description: Select the type of TLS configuration:<br> - `Disabled` (default) to not configure TLS for the endpoint. - `Provided` to manually provide cert file and a key file. - `Auto` to use OpenShift auto generated certificate using annotations.
                                   enum:
-                                    - DISABLED
-                                    - PROVIDED
-                                    - AUTO
+                                    - Disabled
+                                    - Provided
+                                    - Auto
                                   type: string
                               type: object
                           type: object

--- a/pkg/conversion/conversion.go
+++ b/pkg/conversion/conversion.go
@@ -2,11 +2,25 @@
 package conversion
 
 import (
+	"regexp"
+	"strings"
+	"unicode"
+
 	"github.com/netobserv/network-observability-operator/controllers/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 )
+
+// Following K8S convention, mixed capitalization should be preserved
+// see https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#constants
+var upperPascalExceptions = map[string]string{
+	"IPFIX":        "IPFIX",
+	"EBPF":         "eBPF",
+	"SCRAM-SHA512": "ScramSHA512",
+}
+
+var upperTokenizer = regexp.MustCompile(`[\-\_]+`)
 
 // MarshalData stores the source object as json data in the destination object annotations map.
 // It ignores the metadata of the source object.
@@ -43,4 +57,49 @@ func UnmarshalData(from metav1.Object, to interface{}) (bool, error) {
 	delete(annotations, constants.ConversionAnnotation)
 	from.SetAnnotations(annotations)
 	return true, nil
+}
+
+func UpperToPascal(str string) string {
+	if len(str) == 0 {
+		return str
+	}
+
+	// check for any exception in map
+	if exception, found := upperPascalExceptions[str]; found {
+		return exception
+	}
+
+	// Split on '-' or '_' rune, capitalize first letter of each part and join them
+	var sb strings.Builder
+	array := upperTokenizer.Split(strings.ToLower(str), -1)
+	for _, s := range array {
+		runes := []rune(s)
+		runes[0] = unicode.ToUpper(runes[0])
+		sb.WriteString(string(runes))
+	}
+	return sb.String()
+}
+
+func PascalToUpper(str string, splitter rune) string {
+	if len(str) == 0 {
+		return str
+	}
+
+	// check for any exception in map
+	for k, v := range upperPascalExceptions {
+		if v == str {
+			return k
+		}
+	}
+
+	// Split on capital letters, upper each part and join with splitter
+	var sb strings.Builder
+	runes := []rune(str)
+	for i, r := range runes {
+		if i > 0 && unicode.IsUpper(r) {
+			sb.WriteRune(splitter)
+		}
+		sb.WriteRune(unicode.ToUpper(r))
+	}
+	return sb.String()
 }

--- a/pkg/conversion/conversion_test.go
+++ b/pkg/conversion/conversion_test.go
@@ -1,0 +1,39 @@
+package conversion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpperToPascal(t *testing.T) {
+	assert := assert.New(t)
+
+	v := UpperToPascal("")
+	assert.Equal("", v)
+
+	v = UpperToPascal("EBPF")
+	assert.Equal("eBPF", v)
+
+	v = UpperToPascal("ENDED_CONVERSATIONS")
+	assert.Equal("EndedConversations", v)
+
+	v = UpperToPascal("SCRAM-SHA512")
+	assert.Equal("ScramSHA512", v)
+}
+
+func TestPascalToUpper(t *testing.T) {
+	assert := assert.New(t)
+
+	v := PascalToUpper("", ' ')
+	assert.Equal("", v)
+
+	v = PascalToUpper("eBPF", ' ')
+	assert.Equal("EBPF", v)
+
+	v = PascalToUpper("EndedConversations", '_')
+	assert.Equal("ENDED_CONVERSATIONS", v)
+
+	v = PascalToUpper("ScramSHA512", '-')
+	assert.Equal("SCRAM-SHA512", v)
+}


### PR DESCRIPTION
## Description

This PR updates enums to pascal case. It replaces https://github.com/netobserv/network-observability-operator/pull/483 which is outdated.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
