### PR TITLE
swap-image-csv.sh updates and minor fixes to set-plugin-image

### DIFF
--- a/.mk/development.mk
+++ b/.mk/development.mk
@@ -178,7 +178,8 @@ else
 endif
 	@echo -e "\n==> Redeploying..."
 	kubectl rollout status -n $(OPERATOR_NS) --timeout=60s deployment netobserv-controller-manager
-	kubectl wait -n $(releaseRATOR_NS) --timeout=60s --for condition=Available=True deployment netobserv-controller-manager
+	kubectl wait -n $(OPERATOR_NS) --timeout=60s --for condition=Available=True deployment netobserv-controller-manager
+	@echo -e "\n==> Wait a moment before plugin pod is fully redeployed"
 
 .PHONY: set-release-kind-downstream
 set-release-kind-downstream:

--- a/.mk/development.mk
+++ b/.mk/development.mk
@@ -178,13 +178,15 @@ else
 endif
 	@echo -e "\n==> Redeploying..."
 	kubectl rollout status -n $(OPERATOR_NS) --timeout=60s deployment netobserv-controller-manager
-	kubectl wait -n $(OPERATOR_NS) --timeout=60s --for condition=Available=True deployment netobserv-controller-manager
-	kubectl rollout status -n $(NAMESPACE) --timeout=60s deployment netobserv-plugin
-	kubectl wait -n $(NAMESPACE) --timeout=60s --for condition=Available=True deployment netobserv-plugin
+	kubectl wait -n $(releaseRATOR_NS) --timeout=60s --for condition=Available=True deployment netobserv-controller-manager
 
 .PHONY: set-release-kind-downstream
 set-release-kind-downstream:
+ifeq ("", "$(CSV)")
 	kubectl  -n $(NAMESPACE) set env deployment netobserv-controller-manager -c "manager" DOWNSTREAM_DEPLOYMENT=true
+else
+	./hack/swap-image-csv.sh $(CSV) $(OPERATOR_NS) "" DOWNSTREAM_DEPLOYMENT true
+endif
 	@echo -e "\n==> Redeploying..."
 	kubectl rollout status -n $(NAMESPACE) --timeout=60s deployment netobserv-controller-manager
 	kubectl wait -n $(NAMESPACE) --timeout=60s --for condition=Available=True deployment netobserv-controller-manager

--- a/hack/swap-image-csv.sh
+++ b/hack/swap-image-csv.sh
@@ -6,13 +6,19 @@ rel_name=$3
 env_name=$4
 new_image=$5
 
-idx_rel=$(oc get csv $csv_name -n $namespace -o json | jq --arg NAME "$rel_name" '.spec.relatedImages | map(.name == $NAME) | index(true)')
-patch1="{'op': 'replace', 'path': '/spec/relatedImages/$idx_rel', 'value': {'name': '$rel_name', 'image': '$new_image'}}"
+if [[ ! -z $rel_name ]]; then
+  idx_rel=$(oc get csv $csv_name -n $namespace -o json | jq --arg NAME "$rel_name" '.spec.relatedImages | map(.name == $NAME) | index(true)')
+  patch1="{'op': 'replace', 'path': '/spec/relatedImages/$idx_rel', 'value': {'name': '$rel_name', 'image': '$new_image'}}"
+fi
 
 idx_env=$(oc get csv $csv_name -n $namespace -o json | jq --arg NAME "$env_name" '.spec.install.spec.deployments[0].spec.template.spec.containers[0].env | map(.name == $NAME) | index(true)')
 patch2="{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/$idx_env', 'value': {'name': '$env_name', 'value': '$new_image'}}"
 
-oc patch csv $csv_name -n $namespace --type='json' -p "[$patch1, $patch2]"
+if [[ ! -z ${patch1+x} ]] ; then
+  oc patch csv $csv_name -n $namespace --type='json' -p "[$patch1, $patch2]"
+else
+  oc patch csv $csv_name -n $namespace --type='json' -p "[$patch2]"
+fi
 
 if [ $? -eq 0 ]; then
   echo "Patch succeeded"


### PR DESCRIPTION
## Description

Updating `swap-image-csv.sh` script such that DOWNSTREAM_DEPLOYMENT env variable could be patched in CSV and minor fixes to set-plugin-image.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
