### PR TITLE
NETOBSERV-1585: fix issues exposing metrics upstream/downstream

### DIFF
--- a/config/openshift/namespace.yaml
+++ b/config/openshift/namespace.yaml
@@ -1,6 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    openshift.io/cluster-monitoring: "true"
   name: openshift-netobserv-operator

--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -190,5 +190,6 @@ func (r *FlowCollectorReconciler) newCommonInfo(clh *helper.Client, ns, prevNs s
 		AvailableAPIs:     &r.mgr.AvailableAPIs,
 		Watcher:           r.watcher,
 		Loki:              loki,
+		IsDownstream:      r.mgr.Config.DownstreamDeployment,
 	}
 }

--- a/controllers/flp/flp_controller.go
+++ b/controllers/flp/flp_controller.go
@@ -179,6 +179,7 @@ func (r *Reconciler) newCommonInfo(clh *helper.Client, ns, prevNs string, loki *
 		Watcher:           r.watcher,
 		Loki:              loki,
 		ClusterID:         r.clusterID,
+		IsDownstream:      r.mgr.Config.DownstreamDeployment,
 	}
 }
 

--- a/controllers/reconcilers/common.go
+++ b/controllers/reconcilers/common.go
@@ -21,6 +21,7 @@ type Common struct {
 	AvailableAPIs     *discover.AvailableAPIs
 	Loki              *helper.LokiConfig
 	ClusterID         string
+	IsDownstream      bool
 }
 
 func (c *Common) PrivilegedNamespace() string {


### PR DESCRIPTION
- Fix using TLS with user workload monitoring
- Do not set openshift-monitoring annotation on netobserv namespace upstream
- Fix tagging DOWNSTREAM DEPLOYMENT on netobserv-privileged namespace

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
