### PR TITLE
NETOBSERV-1458: reduce loki streams, index FlowInfra

### DIFF
--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -47,9 +47,9 @@ const (
 	LokiCRReader  = "netobserv-reader"
 )
 
-var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstK8S_Type"}
+var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstK8S_Type", "K8S_FlowLayer"}
 var LokiConnectionIndexFields = []string{"_RecordType"}
-var LokiDeduperMarkIndexFields = []string{"FlowDirection", "Duplicate"}
+var LokiDeduperMarkIndexFields = []string{"FlowDirection"}
 var FlowCollectorName = types.NamespacedName{Name: "cluster"}
 var EnvNoHTTP2 = corev1.EnvVar{
 	Name:  "GODEBUG",

--- a/controllers/flp/flp_test.go
+++ b/controllers/flp/flp_test.go
@@ -655,6 +655,7 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiManual(t *testing.T) {
 		"DstK8S_Namespace",
 		"DstK8S_OwnerName",
 		"DstK8S_Type",
+		"K8S_FlowLayer",
 		"_RecordType",
 	}, lokiCfg.Labels)
 	assert.Equal(`{app="netobserv-flowcollector"}`, fmt.Sprintf("%v", lokiCfg.StaticLabels))
@@ -702,7 +703,17 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiStack(t *testing.T) {
 	assert.Equal(cfg.Loki.Advanced.WriteMinBackoff.Duration.String(), lokiCfg.MinBackoff)
 	assert.Equal(cfg.Loki.Advanced.WriteMaxBackoff.Duration.String(), lokiCfg.MaxBackoff)
 	assert.EqualValues(*cfg.Loki.Advanced.WriteMaxRetries, lokiCfg.MaxRetries)
-	assert.EqualValues([]string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstK8S_Type", "_RecordType", "FlowDirection", "Duplicate"}, lokiCfg.Labels)
+	assert.EqualValues([]string{
+		"SrcK8S_Namespace",
+		"SrcK8S_OwnerName",
+		"SrcK8S_Type",
+		"DstK8S_Namespace",
+		"DstK8S_OwnerName",
+		"DstK8S_Type",
+		"K8S_FlowLayer",
+		"_RecordType",
+		"FlowDirection",
+	}, lokiCfg.Labels)
 	assert.Equal(`{app="netobserv-flowcollector"}`, fmt.Sprintf("%v", lokiCfg.StaticLabels))
 
 	assert.Equal(cfg.Processor.Metrics.Server.Port, int32(decoded.MetricsSettings.Port))


### PR DESCRIPTION
This is drastically reducing the number of streams while keeping query performances almost identical
cf details in https://github.com/netobserv/network-observability-operator/pull/554#issuecomment-1921041243

to be backported in 1.5