### PR TITLE
NETOBSERV-1432 Missing drops information in table view

### DIFF
--- a/controllers/consoleplugin/config/config.go
+++ b/controllers/consoleplugin/config/config.go
@@ -38,14 +38,15 @@ type ColumnConfig struct {
 	ID   string `yaml:"id" json:"id"`
 	Name string `yaml:"name" json:"name"`
 
-	Group      string `yaml:"group,omitempty" json:"group,omitempty"`
-	Field      string `yaml:"field,omitempty" json:"field,omitempty"`
-	Calculated string `yaml:"calculated,omitempty" json:"calculated,omitempty"`
-	Tooltip    string `yaml:"tooltip,omitempty" json:"tooltip,omitempty"`
-	DocURL     string `yaml:"docURL,omitempty" json:"docURL,omitempty"`
-	Filter     string `yaml:"filter,omitempty" json:"filter,omitempty"`
-	Default    bool   `yaml:"default,omitempty" json:"default,omitempty"`
-	Width      int    `yaml:"width,omitempty" json:"width,omitempty"`
+	Group      string   `yaml:"group,omitempty" json:"group,omitempty"`
+	Field      string   `yaml:"field,omitempty" json:"field,omitempty"`
+	Fields     []string `yaml:"fields,omitempty" json:"fields,omitempty"`
+	Calculated string   `yaml:"calculated,omitempty" json:"calculated,omitempty"`
+	Tooltip    string   `yaml:"tooltip,omitempty" json:"tooltip,omitempty"`
+	DocURL     string   `yaml:"docURL,omitempty" json:"docURL,omitempty"`
+	Filter     string   `yaml:"filter,omitempty" json:"filter,omitempty"`
+	Default    bool     `yaml:"default,omitempty" json:"default,omitempty"`
+	Width      int      `yaml:"width,omitempty" json:"width,omitempty"`
 }
 
 type FilterConfig struct {

--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -367,13 +367,17 @@ columns:
   - id: Bytes
     name: Bytes
     tooltip: The total aggregated number of bytes.
-    field: Bytes
+    fields: 
+      - Bytes
+      - PktDropBytes
     default: true
     width: 5
   - id: Packets
     name: Packets
     tooltip: The total aggregated number of packets.
-    field: Packets
+    fields: 
+      - Packets
+      - PktDropPackets
     filter: pkt_drop_cause
     default: true
     width: 5


### PR DESCRIPTION
## Description

Fix missing drops information in table view

FYI there is also https://github.com/netobserv/network-observability-console-plugin/pull/437 opened on `pktDrop` filters

## Dependencies

https://github.com/netobserv/network-observability-console-plugin/pull/440

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
