### PR TITLE
NETOBSERV-1466 NodeDirection / IfDirection

### DIFF
--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -381,23 +381,30 @@ columns:
     default: false
     width: 10
   - id: FlowDirection
-    name: Direction
-    tooltip: The direction of the flow observed at the Node observation point.
+    name: Node Direction
+    tooltip: The interpreted direction of the flow observed at the Node observation point.
     field: FlowDirection
-    filter: direction
+    filter: node_direction
     default: false
     width: 10
-  - id: Interface
-    name: Interface
-    tooltip: The network interface of the Flow.
-    field: Interface
-    filter: interface
+  - id: Interfaces
+    name: Interfaces
+    tooltip: The network interfaces of the Flow.
+    field: Interfaces
+    filter: interfaces
+    default: false
+    width: 10
+  - id: IfDirections
+    name: Interface Directions
+    tooltip: The directions of the Flow observed at the network interface observation point.
+    field: IfDirections
+    filter: ifdirections
     default: false
     width: 10
   - id: FlowDirInts
     name: Interfaces and Directions
-    tooltip: Pairs of network interface and direction of the Flow observed at the Node observation point.
-    field: FlowDirection
+    tooltip: Pairs of network interface and direction of the Flow observed at the network interface observation point.
+    field: Interfaces
     default: false
     width: 15
   - id: Bytes
@@ -757,21 +764,26 @@ filters:
     name: ICMP code
     component: number
     hint: Specify an ICMP code value as integer number.
-  - id: direction
-    name: Direction
+  - id: node_direction
+    name: Node Direction
     component: autocomplete
     placeholder: 'E.g: Ingress, Egress, Inner'
-    hint: Specify the direction of the Flow observed at the Node observation point.
+    hint: Specify the interpreted direction of the Flow observed at the Node observation point.
   - id: flow_layer
     name: Flow layer
     component: text
     placeholder: 'Either infra or app'
     hint: Specify the layer of Flow.
-  - id: interface
-    name: Network interface
+  - id: interfaces
+    name: Network interfaces
     component: text
     placeholder: 'E.g: br-ex, ovn-k8s-mp0'
     hint: Specify a network interface.
+  - id: ifdirections
+    name: Interface Directions
+    component: autocomplete
+    placeholder: 'E.g: Ingress, Egress'
+    hint: Specify the direction of the Flow observed at the network interface observation point.
   - id: id
     name: Conversation Id
     component: text
@@ -930,20 +942,20 @@ fields:
   - name: FlowDirection
     type: number
     description: |
-      Flow direction from the node observation point. Can be one of: +
+      Flow interpreted direction from the node observation point. Can be one of: +
       - 0: Ingress (incoming traffic, from the node observation point) +
       - 1: Egress (outgoing traffic, from the node observation point) +
       - 2: Inner (with the same source and destination node)
     lokiLabel: true
-  - name: IfDirection
+  - name: IfDirections
     type: number
     description: |
-      Flow direction from the network interface observation point. Can be one of: +
+      Flow directions from the network interface observation point. Can be one of: +
       - 0: Ingress (interface incoming traffic) +
       - 1: Egress (interface outgoing traffic)
-  - name: Interface
+  - name: Interfaces
     type: string
-    description: Network interface
+    description: Network interfaces
   - name: Flags
     type: number
     description: |

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -49,9 +49,8 @@ const (
 	LokiCRReader  = "netobserv-reader"
 )
 
-var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstK8S_Type", "K8S_FlowLayer"}
+var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstK8S_Type", "K8S_FlowLayer", "FlowDirection"}
 var LokiConnectionIndexFields = []string{"_RecordType"}
-var LokiDeduperMarkIndexFields = []string{"FlowDirection"}
 var LokiZoneIndexFields = []string{"SrcK8S_Zone", "DstK8S_Zone"}
 var FlowCollectorName = types.NamespacedName{Name: "cluster"}
 var EnvNoHTTP2 = corev1.EnvVar{

--- a/controllers/flp/flp_pipeline_builder.go
+++ b/controllers/flp/flp_pipeline_builder.go
@@ -100,7 +100,6 @@ func (b *PipelineBuilder) AddProcessorStages() error {
 			SrcHostField:       "SrcK8S_HostIP",
 			DstHostField:       "DstK8S_HostIP",
 			FlowDirectionField: "FlowDirection",
-			IfDirectionField:   "IfDirection",
 		},
 	})
 

--- a/controllers/flp/flp_test.go
+++ b/controllers/flp/flp_test.go
@@ -655,8 +655,8 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiManual(t *testing.T) {
 		"DstK8S_OwnerName",
 		"DstK8S_Type",
 		"K8S_FlowLayer",
-		"_RecordType",
 		"FlowDirection",
+		"_RecordType",
 	}, lokiCfg.Labels)
 	assert.Equal(`{app="netobserv-flowcollector"}`, fmt.Sprintf("%v", lokiCfg.StaticLabels))
 
@@ -711,8 +711,8 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiStack(t *testing.T) {
 		"DstK8S_OwnerName",
 		"DstK8S_Type",
 		"K8S_FlowLayer",
-		"_RecordType",
 		"FlowDirection",
+		"_RecordType",
 	}, lokiCfg.Labels)
 	assert.Equal(`{app="netobserv-flowcollector"}`, fmt.Sprintf("%v", lokiCfg.StaticLabels))
 

--- a/pkg/loki/labels.go
+++ b/pkg/loki/labels.go
@@ -1,11 +1,8 @@
 package loki
 
 import (
-	"strconv"
-
 	flowslatest "github.com/netobserv/network-observability-operator/apis/flowcollector/v1beta2"
 	"github.com/netobserv/network-observability-operator/controllers/constants"
-	"github.com/netobserv/network-observability-operator/controllers/ebpf"
 	"github.com/netobserv/network-observability-operator/pkg/helper"
 )
 
@@ -22,16 +19,6 @@ func GetLokiLabels(desired *flowslatest.FlowCollectorSpec) []string {
 
 	if helper.IsZoneEnabled(&desired.Processor) {
 		indexFields = append(indexFields, constants.LokiZoneIndexFields...)
-	}
-
-	dedupJustMark, _ := strconv.ParseBool(ebpf.DedupeJustMarkDefault)
-	if desired.Agent.EBPF.Advanced != nil {
-		if v, ok := desired.Agent.EBPF.Advanced.Env[ebpf.EnvDedupeJustMark]; ok {
-			dedupJustMark, _ = strconv.ParseBool(v)
-		}
-	}
-	if dedupJustMark {
-		indexFields = append(indexFields, constants.LokiDeduperMarkIndexFields...)
 	}
 
 	return indexFields


### PR DESCRIPTION
## Description

- ~Rename `FlowDirection` to `NodeDirection`,~ improved descriptions and restore `FlowDirection` label when using deduper merge
- Skip reinterpret field renaming since it's now done directly in eBPF
- Update console plugin fields / queries to plural

To setup deduper merge, simply add the following config in ebpf debug (or advanced) configuration:
```yaml
      advanced:
        env:
          DEDUPER_JUST_MARK: "false"
          DEDUPER_MERGE: "true"
```

## Dependencies

https://github.com/netobserv/netobserv-ebpf-agent/pull/275
https://github.com/netobserv/flowlogs-pipeline/pull/601
https://github.com/netobserv/network-observability-console-plugin/pull/482

## Followup

A followup to remove Duplicate field is available at: https://github.com/netobserv/network-observability-operator/pull/580

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
