### PR TITLE
NETOBSERV-1308: security context enforcement

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -812,6 +812,10 @@ spec:
                     memory: 100Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: cert
@@ -837,6 +841,12 @@ spec:
                   requests:
                     cpu: 5m
                     memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /etc/tls/private
                   name: manager-metric-tls

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -45,6 +45,10 @@ spec:
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz
@@ -82,5 +86,11 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -231,6 +231,7 @@ func (b *builder) podTemplate(cmDigest string) *corev1.PodTemplateSpec {
 					"-loglevel", b.desired.ConsolePlugin.LogLevel,
 					"-config", filepath.Join(configPath, configFile),
 				},
+				SecurityContext: helper.ContainerDefaultSecurityContext(),
 			}},
 			Volumes:            b.volumes.AppendVolumes(volumes),
 			ServiceAccountName: constants.PluginName,

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -374,17 +374,17 @@ func requiredAction(current, desired *v1.DaemonSet) reconcileAction {
 }
 
 func (c *AgentController) securityContext(coll *flowslatest.FlowCollector) *corev1.SecurityContext {
-	sc := corev1.SecurityContext{
-		RunAsUser: ptr.To(int64(0)),
-	}
-
 	if coll.Spec.Agent.EBPF.Privileged {
-		sc.Privileged = &coll.Spec.Agent.EBPF.Privileged
-	} else {
-		sc.Capabilities = &corev1.Capabilities{Add: permissions.AllowedCapabilities}
+		return &corev1.SecurityContext{
+			RunAsUser:  ptr.To(int64(0)),
+			Privileged: &coll.Spec.Agent.EBPF.Privileged,
+		}
 	}
 
-	return &sc
+	sc := helper.ContainerDefaultSecurityContext()
+	sc.RunAsUser = ptr.To(int64(0))
+	sc.Capabilities.Add = permissions.AllowedCapabilities
+	return sc
 }
 
 func (c *AgentController) setEnvConfig(coll *flowslatest.FlowCollector) []corev1.EnvVar {

--- a/controllers/flp/flp_common_objects.go
+++ b/controllers/flp/flp_common_objects.go
@@ -225,6 +225,7 @@ func (b *builder) podTemplate(hasHostPort, hostNetwork bool, annotations map[str
 		VolumeMounts:    volumeMounts,
 		Ports:           ports,
 		Env:             envs,
+		SecurityContext: helper.ContainerDefaultSecurityContext(),
 	}
 	if *debugConfig.EnableKubeProbes {
 		container.LivenessProbe = &corev1.Probe{

--- a/pkg/helper/security.go
+++ b/pkg/helper/security.go
@@ -1,0 +1,16 @@
+package helper
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+func ContainerDefaultSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+}


### PR DESCRIPTION
- Use by default this security context, for all workloads except eBPF Agent:

```yaml
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
              - ALL
          readOnlyRootFilesystem: true
```

- On agent, if not privileged, use a slightly modified version, with necessary caps added

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
