### PR TITLE
NETOBSERV-1203: minor adjustments

### DIFF
--- a/apis/flowcollector/v1beta1/flowcollector_types.go
+++ b/apis/flowcollector/v1beta1/flowcollector_types.go
@@ -485,8 +485,13 @@ type FlowCollectorFLP struct {
 	ClusterName string `json:"clusterName,omitempty"`
 
 	//+kubebuilder:default:=false
-	// Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data
+	// Set `multiClusterDeployment` to `true` to enable multi clusters feature. This adds clusterName label to flows data
 	MultiClusterDeployment *bool `json:"multiClusterDeployment,omitempty"`
+
+	//+optional
+	// `addZone` allows availability zone awareness by labelling flows with their source and destination zones.
+	// This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.
+	AddZone *bool `json:"addZone,omitempty"`
 
 	// `debug` allows setting some aspects of the internal configuration of the flow processor.
 	// This section is aimed exclusively for debugging and fine-grained performance optimizations,

--- a/apis/flowcollector/v1beta1/flowcollector_webhook.go
+++ b/apis/flowcollector/v1beta1/flowcollector_webhook.go
@@ -51,7 +51,6 @@ func (r *FlowCollector) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.Loki.Monolithic = restored.Spec.Loki.Monolithic
 	dst.Spec.Loki.Microservices = restored.Spec.Loki.Microservices
 	dst.Spec.Loki.Manual = restored.Spec.Loki.Manual
-	dst.Spec.Processor.AddZone = restored.Spec.Processor.AddZone
 
 	return nil
 }

--- a/apis/flowcollector/v1beta1/zz_generated.conversion.go
+++ b/apis/flowcollector/v1beta1/zz_generated.conversion.go
@@ -617,6 +617,7 @@ func autoConvert_v1beta1_FlowCollectorFLP_To_v1beta2_FlowCollectorFLP(in *FlowCo
 	// WARNING: in.ConversationTerminatingTimeout requires manual conversion: does not exist in peer-type
 	out.ClusterName = in.ClusterName
 	out.MultiClusterDeployment = (*bool)(unsafe.Pointer(in.MultiClusterDeployment))
+	out.AddZone = (*bool)(unsafe.Pointer(in.AddZone))
 	// WARNING: in.Debug requires manual conversion: does not exist in peer-type
 	return nil
 }
@@ -637,7 +638,7 @@ func autoConvert_v1beta2_FlowCollectorFLP_To_v1beta1_FlowCollectorFLP(in *v1beta
 	out.LogTypes = (*string)(unsafe.Pointer(in.LogTypes))
 	out.ClusterName = in.ClusterName
 	out.MultiClusterDeployment = (*bool)(unsafe.Pointer(in.MultiClusterDeployment))
-	// WARNING: in.AddZone requires manual conversion: does not exist in peer-type
+	out.AddZone = (*bool)(unsafe.Pointer(in.AddZone))
 	// WARNING: in.Advanced requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/apis/flowcollector/v1beta1/zz_generated.deepcopy.go
+++ b/apis/flowcollector/v1beta1/zz_generated.deepcopy.go
@@ -357,6 +357,11 @@ func (in *FlowCollectorFLP) DeepCopyInto(out *FlowCollectorFLP) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AddZone != nil {
+		in, out := &in.AddZone, &out.AddZone
+		*out = new(bool)
+		**out = **in
+	}
 	in.Debug.DeepCopyInto(&out.Debug)
 }
 

