### PR TITLE
Fix envtests with FlowCollector deletion

### DIFF
--- a/controllers/flowcollector_controller_iso_test.go
+++ b/controllers/flowcollector_controller_iso_test.go
@@ -227,18 +227,8 @@ func flowCollectorIsoSpecs() {
 	})
 
 	Context("Cleanup", func() {
-		// Retrieve CR to get its UID
-		flowCR := flowslatest.FlowCollector{}
-		It("Should get CR", func() {
-			Eventually(func() error {
-				return k8sClient.Get(ctx, crKey, &flowCR)
-			}, timeout, interval).Should(Succeed())
-		})
-
 		It("Should delete CR", func() {
-			Eventually(func() error {
-				return k8sClient.Delete(ctx, &flowCR)
-			}, timeout, interval).Should(Succeed())
+			cleanupCR(crKey)
 		})
 	})
 }

--- a/controllers/flowcollector_controller_minimal_test.go
+++ b/controllers/flowcollector_controller_minimal_test.go
@@ -77,18 +77,8 @@ func flowCollectorMinimalSpecs() {
 	})
 
 	Context("Cleanup", func() {
-		// Retrieve CR to get its UID
-		flowCR := flowslatest.FlowCollector{}
-		It("Should get CR", func() {
-			Eventually(func() error {
-				return k8sClient.Get(ctx, crKey, &flowCR)
-			}, timeout, interval).Should(Succeed())
-		})
-
 		It("Should delete CR", func() {
-			Eventually(func() error {
-				return k8sClient.Delete(ctx, &flowCR)
-			}, timeout, interval).Should(Succeed())
+			cleanupCR(crKey)
 		})
 	})
 }

--- a/controllers/flowcollector_controller_test.go
+++ b/controllers/flowcollector_controller_test.go
@@ -10,7 +10,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-	kerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -30,11 +29,18 @@ const (
 	conntrackHeartbeatInterval  = 30 * time.Second
 )
 
-var outputRecordTypes = flowslatest.LogTypeAll
-
-var updateCR = func(key types.NamespacedName, updater func(*flowslatest.FlowCollector)) {
-	test.UpdateCR(ctx, k8sClient, key, updater)
-}
+var (
+	outputRecordTypes = flowslatest.LogTypeAll
+	updateCR          = func(key types.NamespacedName, updater func(*flowslatest.FlowCollector)) {
+		test.UpdateCR(ctx, k8sClient, key, updater)
+	}
+	getCR = func(key types.NamespacedName) *flowslatest.FlowCollector {
+		return test.GetCR(ctx, k8sClient, key)
+	}
+	cleanupCR = func(key types.NamespacedName) {
+		test.CleanupCR(ctx, k8sClient, key)
+	}
+)
 
 // nolint:cyclop
 func flowCollectorControllerSpecs() {
@@ -274,56 +280,45 @@ func flowCollectorControllerSpecs() {
 		})
 	})
 
-	Context("Cleanup", func() {
-		// Retrieve CR to get its UID
-		flowCR := flowslatest.FlowCollector{}
-		It("Should get CR", func() {
-			Eventually(func() error {
-				return k8sClient.Get(ctx, crKey, &flowCR)
-			}, timeout, interval).Should(Succeed())
-		})
-
-		It("Should delete CR", func() {
-			Eventually(func() error {
-				return k8sClient.Delete(ctx, &flowCR)
-			}, timeout, interval).Should(Succeed())
-		})
-
+	Context("Checking CR ownership", func() {
 		It("Should be garbage collected", func() {
+			// Retrieve CR to get its UID
+			By("Getting the CR")
+			flowCR := getCR(crKey)
+
 			By("Expecting console plugin deployment to be garbage collected")
 			Eventually(func() interface{} {
 				d := appsv1.Deployment{}
 				_ = k8sClient.Get(ctx, cpKey2, &d)
 				return &d
-			}, timeout, interval).Should(BeGarbageCollectedBy(&flowCR))
+			}, timeout, interval).Should(BeGarbageCollectedBy(flowCR))
 
 			By("Expecting console plugin service to be garbage collected")
 			Eventually(func() interface{} {
 				svc := v1.Service{}
 				_ = k8sClient.Get(ctx, cpKey2, &svc)
 				return &svc
-			}, timeout, interval).Should(BeGarbageCollectedBy(&flowCR))
+			}, timeout, interval).Should(BeGarbageCollectedBy(flowCR))
 
 			By("Expecting console plugin service account to be garbage collected")
 			Eventually(func() interface{} {
 				svcAcc := v1.ServiceAccount{}
 				_ = k8sClient.Get(ctx, cpKey2, &svcAcc)
 				return &svcAcc
-			}, timeout, interval).Should(BeGarbageCollectedBy(&flowCR))
+			}, timeout, interval).Should(BeGarbageCollectedBy(flowCR))
 
 			By("Expecting ovn-flows-configmap to be garbage collected")
 			Eventually(func() interface{} {
 				cm := v1.ConfigMap{}
 				_ = k8sClient.Get(ctx, ovsConfigMapKey, &cm)
 				return &cm
-			}, timeout, interval).Should(BeGarbageCollectedBy(&flowCR))
+			}, timeout, interval).Should(BeGarbageCollectedBy(flowCR))
 		})
