### PR TITLE
NETOBSERV: 1374 fix pascal case exception in sample

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -378,7 +378,7 @@ metadata:
                 },
                 "sampling": 50
               },
-              "type": "Ebpf"
+              "type": "eBPF"
             },
             "consolePlugin": {
               "autoscaler": {

--- a/config/samples/flows_v1beta2_flowcollector.yaml
+++ b/config/samples/flows_v1beta2_flowcollector.yaml
@@ -6,7 +6,7 @@ spec:
   namespace: netobserv
   deploymentModel: Direct
   agent:
-    type: Ebpf
+    type: eBPF
     ebpf:
       imagePullPolicy: IfNotPresent
       sampling: 50
@@ -139,7 +139,7 @@ spec:
     #     address: "kafka-cluster-kafka-bootstrap.netobserv"
     #     topic: netobserv-flows-export
     # or
-    # - type: Ipfix
+    # - type: IPFIX
     #   ipfix:
     #     targetHost: "ipfix-collector.ipfix.svc.cluster.local"
     #     targetPort: 4739


### PR DESCRIPTION
## Description

Following [Sara's comment](https://github.com/openshift/openshift-docs/pull/67836#discussion_r1424629841) I noticed I made a mistake in the sample CR.

We should use `eBPF` and `IPFIX`. Only the sample CR is affected.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
