### PR TITLE
NETOBSERV-1430: make operator provide agent IP

### DIFF
--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -30,6 +30,7 @@ const (
 	envCacheMaxFlows              = "CACHE_MAX_FLOWS"
 	envExcludeInterfaces          = "EXCLUDE_INTERFACES"
 	envInterfaces                 = "INTERFACES"
+	envAgentIP                    = "AGENT_IP"
 	envFlowsTargetHost            = "FLOWS_TARGET_HOST"
 	envFlowsTargetPort            = "FLOWS_TARGET_PORT"
 	envSampling                   = "SAMPLING"
@@ -474,6 +475,16 @@ func (c *AgentController) setEnvConfig(coll *flowslatest.FlowCollector) []corev1
 	}
 	config = append(config, corev1.EnvVar{Name: envDedupe, Value: dedup})
 	config = append(config, corev1.EnvVar{Name: envDedupeJustMark, Value: dedupJustMark})
+	config = append(config, corev1.EnvVar{
+		Name: envAgentIP,
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				APIVersion: "v1",
+				FieldPath:  "status.hostIP",
+			},
+		},
+	},
+	)
 
 	return config
 }

--- a/controllers/flowcollector_controller_certificates_test.go
+++ b/controllers/flowcollector_controller_certificates_test.go
@@ -466,14 +466,11 @@ func flowCollectorCertificatesSpecs() {
 	Context("Cleanup", func() {
 		// Retrieve CR to get its UID
 		flowCR := flowslatest.FlowCollector{}
-		It("Should get CR", func() {
-			Eventually(func() error {
-				return k8sClient.Get(ctx, crKey, &flowCR)
-			}, timeout, interval).Should(Succeed())
-		})
-
 		It("Should delete CR", func() {
 			Eventually(func() error {
+				if err := k8sClient.Get(ctx, crKey, &flowCR); err != nil {
+					return err
+				}
 				return k8sClient.Delete(ctx, &flowCR)
 			}, timeout, interval).Should(Succeed())
 		})


### PR DESCRIPTION
## Description

The agent IP as detected by the agent itself could potentially differ from the expected machine network IP, e.g. getting " 192.168.12.2" instead of "10.10.10.2".

By forcing the IP from the operator by inferring its host node IP, we ensure using the correct one

Note that the AGENT_IP env was already implemented on Agent side to override IP detection

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
