### PR TITLE
NETOBSERV-1203: New Features field for FLP

### DIFF
--- a/apis/flowcollector/v1alpha1/flowcollector_webhook.go
+++ b/apis/flowcollector/v1alpha1/flowcollector_webhook.go
@@ -68,9 +68,9 @@ func (r *FlowCollector) ConvertTo(dstRaw conversion.Hub) error {
 	if restored.Spec.Processor.ClusterName != "" {
 		dst.Spec.Processor.ClusterName = restored.Spec.Processor.ClusterName
 	}
-	dst.Spec.Processor.AddZone = restored.Spec.Processor.AddZone
-	if restored.Spec.Processor.MultiClusterDeployment != nil {
-		dst.Spec.Processor.MultiClusterDeployment = restored.Spec.Processor.MultiClusterDeployment
+	if restored.Spec.Processor.Features != nil {
+		dst.Spec.Processor.Features = make([]v1beta2.ProcessorFeature, len(restored.Spec.Processor.Features))
+		copy(dst.Spec.Processor.Features, restored.Spec.Processor.Features)
 	}
 
 	dst.Spec.Processor.Metrics.Server.TLS.InsecureSkipVerify = restored.Spec.Processor.Metrics.Server.TLS.InsecureSkipVerify

--- a/apis/flowcollector/v1alpha1/zz_generated.conversion.go
+++ b/apis/flowcollector/v1alpha1/zz_generated.conversion.go
@@ -647,9 +647,8 @@ func autoConvert_v1beta2_FlowCollectorFLP_To_v1alpha1_FlowCollectorFLP(in *v1bet
 	out.KafkaConsumerQueueCapacity = in.KafkaConsumerQueueCapacity
 	out.KafkaConsumerBatchSize = in.KafkaConsumerBatchSize
 	// WARNING: in.LogTypes requires manual conversion: does not exist in peer-type
+	// WARNING: in.Features requires manual conversion: does not exist in peer-type
 	// WARNING: in.ClusterName requires manual conversion: does not exist in peer-type
-	// WARNING: in.MultiClusterDeployment requires manual conversion: does not exist in peer-type
-	// WARNING: in.AddZone requires manual conversion: does not exist in peer-type
 	// WARNING: in.Advanced requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/apis/flowcollector/v1beta1/flowcollector_types.go
+++ b/apis/flowcollector/v1beta1/flowcollector_types.go
@@ -488,6 +488,11 @@ type FlowCollectorFLP struct {
 	// Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data
 	MultiClusterDeployment *bool `json:"multiClusterDeployment,omitempty"`
 
+	//+optional
+	// `addZone` allows availability zone awareness by labelling flows with their source and destination zones.
+	// This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.
+	AddZone *bool `json:"addZone,omitempty"`
+
 	// `debug` allows setting some aspects of the internal configuration of the flow processor.
 	// This section is aimed exclusively for debugging and fine-grained performance optimizations,
 	// such as `GOGC` and `GOMAXPROCS` env vars. Users setting its values do it at their own risk.

--- a/apis/flowcollector/v1beta1/zz_generated.conversion.go
+++ b/apis/flowcollector/v1beta1/zz_generated.conversion.go
@@ -616,7 +616,8 @@ func autoConvert_v1beta1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(in *FlowCo
 	// WARNING: in.ConversationEndTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.ConversationTerminatingTimeout requires manual conversion: does not exist in peer-type
 	out.ClusterName = in.ClusterName
-	out.MultiClusterDeployment = (*bool)(unsafe.Pointer(in.MultiClusterDeployment))
+	// WARNING: in.MultiClusterDeployment requires manual conversion: does not exist in peer-type
+	// WARNING: in.AddZone requires manual conversion: does not exist in peer-type
 	// WARNING: in.Debug requires manual conversion: does not exist in peer-type
 	return nil
 }
@@ -635,9 +636,8 @@ func autoConvert_v1beta2_FlowCollectorFLP_To_v1beta1_FlowCollectorFLP(in *v1beta
 	out.KafkaConsumerQueueCapacity = in.KafkaConsumerQueueCapacity
 	out.KafkaConsumerBatchSize = in.KafkaConsumerBatchSize
 	out.LogTypes = (*string)(unsafe.Pointer(in.LogTypes))
+	// WARNING: in.Features requires manual conversion: does not exist in peer-type
 	out.ClusterName = in.ClusterName
-	out.MultiClusterDeployment = (*bool)(unsafe.Pointer(in.MultiClusterDeployment))
-	// WARNING: in.AddZone requires manual conversion: does not exist in peer-type
 	// WARNING: in.Advanced requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/apis/flowcollector/v1beta1/zz_generated.deepcopy.go
+++ b/apis/flowcollector/v1beta1/zz_generated.deepcopy.go
@@ -357,6 +357,11 @@ func (in *FlowCollectorFLP) DeepCopyInto(out *FlowCollectorFLP) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AddZone != nil {
+		in, out := &in.AddZone, &out.AddZone
+		*out = new(bool)
+		**out = **in
+	}
 	in.Debug.DeepCopyInto(&out.Debug)
 }
 

--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -373,6 +373,17 @@ type FLPMetrics struct {
 	DisableAlerts []FLPAlert `json:"disableAlerts"`
 }
 
+// Processor feature, can be one of:<br>
+// - `MultiCluster`, for multi-cluster awareness.<br>
+// - `Zone`, for availability zones awareness.<br>
+// +kubebuilder:validation:Enum:="MultiCluster";"Zone"
+type ProcessorFeature string
+
+const (
+	FeatureMultiCluster ProcessorFeature = "MultiCluster"
+	FeatureZone         ProcessorFeature = "Zone"
+)
+
 type FLPLogTypes string
 
 const (
@@ -436,19 +447,17 @@ type FlowCollectorFLP struct {
 	// +kubebuilder:default:=Flows
 	LogTypes *FLPLogTypes `json:"logTypes,omitempty"`
 
+	// List of additional features to enable. Possible values are:<br>
+	// - `MultiCluster`: allows multi-cluster awareness by labelling flows in this cluster with the cluster name.<br>
+	// - `Zone`: allows availability zone awareness by labelling flows with their source and destination zones.
+	// This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.<br>
+	// +optional
+	Features []ProcessorFeature `json:"features,omitempty"`
+
 	//+kubebuilder:default:=""
 	// +optional
 	// `clusterName` is the name of the cluster to appear in the flows data. This is useful in a multi-cluster context. When using OpenShift, leave empty to make it automatically determined.
 	ClusterName string `json:"clusterName,omitempty"`
-
-	//+kubebuilder:default:=false
-	// Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data
-	MultiClusterDeployment *bool `json:"multiClusterDeployment,omitempty"`
-
-	//+kubebuilder:default:=false
-	//+optional
-	// `addZone` when set to `true`, the source and destination of flow will their zone added to the flow
-	AddZone *bool `json:"addZone,omitempty"`
 
 	// `advanced` allows setting some aspects of the internal configuration of the flow processor.
 	// This section is aimed mostly for debugging and fine-grained performance optimizations,

--- a/apis/flowcollector/v1beta2/zz_generated.deepcopy.go
+++ b/apis/flowcollector/v1beta2/zz_generated.deepcopy.go
@@ -462,15 +462,10 @@ func (in *FlowCollectorFLP) DeepCopyInto(out *FlowCollectorFLP) {
 		*out = new(FLPLogTypes)
 		**out = **in
 	}
-	if in.MultiClusterDeployment != nil {
-		in, out := &in.MultiClusterDeployment, &out.MultiClusterDeployment
-		*out = new(bool)
-		**out = **in
-	}
-	if in.AddZone != nil {
-		in, out := &in.AddZone, &out.AddZone
-		*out = new(bool)
-		**out = **in
+	if in.Features != nil {
+		in, out := &in.Features, &out.Features
+		*out = make([]ProcessorFeature, len(*in))
+		copy(*out, *in)
 	}
 	if in.Advanced != nil {
 		in, out := &in.Advanced, &out.Advanced

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -4135,6 +4135,12 @@ spec:
                   and forwards them to the Loki persistence layer and/or any available
                   exporter.'
                 properties:
+                  addZone:
+                    description: '`addZone` allows availability zone awareness by
+                      labelling flows with their source and destination zones. This
+                      feature requires the "topology.kubernetes.io/zone" label to
+                      be set on nodes.'
+                    type: boolean
                   clusterName:
                     default: ""
                     description: '`clusterName` is the name of the cluster to appear
@@ -7102,11 +7108,6 @@ spec:
                   and forwards them to the Loki persistence layer and/or any available
                   exporter.'
                 properties:
-                  addZone:
-                    default: false
-                    description: '`addZone` when set to `true`, the source and destination
-                      of flow will their zone added to the flow'
-                    type: boolean
                   advanced:
                     description: '`advanced` allows setting some aspects of the internal
                       configuration of the flow processor. This section is aimed mostly
@@ -7185,6 +7186,22 @@ spec:
                       in the flows data. This is useful in a multi-cluster context.
                       When using OpenShift, leave empty to make it automatically determined.'
                     type: string
+                  features:
+                    description: 'List of additional features to enable. Possible
+                      values are:<br> - `MultiCluster`: allows multi-cluster awareness
+                      by labelling flows in this cluster with the cluster name.<br>
+                      - `Zone`: allows availability zone awareness by labelling flows
+                      with their source and destination zones. This feature requires
+                      the "topology.kubernetes.io/zone" label to be set on nodes.<br>'
+                    items:
+                      description: Processor feature, can be one of:<br> - `MultiCluster`,
+                        for multi-cluster awareness.<br> - `Zone`, for availability
+                        zones awareness.<br>
+                      enum:
+                      - MultiCluster
+                      - Zone
+                      type: string
+                    type: array
                   imagePullPolicy:
                     default: IfNotPresent
                     description: '`imagePullPolicy` is the Kubernetes pull policy
@@ -7939,12 +7956,6 @@ spec:
                             type: object
                         type: object
                     type: object
-                  multiClusterDeployment:
-                    default: false
-                    description: Set `multiClusterDeployment` to `true` to enable
-                      multi clusters feature. This will add clusterName label to flows
-                      data
-                    type: boolean
                   resources:
                     default:
                       limits:

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -526,16 +526,10 @@ spec:
           and/or any available exporter.
         displayName: Processor configuration
         path: processor
-      - displayName: Multi-cluster deployment
-        path: processor.multiClusterDeployment
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Cluster name
         path: processor.clusterName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.multiClusterDeployment:true
       - path: processor.advanced
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
@@ -740,8 +734,8 @@ spec:
         path: loki.readTimeout
       - displayName: Namespace
         path: namespace
-      - displayName: Add zone
-        path: processor.addZone
+      - displayName: Features
+        path: processor.features
       - displayName: Log types
         path: processor.logTypes
       - displayName: Disable alerts

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -4121,6 +4121,12 @@ spec:
                   and forwards them to the Loki persistence layer and/or any available
                   exporter.'
                 properties:
+                  addZone:
+                    description: '`addZone` allows availability zone awareness by
+                      labelling flows with their source and destination zones. This
+                      feature requires the "topology.kubernetes.io/zone" label to
+                      be set on nodes.'
+                    type: boolean
                   clusterName:
                     default: ""
                     description: '`clusterName` is the name of the cluster to appear
@@ -7088,11 +7094,6 @@ spec:
                   and forwards them to the Loki persistence layer and/or any available
                   exporter.'
                 properties:
-                  addZone:
-                    default: false
-                    description: '`addZone` when set to `true`, the source and destination
-                      of flow will their zone added to the flow'
-                    type: boolean
                   advanced:
                     description: '`advanced` allows setting some aspects of the internal
                       configuration of the flow processor. This section is aimed mostly
@@ -7171,6 +7172,22 @@ spec:
                       in the flows data. This is useful in a multi-cluster context.
                       When using OpenShift, leave empty to make it automatically determined.'
                     type: string
+                  features:
+                    description: 'List of additional features to enable. Possible
+                      values are:<br> - `MultiCluster`: allows multi-cluster awareness
+                      by labelling flows in this cluster with the cluster name.<br>
+                      - `Zone`: allows availability zone awareness by labelling flows
+                      with their source and destination zones. This feature requires
+                      the "topology.kubernetes.io/zone" label to be set on nodes.<br>'
+                    items:
+                      description: Processor feature, can be one of:<br> - `MultiCluster`,
+                        for multi-cluster awareness.<br> - `Zone`, for availability
+                        zones awareness.<br>
+                      enum:
+                      - MultiCluster
+                      - Zone
+                      type: string
+                    type: array
                   imagePullPolicy:
                     default: IfNotPresent
                     description: '`imagePullPolicy` is the Kubernetes pull policy
@@ -7925,12 +7942,6 @@ spec:
                             type: object
                         type: object
                     type: object
-                  multiClusterDeployment:
-                    default: false
-                    description: Set `multiClusterDeployment` to `true` to enable
-                      multi clusters feature. This will add clusterName label to flows
-                      data
-                    type: boolean
                   resources:
                     default:
                       limits:

--- a/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
@@ -121,15 +121,9 @@ spec:
         - description: of the component that receives the flows from the agent, enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.
           displayName: Processor configuration
           path: processor
-        - displayName: Multi-cluster deployment
-          path: processor.multiClusterDeployment
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - path: processor.clusterName
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:advanced
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.multiClusterDeployment:true
         - path: processor.advanced
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:hidden

--- a/config/samples/flows_v1beta2_flowcollector.yaml
+++ b/config/samples/flows_v1beta2_flowcollector.yaml
@@ -48,9 +48,11 @@ spec:
     logLevel: info
     # Change logTypes to "CONVERSATIONS" or "ALL" to enable conversation tracking
     logTypes: Flows
+    # features:
+    # - "MultiCluster"
+    # - "Zone"
     # Append a unique cluster name to each record
     # clusterName: <CLUSTER NAME>
-    # addZone: true
     metrics:
       server:
         port: 9102

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -209,7 +209,7 @@ func (c *AgentController) desired(ctx context.Context, coll *flowslatest.FlowCol
 		volumeMounts = append(volumeMounts, volumeMount)
 	}
 
-	if helper.IsFeatureEnabled(&coll.Spec.Agent.EBPF, flowslatest.PacketDrop) {
+	if helper.IsAgentFeatureEnabled(&coll.Spec.Agent.EBPF, flowslatest.PacketDrop) {
 		if !coll.Spec.Agent.EBPF.Privileged {
 			rlog.Error(fmt.Errorf("invalid configuration"), "To use PacketsDrop feature privileged mode needs to be enabled")
 		} else {

--- a/controllers/flowcollector_controller_iso_test.go
+++ b/controllers/flowcollector_controller_iso_test.go
@@ -65,9 +65,8 @@ func flowCollectorIsoSpecs() {
 				KafkaConsumerAutoscaler:    flowslatest.FlowCollectorHPA{Status: "Disabled", MinReplicas: &zero, MaxReplicas: zero, Metrics: []ascv2.MetricSpec{}},
 				KafkaConsumerQueueCapacity: int(zero),
 				KafkaConsumerBatchSize:     int(zero),
-				MultiClusterDeployment:     ptr.To(true),
+				Features:                   nil,
 				ClusterName:                "testCluster",
-				AddZone:                    ptr.To(false),
 				Advanced: &flowslatest.AdvancedProcessorConfig{
 					Port:                           ptr.To(int32(12345)),
 					HealthPort:                     ptr.To(int32(12346)),

--- a/controllers/flp/flp_pipeline_builder.go
+++ b/controllers/flp/flp_pipeline_builder.go
@@ -52,10 +52,7 @@ func (b *PipelineBuilder) AddProcessorStages() error {
 	lastStage = b.addTransformFilter(lastStage)
 	lastStage = b.addConnectionTracking(lastStage)
 
-	addZone := false
-	if b.desired.Processor.AddZone != nil {
-		addZone = *b.desired.Processor.AddZone
-	}
+	addZone := helper.IsZoneEnabled(&b.desired.Processor)
 
 	// enrich stage (transform) configuration
 	enrichedStage := lastStage.TransformNetwork("enrich", api.TransformNetwork{
@@ -359,7 +356,7 @@ func (b *PipelineBuilder) addTransformFilter(lastStage config.PipelineBuilderSta
 	var clusterName string
 	transformFilterRules := []api.TransformFilterRule{}
 
-	if b.desired.Processor.MultiClusterDeployment != nil && *b.desired.Processor.MultiClusterDeployment {
+	if helper.IsMultiClusterEnabled(&b.desired.Processor) {
 		if b.desired.Processor.ClusterName != "" {
 			clusterName = b.desired.Processor.ClusterName
 		} else {

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -7401,6 +7401,13 @@ TLS client configuration for Loki URL.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>addZone</b></td>
+        <td>boolean</td>
+        <td>
+          `addZone` allows availability zone awareness by labelling flows with their source and destination zones. This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>clusterName</b></td>
         <td>string</td>
         <td>
@@ -12657,15 +12664,6 @@ TLS client configuration for Loki URL.
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>addZone</b></td>
-        <td>boolean</td>
-        <td>
-          `addZone` when set to `true`, the source and destination of flow will their zone added to the flow<br/>
-          <br/>
-            <i>Default</i>: false<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b><a href="#flowcollectorspecprocessoradvanced">advanced</a></b></td>
         <td>object</td>
         <td>
@@ -12679,6 +12677,13 @@ TLS client configuration for Loki URL.
           `clusterName` is the name of the cluster to appear in the flows data. This is useful in a multi-cluster context. When using OpenShift, leave empty to make it automatically determined.<br/>
           <br/>
             <i>Default</i>: <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>features</b></td>
+        <td>[]enum</td>
+        <td>
+          List of additional features to enable. Possible values are:<br> - `MultiCluster`: allows multi-cluster awareness by labelling flows in this cluster with the cluster name.<br> - `Zone`: allows availability zone awareness by labelling flows with their source and destination zones. This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.<br><br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12752,15 +12757,6 @@ TLS client configuration for Loki URL.
         <td>object</td>
         <td>
           `Metrics` define the processor configuration regarding metrics<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>multiClusterDeployment</b></td>
-        <td>boolean</td>
-        <td>
-          Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data<br/>
-          <br/>
-            <i>Default</i>: false<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/hack/cloned.flows.netobserv.io_flowcollectors.yaml
+++ b/hack/cloned.flows.netobserv.io_flowcollectors.yaml
@@ -2887,6 +2887,9 @@ spec:
                 processor:
                   description: '`processor` defines the settings of the component that receives the flows from the agent, enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.'
                   properties:
+                    addZone:
+                      description: '`addZone` allows availability zone awareness by labelling flows with their source and destination zones. This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.'
+                      type: boolean
                     clusterName:
                       default: ""
                       description: '`clusterName` is the name of the cluster to appear in the flows data. This is useful in a multi-cluster context. When using OpenShift, leave empty to make it automatically determined.'
@@ -4933,10 +4936,6 @@ spec:
                 processor:
                   description: '`processor` defines the settings of the component that receives the flows from the agent, enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.'
                   properties:
-                    addZone:
-                      default: false
-                      description: '`addZone` when set to `true`, the source and destination of flow will their zone added to the flow'
-                      type: boolean
                     advanced:
                       description: '`advanced` allows setting some aspects of the internal configuration of the flow processor. This section is aimed mostly for debugging and fine-grained performance optimizations, such as `GOGC` and `GOMAXPROCS` env vars. Users setting its values do it at their own risk.'
                       properties:
@@ -4991,6 +4990,15 @@ spec:
                       default: ""
                       description: '`clusterName` is the name of the cluster to appear in the flows data. This is useful in a multi-cluster context. When using OpenShift, leave empty to make it automatically determined.'
                       type: string
+                    features:
+                      description: 'List of additional features to enable. Possible values are:<br> - `MultiCluster`: allows multi-cluster awareness by labelling flows in this cluster with the cluster name.<br> - `Zone`: allows availability zone awareness by labelling flows with their source and destination zones. This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.<br>'
+                      items:
+                        description: Processor feature, can be one of:<br> - `MultiCluster`, for multi-cluster awareness.<br> - `Zone`, for availability zones awareness.<br>
+                        enum:
+                          - MultiCluster
+                          - Zone
+                        type: string
+                      type: array
                     imagePullPolicy:
                       default: IfNotPresent
                       description: '`imagePullPolicy` is the Kubernetes pull policy for the image defined above'
@@ -5497,10 +5505,6 @@ spec:
                               type: object
                           type: object
                       type: object
-                    multiClusterDeployment:
-                      default: false
-                      description: Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data
-                      type: boolean
                     resources:
                       default:
                         limits:

--- a/pkg/helper/flowcollector.go
+++ b/pkg/helper/flowcollector.go
@@ -86,7 +86,7 @@ func UseConsolePlugin(spec *flowslatest.FlowCollectorSpec) bool {
 		(spec.ConsolePlugin.Enable == nil || *spec.ConsolePlugin.Enable)
 }
 
-func IsFeatureEnabled(spec *flowslatest.FlowCollectorEBPF, feature flowslatest.AgentFeature) bool {
+func IsAgentFeatureEnabled(spec *flowslatest.FlowCollectorEBPF, feature flowslatest.AgentFeature) bool {
 	for _, f := range spec.Features {
 		if f == feature {
 			return true
@@ -100,18 +100,35 @@ func IsPrivileged(spec *flowslatest.FlowCollectorEBPF) bool {
 }
 
 func IsPktDropEnabled(spec *flowslatest.FlowCollectorEBPF) bool {
-	if IsPrivileged(spec) && IsFeatureEnabled(spec, flowslatest.PacketDrop) {
+	if IsPrivileged(spec) && IsAgentFeatureEnabled(spec, flowslatest.PacketDrop) {
 		return true
 	}
 	return false
 }
 
 func IsDNSTrackingEnabled(spec *flowslatest.FlowCollectorEBPF) bool {
-	return IsFeatureEnabled(spec, flowslatest.DNSTracking)
+	return IsAgentFeatureEnabled(spec, flowslatest.DNSTracking)
 }
 
 func IsFlowRTTEnabled(spec *flowslatest.FlowCollectorEBPF) bool {
-	return IsFeatureEnabled(spec, flowslatest.FlowRTT)
+	return IsAgentFeatureEnabled(spec, flowslatest.FlowRTT)
+}
+
+func IsFLPFeatureEnabled(spec *flowslatest.FlowCollectorFLP, feature flowslatest.ProcessorFeature) bool {
+	for _, f := range spec.Features {
+		if f == feature {
+			return true
+		}
+	}
+	return false
+}
+
+func IsMultiClusterEnabled(spec *flowslatest.FlowCollectorFLP) bool {
+	return IsFLPFeatureEnabled(spec, flowslatest.FeatureMultiCluster)
+}
+
+func IsZoneEnabled(spec *flowslatest.FlowCollectorFLP) bool {
+	return IsFLPFeatureEnabled(spec, flowslatest.FeatureZone)
 }
 
 func PtrBool(b *bool) bool {

--- a/pkg/loki/labels.go
+++ b/pkg/loki/labels.go
@@ -16,7 +16,7 @@ func GetLokiLabels(desired *flowslatest.FlowCollectorSpec) []string {
 		indexFields = append(indexFields, constants.LokiConnectionIndexFields...)
 	}
 
-	if desired.Processor.MultiClusterDeployment != nil && *desired.Processor.MultiClusterDeployment {
+	if helper.IsMultiClusterEnabled(&desired.Processor) {
 		indexFields = append(indexFields, constants.ClusterNameLabelName)
 	}
 


### PR DESCRIPTION
## Description

Follow-up on https://github.com/netobserv/network-observability-operator/pull/537

Move MultiCluster and Zone into a new Feature enum/list, similar to Agent's features.

**This should be backported to 1.5**

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
