### PR TITLE
NETOBSERV-1407 - Loki labels for deduper merge

### DIFF
--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -22,6 +22,7 @@ import (
 	"github.com/netobserv/network-observability-operator/controllers/constants"
 	"github.com/netobserv/network-observability-operator/controllers/ebpf"
 	"github.com/netobserv/network-observability-operator/pkg/helper"
+	"github.com/netobserv/network-observability-operator/pkg/loki"
 	"github.com/netobserv/network-observability-operator/pkg/volumes"
 )
 
@@ -310,12 +311,7 @@ func (b *builder) setLokiConfig(lconf *config.LokiConfig) {
 	if lconf.URL != statusURL {
 		lconf.StatusURL = statusURL
 	}
-	// check for connection traking to list indexes
-	indexFields := constants.LokiIndexFields
-	if b.desired.Processor.LogTypes != nil && *b.desired.Processor.LogTypes != flowslatest.LogTypeFlows {
-		indexFields = append(indexFields, constants.LokiConnectionIndexFields...)
-	}
-	lconf.Labels = indexFields
+	lconf.Labels = loki.GetLokiLabels(b.desired)
 	lconf.TenantID = b.loki.TenantID
 	lconf.ForwardUserToken = b.loki.UseForwardToken()
 	if b.loki.TLS.Enable {

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -344,7 +344,8 @@ func (b *builder) setLokiConfig(lconf *config.LokiConfig) {
 }
 
 func (b *builder) setFrontendConfig(fconf *config.FrontendConfig) {
-	var dedupJustMark, dedupMerge bool
+	dedupJustMark, _ := strconv.ParseBool(ebpf.DedupeJustMarkDefault)
+	dedupMerge, _ := strconv.ParseBool(ebpf.DedupeMergeDefault)
 	if helper.UseEBPF(b.desired) {
 		if helper.IsPktDropEnabled(&b.desired.Agent.EBPF) {
 			fconf.Features = append(fconf.Features, "pktDrop")
@@ -361,14 +362,10 @@ func (b *builder) setFrontendConfig(fconf *config.FrontendConfig) {
 		if b.desired.Agent.EBPF.Advanced != nil {
 			if v, ok := b.desired.Agent.EBPF.Advanced.Env[ebpf.EnvDedupeJustMark]; ok {
 				dedupJustMark, _ = strconv.ParseBool(v)
-			} else {
-				dedupJustMark, _ = strconv.ParseBool(ebpf.DedupeJustMarkDefault)
 			}
 
 			if v, ok := b.desired.Agent.EBPF.Advanced.Env[ebpf.EnvDedupeMerge]; ok {
 				dedupMerge, _ = strconv.ParseBool(v)
-			} else {
-				dedupMerge, _ = strconv.ParseBool(ebpf.DedupeMergeDefault)
 			}
 		}
 	}

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -36,6 +36,8 @@ const (
 	HeartbeatType     = "heartbeat"
 	EndConnectionType = "endConnection"
 
+	ClusterNameLabelName = "K8S_ClusterName"
+
 	MonitoringNamespace      = "openshift-monitoring"
 	MonitoringServiceAccount = "prometheus-k8s"
 
@@ -45,8 +47,9 @@ const (
 	LokiCRReader  = "netobserv-reader"
 )
 
-var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstK8S_Type", "FlowDirection", "Duplicate"}
+var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstK8S_Type"}
 var LokiConnectionIndexFields = []string{"_RecordType"}
+var LokiDeduperMarkIndexFields = []string{"FlowDirection", "Duplicate"}
 var FlowCollectorName = types.NamespacedName{Name: "cluster"}
 var EnvNoHTTP2 = corev1.EnvVar{
 	Name:  "GODEBUG",

--- a/controllers/flowcollector_controller_certificates_test.go
+++ b/controllers/flowcollector_controller_certificates_test.go
@@ -146,6 +146,13 @@ func flowCollectorCertificatesSpecs() {
 			DeploymentModel: flowslatest.DeploymentModelKafka,
 			Agent: flowslatest.FlowCollectorAgent{
 				Type: "eBPF",
+				EBPF: flowslatest.FlowCollectorEBPF{
+					Advanced: &flowslatest.AdvancedAgentConfig{
+						Env: map[string]string{
+							"DEDUPER_JUST_MARK": "true",
+						},
+					},
+				},
 			},
 			Loki: flowslatest.FlowCollectorLoki{
 				Enable: ptr.To(true),

--- a/controllers/flp/flp_test.go
+++ b/controllers/flp/flp_test.go
@@ -655,8 +655,6 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiManual(t *testing.T) {
 		"DstK8S_Namespace",
 		"DstK8S_OwnerName",
 		"DstK8S_Type",
-		"FlowDirection",
-		"Duplicate",
 		"_RecordType",
 	}, lokiCfg.Labels)
 	assert.Equal(`{app="netobserv-flowcollector"}`, fmt.Sprintf("%v", lokiCfg.StaticLabels))
@@ -670,7 +668,7 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiStack(t *testing.T) {
 	ns := "namespace"
 	cfg := getConfig()
 	useLokiStack(&cfg)
-	cfg.Agent.Type = flowslatest.AgentIPFIX
+	cfg.Agent.Type = flowslatest.AgentEBPF
 	b := monoBuilder(ns, &cfg)
 	cm, digest, err := b.configMap()
 	assert.NoError(err)
@@ -689,7 +687,6 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiStack(t *testing.T) {
 
 	params := decoded.Parameters
 	assert.Len(params, 6)
-	assert.Equal(*cfg.Processor.Advanced.Port, int32(params[0].Ingest.Collector.Port))
 
 	lokiCfg := params[3].Write.Loki
 	assert.Equal("https://lokistack-gateway-http.ls-namespace.svc:8080/api/logs/v1/network/", lokiCfg.URL)
@@ -705,7 +702,7 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiStack(t *testing.T) {
 	assert.Equal(cfg.Loki.Advanced.WriteMinBackoff.Duration.String(), lokiCfg.MinBackoff)
 	assert.Equal(cfg.Loki.Advanced.WriteMaxBackoff.Duration.String(), lokiCfg.MaxBackoff)
 	assert.EqualValues(*cfg.Loki.Advanced.WriteMaxRetries, lokiCfg.MaxRetries)
-	assert.EqualValues([]string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstK8S_Type", "FlowDirection", "Duplicate", "_RecordType"}, lokiCfg.Labels)
+	assert.EqualValues([]string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstK8S_Type", "_RecordType", "FlowDirection", "Duplicate"}, lokiCfg.Labels)
 	assert.Equal(`{app="netobserv-flowcollector"}`, fmt.Sprintf("%v", lokiCfg.StaticLabels))
 
 	assert.Equal(cfg.Processor.Metrics.Server.Port, int32(decoded.MetricsSettings.Port))

--- a/pkg/loki/labels.go
+++ b/pkg/loki/labels.go
@@ -1,0 +1,36 @@
+package loki
+
+import (
+	"strconv"
+
+	flowslatest "github.com/netobserv/network-observability-operator/apis/flowcollector/v1beta2"
+	"github.com/netobserv/network-observability-operator/controllers/constants"
+	"github.com/netobserv/network-observability-operator/controllers/ebpf"
+	"github.com/netobserv/network-observability-operator/pkg/helper"
+)
+
+func GetLokiLabels(desired *flowslatest.FlowCollectorSpec) []string {
+	indexFields := constants.LokiIndexFields
+
+	if desired.Processor.LogTypes != nil && *desired.Processor.LogTypes != flowslatest.LogTypeFlows {
+		indexFields = append(indexFields, constants.LokiConnectionIndexFields...)
+	}
+
+	if desired.Processor.MultiClusterDeployment != nil && *desired.Processor.MultiClusterDeployment {
+		indexFields = append(indexFields, constants.ClusterNameLabelName)
+	}
+
+	if helper.UseEBPF(desired) {
+		dedupJustMark, _ := strconv.ParseBool(ebpf.DedupeJustMarkDefault)
+		if desired.Agent.EBPF.Advanced != nil {
+			if v, ok := desired.Agent.EBPF.Advanced.Env[ebpf.EnvDedupeJustMark]; ok {
+				dedupJustMark, _ = strconv.ParseBool(v)
+			}
+		}
+		if dedupJustMark {
+			indexFields = append(indexFields, constants.LokiDeduperMarkIndexFields...)
+		}
+	}
+
+	return indexFields
+}


### PR DESCRIPTION
## Description

This PR removes `FlowDirection` and `Duplicate` labels when deduper merge mode is enabled.

It also centralize labels array in a single function (`K8S_ClusterName` was not sent to console plugin).

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