+	})
 
-		It("Should not get CR", func() {
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, crKey, &flowCR)
-				return kerr.IsNotFound(err)
-			}, timeout, interval).Should(BeTrue())
+	Context("Cleanup", func() {
+		It("Should delete CR", func() {
+			cleanupCR(crKey)
 		})
 
 		It("Should cleanup other data", func() {

--- a/controllers/flp/flp_controller_flowmetrics_test.go
+++ b/controllers/flp/flp_controller_flowmetrics_test.go
@@ -5,7 +5,6 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	kerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/strings/slices"
@@ -157,25 +156,8 @@ func ControllerFlowMetricsSpecs() {
 	})
 
 	Context("Cleanup", func() {
-		// Retrieve CR to get its UID
-		flowCR := flowslatest.FlowCollector{}
-		It("Should get CR", func() {
-			Eventually(func() error {
-				return k8sClient.Get(ctx, crKey, &flowCR)
-			}, timeout, interval).Should(Succeed())
-		})
-
 		It("Should delete CR", func() {
-			Eventually(func() error {
-				return k8sClient.Delete(ctx, &flowCR)
-			}, timeout, interval).Should(Succeed())
-		})
-
-		It("Should not get CR", func() {
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, crKey, &flowCR)
-				return kerr.IsNotFound(err)
-			}, timeout, interval).Should(BeTrue())
+			cleanupCR(crKey)
 		})
 	})
 }

--- a/controllers/flp/suite_test.go
+++ b/controllers/flp/suite_test.go
@@ -26,6 +26,8 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
+	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
+	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "FLP Controller Suite")
 }

--- a/controllers/monitoring/suite_test.go
+++ b/controllers/monitoring/suite_test.go
@@ -26,6 +26,8 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
+	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
+	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Monitoring Controller Suite")
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -41,6 +41,8 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
+	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
+	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controller Suite")
 }

--- a/pkg/manager/status/status_manager.go
+++ b/pkg/manager/status/status_manager.go
@@ -168,12 +168,16 @@ func (i *Instance) SetUnused(message string) {
 func (i *Instance) CheckDeploymentProgress(d *appsv1.Deployment) {
 	// TODO (when legacy controller is broken down into individual controllers)
 	// this should set the status as Ready when replicas match
-	for _, c := range d.Status.Conditions {
-		if c.Type == appsv1.DeploymentAvailable {
-			if c.Status != v1.ConditionTrue {
-				i.s.setInProgress(i.cpnt, "DeploymentNotReady", fmt.Sprintf("Deployment %s not ready: %d/%d (%s)", d.Name, d.Status.UpdatedReplicas, d.Status.Replicas, c.Message))
+	if d == nil {
+		i.s.setInProgress(i.cpnt, "DeploymentNotCreated", "Deployment not created")
+	} else {
+		for _, c := range d.Status.Conditions {
+			if c.Type == appsv1.DeploymentAvailable {
+				if c.Status != v1.ConditionTrue {
+					i.s.setInProgress(i.cpnt, "DeploymentNotReady", fmt.Sprintf("Deployment %s not ready: %d/%d (%s)", d.Name, d.Status.UpdatedReplicas, d.Status.Replicas, c.Message))
+				}
+				return
 			}
-			return
 		}
 	}
 }
@@ -181,7 +185,9 @@ func (i *Instance) CheckDeploymentProgress(d *appsv1.Deployment) {
 func (i *Instance) CheckDaemonSetProgress(ds *appsv1.DaemonSet) {
 	// TODO (when legacy controller is broken down into individual controllers)
 	// this should set the status as Ready when replicas match
-	if ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled {
+	if ds == nil {
+		i.s.setInProgress(i.cpnt, "DaemonSetNotCreated", "DaemonSet not created")
+	} else if ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled {
 		i.s.setInProgress(i.cpnt, "DaemonSetNotReady", fmt.Sprintf("DaemonSet %s not ready: %d/%d", ds.Name, ds.Status.UpdatedNumberScheduled, ds.Status.DesiredNumberScheduled))
 	}
 }


### PR DESCRIPTION
There was is timing issue with FlowCollector taking more time than the test timeout to be deleted. One option could have been to increase the timeout, but here we're simply checking that the DeletionTimestamp field is set, which means the resource has been marked for deletion.

Another issue found while testing, was the eBPF agent potentially calling `status.CheckDaemonSetProgress` with a nil parameter, which triggered an error. Adding nil-checks to StatusManager functions.
