### PR TITLE
NETOBSERV-1532: add TLS support to ebpf agent metrics config

### DIFF
--- a/apis/flowcollector/v1beta1/flowcollector_types.go
+++ b/apis/flowcollector/v1beta1/flowcollector_types.go
@@ -301,7 +301,7 @@ type ServerTLSConfigType string
 type ServerTLS struct {
 	// Select the type of TLS configuration:<br>
 	// - `DISABLED` (default) to not configure TLS for the endpoint.
-	// - `PROVIDED` to manually provide cert file and a key file.
+	// - `PROVIDED` to manually provide cert file and a key file. [Unsupported (*)].
 	// - `AUTO` to use OpenShift auto generated certificate using annotations.
 	// +unionDiscriminator
 	// +kubebuilder:validation:Enum:="DISABLED";"PROVIDED";"AUTO"

--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -308,7 +308,7 @@ const (
 type ServerTLS struct {
 	// Select the type of TLS configuration:<br>
 	// - `Disabled` (default) to not configure TLS for the endpoint.
-	// - `Provided` to manually provide cert file and a key file.
+	// - `Provided` to manually provide cert file and a key file. [Unsupported (*)].
 	// - `Auto` to use OpenShift auto generated certificate using annotations.
 	// +unionDiscriminator
 	// +kubebuilder:validation:Enum:="Disabled";"Provided";"Auto"

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -286,8 +286,9 @@ spec:
                                     description: Select the type of TLS configuration:<br>
                                       - `DISABLED` (default) to not configure TLS
                                       for the endpoint. - `PROVIDED` to manually provide
-                                      cert file and a key file. - `AUTO` to use OpenShift
-                                      auto generated certificate using annotations.
+                                      cert file and a key file. [Unsupported (*)].
+                                      - `AUTO` to use OpenShift auto generated certificate
+                                      using annotations.
                                     enum:
                                     - DISABLED
                                     - PROVIDED
@@ -2182,8 +2183,9 @@ spec:
                                 description: Select the type of TLS configuration:<br>
                                   - `DISABLED` (default) to not configure TLS for
                                   the endpoint. - `PROVIDED` to manually provide cert
-                                  file and a key file. - `AUTO` to use OpenShift auto
-                                  generated certificate using annotations.
+                                  file and a key file. [Unsupported (*)]. - `AUTO`
+                                  to use OpenShift auto generated certificate using
+                                  annotations.
                                 enum:
                                 - DISABLED
                                 - PROVIDED
@@ -3029,8 +3031,9 @@ spec:
                                     description: Select the type of TLS configuration:<br>
                                       - `Disabled` (default) to not configure TLS
                                       for the endpoint. - `Provided` to manually provide
-                                      cert file and a key file. - `Auto` to use OpenShift
-                                      auto generated certificate using annotations.
+                                      cert file and a key file. [Unsupported (*)].
+                                      - `Auto` to use OpenShift auto generated certificate
+                                      using annotations.
                                     enum:
                                     - Disabled
                                     - Provided
@@ -6028,8 +6031,9 @@ spec:
                                 description: Select the type of TLS configuration:<br>
                                   - `Disabled` (default) to not configure TLS for
                                   the endpoint. - `Provided` to manually provide cert
-                                  file and a key file. - `Auto` to use OpenShift auto
-                                  generated certificate using annotations.
+                                  file and a key file. [Unsupported (*)]. - `Auto`
+                                  to use OpenShift auto generated certificate using
+                                  annotations.
                                 enum:
                                 - Disabled
                                 - Provided

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -186,7 +186,7 @@ spec:
                                       type: object
                                     type:
                                       default: DISABLED
-                                      description: Select the type of TLS configuration:<br> - `DISABLED` (default) to not configure TLS for the endpoint. - `PROVIDED` to manually provide cert file and a key file. - `AUTO` to use OpenShift auto generated certificate using annotations.
+                                      description: Select the type of TLS configuration:<br> - `DISABLED` (default) to not configure TLS for the endpoint. - `PROVIDED` to manually provide cert file and a key file. [Unsupported (*)]. - `AUTO` to use OpenShift auto generated certificate using annotations.
                                       enum:
                                         - DISABLED
                                         - PROVIDED
@@ -1695,7 +1695,7 @@ spec:
                                   type: object
                                 type:
                                   default: DISABLED
-                                  description: Select the type of TLS configuration:<br> - `DISABLED` (default) to not configure TLS for the endpoint. - `PROVIDED` to manually provide cert file and a key file. - `AUTO` to use OpenShift auto generated certificate using annotations.
+                                  description: Select the type of TLS configuration:<br> - `DISABLED` (default) to not configure TLS for the endpoint. - `PROVIDED` to manually provide cert file and a key file. [Unsupported (*)]. - `AUTO` to use OpenShift auto generated certificate using annotations.
                                   enum:
                                     - DISABLED
                                     - PROVIDED
@@ -2397,7 +2397,7 @@ spec:
                                       type: object
                                     type:
                                       default: Disabled
-                                      description: Select the type of TLS configuration:<br> - `Disabled` (default) to not configure TLS for the endpoint. - `Provided` to manually provide cert file and a key file. - `Auto` to use OpenShift auto generated certificate using annotations.
+                                      description: Select the type of TLS configuration:<br> - `Disabled` (default) to not configure TLS for the endpoint. - `Provided` to manually provide cert file and a key file. [Unsupported (*)]. - `Auto` to use OpenShift auto generated certificate using annotations.
                                       enum:
                                         - Disabled
                                         - Provided
@@ -4903,7 +4903,7 @@ spec:
                                   type: object
                                 type:
                                   default: Disabled
-                                  description: Select the type of TLS configuration:<br> - `Disabled` (default) to not configure TLS for the endpoint. - `Provided` to manually provide cert file and a key file. - `Auto` to use OpenShift auto generated certificate using annotations.
+                                  description: Select the type of TLS configuration:<br> - `Disabled` (default) to not configure TLS for the endpoint. - `Provided` to manually provide cert file and a key file. [Unsupported (*)]. - `Auto` to use OpenShift auto generated certificate using annotations.
                                   enum:
                                     - Disabled
                                     - Provided

--- a/config/openshift/namespace.yaml
+++ b/config/openshift/namespace.yaml
@@ -1,6 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    openshift.io/cluster-monitoring: "true"
   name: openshift-netobserv-operator

--- a/controllers/ebpf/agent-metrics-test.go
+++ b/controllers/ebpf/agent-metrics-test.go
@@ -36,8 +36,16 @@ func TestPromServiceMonitoring(t *testing.T) {
 	// Create a new instance of your controller
 	controller := &AgentController{}
 
+	// Create a sample FlowCollectorEBPF object for testing
+	target := &flowslatest.FlowCollectorEBPF{
+		Metrics: flowslatest.EBPFMetrics{
+			Server: flowslatest.MetricsServerConfig{
+				Port: 8080, // Sample port for testing
+			},
+		},
+	}
 	// Call the promServiceMonitoring function
-	monitor := controller.promServiceMonitoring()
+	monitor := controller.promServiceMonitoring(target)
 
 	// Assert that the returned monitor is not nil
 	assert.NotNil(t, monitor)

--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -190,5 +190,6 @@ func (r *FlowCollectorReconciler) newCommonInfo(clh *helper.Client, ns, prevNs s
 		AvailableAPIs:     &r.mgr.AvailableAPIs,
 		Watcher:           r.watcher,
 		Loki:              loki,
+		IsDownstream:      r.mgr.Config.DownstreamDeployment,
 	}
 }

--- a/controllers/flp/flp_controller.go
+++ b/controllers/flp/flp_controller.go
@@ -179,6 +179,7 @@ func (r *Reconciler) newCommonInfo(clh *helper.Client, ns, prevNs string, loki *
 		Watcher:           r.watcher,
 		Loki:              loki,
 		ClusterID:         r.clusterID,
+		IsDownstream:      r.mgr.Config.DownstreamDeployment,
 	}
 }
 

--- a/controllers/reconcilers/common.go
+++ b/controllers/reconcilers/common.go
@@ -21,6 +21,7 @@ type Common struct {
 	AvailableAPIs     *discover.AvailableAPIs
 	Loki              *helper.LokiConfig
 	ClusterID         string
+	IsDownstream      bool
 }
 
 func (c *Common) PrivilegedNamespace() string {

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -469,7 +469,7 @@ TLS configuration.
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Select the type of TLS configuration:<br> - `DISABLED` (default) to not configure TLS for the endpoint. - `PROVIDED` to manually provide cert file and a key file. - `AUTO` to use OpenShift auto generated certificate using annotations.<br/>
+          Select the type of TLS configuration:<br> - `DISABLED` (default) to not configure TLS for the endpoint. - `PROVIDED` to manually provide cert file and a key file. [Unsupported (*)]. - `AUTO` to use OpenShift auto generated certificate using annotations.<br/>
           <br/>
             <i>Enum</i>: DISABLED, PROVIDED, AUTO<br/>
             <i>Default</i>: DISABLED<br/>
@@ -4614,7 +4614,7 @@ TLS configuration.
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Select the type of TLS configuration:<br> - `DISABLED` (default) to not configure TLS for the endpoint. - `PROVIDED` to manually provide cert file and a key file. - `AUTO` to use OpenShift auto generated certificate using annotations.<br/>
+          Select the type of TLS configuration:<br> - `DISABLED` (default) to not configure TLS for the endpoint. - `PROVIDED` to manually provide cert file and a key file. [Unsupported (*)]. - `AUTO` to use OpenShift auto generated certificate using annotations.<br/>
           <br/>
             <i>Enum</i>: DISABLED, PROVIDED, AUTO<br/>
             <i>Default</i>: DISABLED<br/>
@@ -6752,7 +6752,7 @@ TLS configuration.
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Select the type of TLS configuration:<br> - `Disabled` (default) to not configure TLS for the endpoint. - `Provided` to manually provide cert file and a key file. - `Auto` to use OpenShift auto generated certificate using annotations.<br/>
+          Select the type of TLS configuration:<br> - `Disabled` (default) to not configure TLS for the endpoint. - `Provided` to manually provide cert file and a key file. [Unsupported (*)]. - `Auto` to use OpenShift auto generated certificate using annotations.<br/>
           <br/>
             <i>Enum</i>: Disabled, Provided, Auto<br/>
             <i>Default</i>: Disabled<br/>
@@ -14250,7 +14250,7 @@ TLS configuration.
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Select the type of TLS configuration:<br> - `Disabled` (default) to not configure TLS for the endpoint. - `Provided` to manually provide cert file and a key file. - `Auto` to use OpenShift auto generated certificate using annotations.<br/>
+          Select the type of TLS configuration:<br> - `Disabled` (default) to not configure TLS for the endpoint. - `Provided` to manually provide cert file and a key file. [Unsupported (*)]. - `Auto` to use OpenShift auto generated certificate using annotations.<br/>
           <br/>
             <i>Enum</i>: Disabled, Provided, Auto<br/>
             <i>Default</i>: Disabled<br/>


### PR DESCRIPTION
## Description

add TLS config support to ebpf agent
## Dependencies
https://github.com/netobserv/netobserv-ebpf-agent/pull/305
https://github.com/netobserv/network-observability-operator/pull/604

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
