### PR TITLE
NETOBSERV-1474: change dup mode to use list as the default

### DIFF
--- a/controllers/consoleplugin/consoleplugin_test.go
+++ b/controllers/consoleplugin/consoleplugin_test.go
@@ -326,8 +326,8 @@ func TestConfigMapContent(t *testing.T) {
 	assert.NotEmpty(config.Frontend.Columns)
 	assert.NotEmpty(config.Frontend.Filters)
 	assert.Equal(config.Frontend.Sampling, 1)
-	assert.Equal(config.Frontend.Deduper.Mark, true)
-	assert.Equal(config.Frontend.Deduper.Merge, false)
+	assert.Equal(config.Frontend.Deduper.Mark, false)
+	assert.Equal(config.Frontend.Deduper.Merge, true)
 }
 
 func TestConfigMapError(t *testing.T) {

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -76,8 +76,8 @@ const (
 const (
 	EnvDedupeJustMark     = "DEDUPER_JUST_MARK"
 	EnvDedupeMerge        = "DEDUPER_MERGE"
-	DedupeJustMarkDefault = "true"
-	DedupeMergeDefault    = "false"
+	DedupeJustMarkDefault = "false"
+	DedupeMergeDefault    = "true"
 )
 
 type reconcileAction int


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