--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -356,7 +356,7 @@ type FLPMetrics struct {
 
 	// `includeList` is a list of metric names to specify which ones to generate.
 	// The names correspond to the names in Prometheus without the prefix. For example,
-	// `namespace_egress_packets_total` will show up as `netobserv_namespace_egress_packets_total` in Prometheus.
+	// `namespace_egress_packets_total` shows up as `netobserv_namespace_egress_packets_total` in Prometheus.
 	// Note that the more metrics you add, the bigger is the impact on Prometheus workload resources.
 	// Metrics enabled by default are:
 	// `namespace_flows_total`, `node_ingress_bytes_total`, `workload_ingress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled),
@@ -442,12 +442,12 @@ type FlowCollectorFLP struct {
 	ClusterName string `json:"clusterName,omitempty"`
 
 	//+kubebuilder:default:=false
-	// Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data
+	// Set `multiClusterDeployment` to `true` to enable multi clusters feature. This adds `clusterName` label to flows data
 	MultiClusterDeployment *bool `json:"multiClusterDeployment,omitempty"`
 
-	//+kubebuilder:default:=false
 	//+optional
-	// `addZone` when set to `true`, the source and destination of flow will their zone added to the flow
+	// `addZone` allows availability zone awareness by labelling flows with their source and destination zones.
+	// This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.
 	AddZone *bool `json:"addZone,omitempty"`
 
 	// `advanced` allows setting some aspects of the internal configuration of the flow processor.

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -4135,6 +4135,12 @@ spec:
                   and forwards them to the Loki persistence layer and/or any available
                   exporter.'
                 properties:
+                  addZone:
+                    description: '`addZone` allows availability zone awareness by
+                      labelling flows with their source and destination zones. This
+                      feature requires the "topology.kubernetes.io/zone" label to
+                      be set on nodes.'
+                    type: boolean
                   clusterName:
                     default: ""
                     description: '`clusterName` is the name of the cluster to appear
@@ -4974,7 +4980,7 @@ spec:
                   multiClusterDeployment:
                     default: false
                     description: Set `multiClusterDeployment` to `true` to enable
-                      multi clusters feature. This will add clusterName label to flows
+                      multi clusters feature. This adds clusterName label to flows
                       data
                     type: boolean
                   port:
@@ -7103,9 +7109,10 @@ spec:
                   exporter.'
                 properties:
                   addZone:
-                    default: false
-                    description: '`addZone` when set to `true`, the source and destination
-                      of flow will their zone added to the flow'
+                    description: '`addZone` allows availability zone awareness by
+                      labelling flows with their source and destination zones. This
+                      feature requires the "topology.kubernetes.io/zone" label to
+                      be set on nodes.'
                     type: boolean
                   advanced:
                     description: '`advanced` allows setting some aspects of the internal
@@ -7797,8 +7804,8 @@ spec:
                         description: '`includeList` is a list of metric names to specify
                           which ones to generate. The names correspond to the names
                           in Prometheus without the prefix. For example, `namespace_egress_packets_total`
-                          will show up as `netobserv_namespace_egress_packets_total`
-                          in Prometheus. Note that the more metrics you add, the bigger
+                          shows up as `netobserv_namespace_egress_packets_total` in
+                          Prometheus. Note that the more metrics you add, the bigger
                           is the impact on Prometheus workload resources. Metrics
                           enabled by default are: `namespace_flows_total`, `node_ingress_bytes_total`,
                           `workload_ingress_bytes_total`, `namespace_drop_packets_total`
@@ -7942,7 +7949,7 @@ spec:
                   multiClusterDeployment:
                     default: false
                     description: Set `multiClusterDeployment` to `true` to enable
-                      multi clusters feature. This will add clusterName label to flows
+                      multi clusters feature. This adds `clusterName` label to flows
                       data
                     type: boolean
                   resources:

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -536,6 +536,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.multiClusterDeployment:true
+      - displayName: Availability zones
+        path: processor.addZone
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - path: processor.advanced
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
@@ -740,8 +744,6 @@ spec:
         path: loki.readTimeout
       - displayName: Namespace
         path: namespace
-      - displayName: Add zone
-        path: processor.addZone
       - displayName: Log types
         path: processor.logTypes
       - displayName: Disable alerts

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -4121,6 +4121,12 @@ spec:
                   and forwards them to the Loki persistence layer and/or any available
                   exporter.'
                 properties:
+                  addZone:
+                    description: '`addZone` allows availability zone awareness by
+                      labelling flows with their source and destination zones. This
+                      feature requires the "topology.kubernetes.io/zone" label to
+                      be set on nodes.'
+                    type: boolean
                   clusterName:
                     default: ""
                     description: '`clusterName` is the name of the cluster to appear
@@ -4960,7 +4966,7 @@ spec:
                   multiClusterDeployment:
                     default: false
                     description: Set `multiClusterDeployment` to `true` to enable
-                      multi clusters feature. This will add clusterName label to flows
+                      multi clusters feature. This adds clusterName label to flows
                       data
                     type: boolean
                   port:
@@ -7089,9 +7095,10 @@ spec:
                   exporter.'
                 properties:
                   addZone:
-                    default: false
-                    description: '`addZone` when set to `true`, the source and destination
-                      of flow will their zone added to the flow'
+                    description: '`addZone` allows availability zone awareness by
+                      labelling flows with their source and destination zones. This
+                      feature requires the "topology.kubernetes.io/zone" label to
+                      be set on nodes.'
                     type: boolean
                   advanced:
                     description: '`advanced` allows setting some aspects of the internal
@@ -7783,8 +7790,8 @@ spec:
                         description: '`includeList` is a list of metric names to specify
                           which ones to generate. The names correspond to the names
                           in Prometheus without the prefix. For example, `namespace_egress_packets_total`
-                          will show up as `netobserv_namespace_egress_packets_total`
-                          in Prometheus. Note that the more metrics you add, the bigger
+                          shows up as `netobserv_namespace_egress_packets_total` in
+                          Prometheus. Note that the more metrics you add, the bigger
                           is the impact on Prometheus workload resources. Metrics
                           enabled by default are: `namespace_flows_total`, `node_ingress_bytes_total`,
                           `workload_ingress_bytes_total`, `namespace_drop_packets_total`
@@ -7928,7 +7935,7 @@ spec:
                   multiClusterDeployment:
                     default: false
                     description: Set `multiClusterDeployment` to `true` to enable
-                      multi clusters feature. This will add clusterName label to flows
+                      multi clusters feature. This adds `clusterName` label to flows
                       data
                     type: boolean
                   resources:

--- a/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
@@ -130,6 +130,10 @@ spec:
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:advanced
             - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.multiClusterDeployment:true
+        - displayName: Availability zones
+          path: processor.addZone
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - path: processor.advanced
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:hidden

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -209,7 +209,7 @@ func (c *AgentController) desired(ctx context.Context, coll *flowslatest.FlowCol
 		volumeMounts = append(volumeMounts, volumeMount)
 	}
 
-	if helper.IsFeatureEnabled(&coll.Spec.Agent.EBPF, flowslatest.PacketDrop) {
+	if helper.IsAgentFeatureEnabled(&coll.Spec.Agent.EBPF, flowslatest.PacketDrop) {
 		if !coll.Spec.Agent.EBPF.Privileged {
 			rlog.Error(fmt.Errorf("invalid configuration"), "To use PacketsDrop feature privileged mode needs to be enabled")
 		} else {

--- a/controllers/flp/flp_pipeline_builder.go
+++ b/controllers/flp/flp_pipeline_builder.go
@@ -52,10 +52,7 @@ func (b *PipelineBuilder) AddProcessorStages() error {
 	lastStage = b.addTransformFilter(lastStage)
 	lastStage = b.addConnectionTracking(lastStage)
 
-	addZone := false
-	if b.desired.Processor.AddZone != nil {
-		addZone = *b.desired.Processor.AddZone
-	}
+	addZone := helper.IsZoneEnabled(&b.desired.Processor)
 
 	// enrich stage (transform) configuration
 	enrichedStage := lastStage.TransformNetwork("enrich", api.TransformNetwork{
@@ -359,7 +356,7 @@ func (b *PipelineBuilder) addTransformFilter(lastStage config.PipelineBuilderSta
 	var clusterName string
 	transformFilterRules := []api.TransformFilterRule{}
 
-	if b.desired.Processor.MultiClusterDeployment != nil && *b.desired.Processor.MultiClusterDeployment {
+	if helper.IsMultiClusterEnabled(&b.desired.Processor) {
 		if b.desired.Processor.ClusterName != "" {
 			clusterName = b.desired.Processor.ClusterName
 		} else {

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -7401,6 +7401,13 @@ TLS client configuration for Loki URL.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>addZone</b></td>
+        <td>boolean</td>
+        <td>
+          `addZone` allows availability zone awareness by labelling flows with their source and destination zones. This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>clusterName</b></td>
         <td>string</td>
         <td>
@@ -7550,7 +7557,7 @@ TLS client configuration for Loki URL.
         <td><b>multiClusterDeployment</b></td>
         <td>boolean</td>
         <td>
-          Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data<br/>
+          Set `multiClusterDeployment` to `true` to enable multi clusters feature. This adds clusterName label to flows data<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -12660,9 +12667,7 @@ TLS client configuration for Loki URL.
         <td><b>addZone</b></td>
         <td>boolean</td>
         <td>
-          `addZone` when set to `true`, the source and destination of flow will their zone added to the flow<br/>
-          <br/>
-            <i>Default</i>: false<br/>
+          `addZone` allows availability zone awareness by labelling flows with their source and destination zones. This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -12758,7 +12763,7 @@ TLS client configuration for Loki URL.
         <td><b>multiClusterDeployment</b></td>
         <td>boolean</td>
         <td>
-          Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data<br/>
+          Set `multiClusterDeployment` to `true` to enable multi clusters feature. This adds `clusterName` label to flows data<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -13831,7 +13836,7 @@ target specifies the target value for the given metric
         <td><b>includeList</b></td>
         <td>[]enum</td>
         <td>
-          `includeList` is a list of metric names to specify which ones to generate. The names correspond to the names in Prometheus without the prefix. For example, `namespace_egress_packets_total` will show up as `netobserv_namespace_egress_packets_total` in Prometheus. Note that the more metrics you add, the bigger is the impact on Prometheus workload resources. Metrics enabled by default are: `namespace_flows_total`, `node_ingress_bytes_total`, `workload_ingress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled), `namespace_rtt_seconds` (when `FlowRTT` feature is enabled), `namespace_dns_latency_seconds` (when `DNSTracking` feature is enabled). More information, with full list of available metrics: https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md<br/>
+          `includeList` is a list of metric names to specify which ones to generate. The names correspond to the names in Prometheus without the prefix. For example, `namespace_egress_packets_total` shows up as `netobserv_namespace_egress_packets_total` in Prometheus. Note that the more metrics you add, the bigger is the impact on Prometheus workload resources. Metrics enabled by default are: `namespace_flows_total`, `node_ingress_bytes_total`, `workload_ingress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled), `namespace_rtt_seconds` (when `FlowRTT` feature is enabled), `namespace_dns_latency_seconds` (when `DNSTracking` feature is enabled). More information, with full list of available metrics: https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/hack/cloned.flows.netobserv.io_flowcollectors.yaml
+++ b/hack/cloned.flows.netobserv.io_flowcollectors.yaml
@@ -2887,6 +2887,9 @@ spec:
                 processor:
                   description: '`processor` defines the settings of the component that receives the flows from the agent, enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.'
                   properties:
+                    addZone:
+                      description: '`addZone` allows availability zone awareness by labelling flows with their source and destination zones. This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.'
+                      type: boolean
                     clusterName:
                       default: ""
                       description: '`clusterName` is the name of the cluster to appear in the flows data. This is useful in a multi-cluster context. When using OpenShift, leave empty to make it automatically determined.'
@@ -3447,7 +3450,7 @@ spec:
                       type: object
                     multiClusterDeployment:
                       default: false
-                      description: Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data
+                      description: Set `multiClusterDeployment` to `true` to enable multi clusters feature. This adds clusterName label to flows data
                       type: boolean
                     port:
                       default: 2055
@@ -4934,8 +4937,7 @@ spec:
                   description: '`processor` defines the settings of the component that receives the flows from the agent, enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.'
                   properties:
                     addZone:
-                      default: false
-                      description: '`addZone` when set to `true`, the source and destination of flow will their zone added to the flow'
+                      description: '`addZone` allows availability zone awareness by labelling flows with their source and destination zones. This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.'
                       type: boolean
                     advanced:
                       description: '`advanced` allows setting some aspects of the internal configuration of the flow processor. This section is aimed mostly for debugging and fine-grained performance optimizations, such as `GOGC` and `GOMAXPROCS` env vars. Users setting its values do it at their own risk.'
@@ -5393,7 +5395,7 @@ spec:
                             type: string
                           type: array
                         includeList:
-                          description: '`includeList` is a list of metric names to specify which ones to generate. The names correspond to the names in Prometheus without the prefix. For example, `namespace_egress_packets_total` will show up as `netobserv_namespace_egress_packets_total` in Prometheus. Note that the more metrics you add, the bigger is the impact on Prometheus workload resources. Metrics enabled by default are: `namespace_flows_total`, `node_ingress_bytes_total`, `workload_ingress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled), `namespace_rtt_seconds` (when `FlowRTT` feature is enabled), `namespace_dns_latency_seconds` (when `DNSTracking` feature is enabled). More information, with full list of available metrics: https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md'
+                          description: '`includeList` is a list of metric names to specify which ones to generate. The names correspond to the names in Prometheus without the prefix. For example, `namespace_egress_packets_total` shows up as `netobserv_namespace_egress_packets_total` in Prometheus. Note that the more metrics you add, the bigger is the impact on Prometheus workload resources. Metrics enabled by default are: `namespace_flows_total`, `node_ingress_bytes_total`, `workload_ingress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled), `namespace_rtt_seconds` (when `FlowRTT` feature is enabled), `namespace_dns_latency_seconds` (when `DNSTracking` feature is enabled). More information, with full list of available metrics: https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md'
                           items:
                             description: Metric name. More information in https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md.
                             enum:
@@ -5499,7 +5501,7 @@ spec:
                       type: object
                     multiClusterDeployment:
                       default: false
-                      description: Set `multiClusterDeployment` to `true` to enable multi clusters feature. This will add clusterName label to flows data
+                      description: Set `multiClusterDeployment` to `true` to enable multi clusters feature. This adds `clusterName` label to flows data
                       type: boolean
                     resources:
                       default:

--- a/pkg/helper/flowcollector.go
+++ b/pkg/helper/flowcollector.go
@@ -86,7 +86,7 @@ func UseConsolePlugin(spec *flowslatest.FlowCollectorSpec) bool {
 		(spec.ConsolePlugin.Enable == nil || *spec.ConsolePlugin.Enable)
 }
 
-func IsFeatureEnabled(spec *flowslatest.FlowCollectorEBPF, feature flowslatest.AgentFeature) bool {
+func IsAgentFeatureEnabled(spec *flowslatest.FlowCollectorEBPF, feature flowslatest.AgentFeature) bool {
 	for _, f := range spec.Features {
 		if f == feature {
 			return true
@@ -100,18 +100,26 @@ func IsPrivileged(spec *flowslatest.FlowCollectorEBPF) bool {
 }
 
 func IsPktDropEnabled(spec *flowslatest.FlowCollectorEBPF) bool {
-	if IsPrivileged(spec) && IsFeatureEnabled(spec, flowslatest.PacketDrop) {
+	if IsPrivileged(spec) && IsAgentFeatureEnabled(spec, flowslatest.PacketDrop) {
 		return true
 	}
 	return false
 }
 
 func IsDNSTrackingEnabled(spec *flowslatest.FlowCollectorEBPF) bool {
-	return IsFeatureEnabled(spec, flowslatest.DNSTracking)
+	return IsAgentFeatureEnabled(spec, flowslatest.DNSTracking)
 }
 
 func IsFlowRTTEnabled(spec *flowslatest.FlowCollectorEBPF) bool {
-	return IsFeatureEnabled(spec, flowslatest.FlowRTT)
+	return IsAgentFeatureEnabled(spec, flowslatest.FlowRTT)
+}
+
+func IsMultiClusterEnabled(spec *flowslatest.FlowCollectorFLP) bool {
+	return spec.MultiClusterDeployment != nil && *spec.MultiClusterDeployment
+}
+
+func IsZoneEnabled(spec *flowslatest.FlowCollectorFLP) bool {
+	return spec.AddZone != nil && *spec.AddZone
 }
 
 func PtrBool(b *bool) bool {

--- a/pkg/loki/labels.go
+++ b/pkg/loki/labels.go
@@ -16,7 +16,7 @@ func GetLokiLabels(desired *flowslatest.FlowCollectorSpec) []string {
 		indexFields = append(indexFields, constants.LokiConnectionIndexFields...)
 	}
 
-	if desired.Processor.MultiClusterDeployment != nil && *desired.Processor.MultiClusterDeployment {
+	if helper.IsMultiClusterEnabled(&desired.Processor) {
 		indexFields = append(indexFields, constants.ClusterNameLabelName)
 	}
 


### PR DESCRIPTION
supersedes https://github.com/netobserv/network-observability-operator/pull/540

- Add "AddZone" field also in v1beta1
- Update descriptions / avoid using "will"
- Use helper functions (centralizes handling of default/nil case)

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
