### PR TITLE
NETOBSERV-1017: pods/services bandwidth (flowmetrics / dev preview)

### DIFF
--- a/config/samples/flowmetrics/pods_incoming_bytes.yaml
+++ b/config/samples/flowmetrics/pods_incoming_bytes.yaml
@@ -1,0 +1,13 @@
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: flowmetric-pod-incoming
+spec:
+  metricName: pod_incoming_bytes_total
+  type: Counter
+  valueField: Bytes
+  direction: Ingress
+  labels: [DstK8S_Name,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType,DstK8S_HostName]
+  filters:
+  - field: DstK8S_Type
+    value: Pod

--- a/config/samples/flowmetrics/pods_outgoing_bytes.yaml
+++ b/config/samples/flowmetrics/pods_outgoing_bytes.yaml
@@ -1,0 +1,13 @@
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: flowmetric-pod-outgoing
+spec:
+  metricName: pod_outgoing_bytes_total
+  type: Counter
+  valueField: Bytes
+  direction: Egress
+  labels: [SrcK8S_Name,SrcK8S_Namespace,SrcK8S_OwnerName,SrcK8S_OwnerType,SrcK8S_HostName]
+  filters:
+  - field: SrcK8S_Type
+    value: Pod

--- a/config/samples/flowmetrics/services_incoming_bytes.yaml
+++ b/config/samples/flowmetrics/services_incoming_bytes.yaml
@@ -1,0 +1,14 @@
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: flowmetric-service-incoming
+spec:
+  metricName: service_incoming_bytes_total
+  type: Counter
+  valueField: Bytes
+  # Note that we need to look from the sender point of view to get traffic to services, hence Egress here
+  direction: Egress
+  labels: [DstK8S_Name,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType,DstK8S_HostName]
+  filters:
+  - field: DstK8S_Type
+    value: Service


### PR DESCRIPTION
## Description

Provide sample FlowMetrics files to get top pods/services bandwidth The metrics can be queried with:

- Pods incoming: `topk(10, sum(rate(netobserv_pod_incoming_bytes_total[1m])) by (DstK8S_Name, DstK8S_Namespace))`
- Pods outgoing: `topk(10, sum(rate(netobserv_pod_outgoing_bytes_total[1m])) by (SrcK8S_Name, SrcK8S_Namespace))`
- Services incoming: `topk(10, sum(rate(netobserv_service_incoming_bytes_total[1m])) by (DstK8S_Name, DstK8S_Namespace))`

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
