### PR TITLE
NETOBSERV-1427 Added support to FLP dynamic configmap

### DIFF
--- a/controllers/flp/flp_common_objects.go
+++ b/controllers/flp/flp_common_objects.go
@@ -105,19 +105,21 @@ func NewBuilder(info *reconcilers.Instance, desired *flowslatest.FlowCollectorSp
 	}, nil
 }
 
-func name(ck ConfKind) string                 { return constants.FLPName + FlpConfSuffix[ck] }
-func RoleBindingName(ck ConfKind) string      { return name(ck) + "-role" }
-func RoleBindingMonoName(ck ConfKind) string  { return name(ck) + "-role-mono" }
-func promServiceName(ck ConfKind) string      { return name(ck) + "-prom" }
-func configMapName(ck ConfKind) string        { return name(ck) + "-config" }
-func serviceMonitorName(ck ConfKind) string   { return name(ck) + "-monitor" }
-func prometheusRuleName(ck ConfKind) string   { return name(ck) + "-alert" }
-func (b *builder) name() string               { return name(b.confKind) }
-func (b *builder) promServiceName() string    { return promServiceName(b.confKind) }
-func (b *builder) configMapName() string      { return configMapName(b.confKind) }
-func (b *builder) serviceMonitorName() string { return serviceMonitorName(b.confKind) }
-func (b *builder) prometheusRuleName() string { return prometheusRuleName(b.confKind) }
-func (b *builder) Pipeline() *PipelineBuilder { return b.pipeline }
+func name(ck ConfKind) string                   { return constants.FLPName + FlpConfSuffix[ck] }
+func RoleBindingName(ck ConfKind) string        { return name(ck) + "-role" }
+func RoleBindingMonoName(ck ConfKind) string    { return name(ck) + "-role-mono" }
+func promServiceName(ck ConfKind) string        { return name(ck) + "-prom" }
+func staticConfigMapName(ck ConfKind) string    { return name(ck) + "-config" }
+func dynamicConfigMapName(ck ConfKind) string   { return name(ck) + "-config-dynamic" }
+func serviceMonitorName(ck ConfKind) string     { return name(ck) + "-monitor" }
+func prometheusRuleName(ck ConfKind) string     { return name(ck) + "-alert" }
+func (b *builder) name() string                 { return name(b.confKind) }
+func (b *builder) promServiceName() string      { return promServiceName(b.confKind) }
+func (b *builder) staticConfigMapName() string  { return staticConfigMapName(b.confKind) }
+func (b *builder) dynamicConfigMapName() string { return dynamicConfigMapName(b.confKind) }
+func (b *builder) serviceMonitorName() string   { return serviceMonitorName(b.confKind) }
+func (b *builder) prometheusRuleName() string   { return prometheusRuleName(b.confKind) }
+func (b *builder) Pipeline() *PipelineBuilder   { return b.pipeline }
 
 func (b *builder) NewGRPCPipeline() PipelineBuilder {
 	return b.initPipeline(config.NewGRPCPipeline("grpc", api.IngestGRPCProto{
@@ -184,7 +186,7 @@ func (b *builder) podTemplate(hasHostPort, hostNetwork bool, annotations map[str
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: b.configMapName(),
+					Name: b.staticConfigMapName(),
 				},
 			},
 		},
@@ -260,15 +262,15 @@ func (b *builder) podTemplate(hasHostPort, hostNetwork bool, annotations map[str
 
 // returns a configmap with a digest of its configuration contents, which will be used to
 // detect any configuration change
-func (b *builder) ConfigMap() (*corev1.ConfigMap, string, error) {
-	configStr, err := b.GetJSONConfig()
+func (b *builder) StaticConfigMap() (*corev1.ConfigMap, string, error) {
+	configStr, err := b.GetStaticJSONConfig()
 	if err != nil {
 		return nil, "", err
 	}
 
 	configMap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      b.configMapName(),
+			Name:      b.staticConfigMapName(),
 			Namespace: b.info.Namespace,
 			Labels:    b.labels,
 		},
@@ -282,7 +284,28 @@ func (b *builder) ConfigMap() (*corev1.ConfigMap, string, error) {
 	return &configMap, digest, nil
 }
 
-func (b *builder) GetJSONConfig() (string, error) {
+func (b *builder) DynamicConfigMap() (*corev1.ConfigMap, error) {
+	configStr, err := b.GetDynamicJSONConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	configMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      b.dynamicConfigMapName(),
+			Namespace: b.info.Namespace,
+			Labels:    b.labels,
+		},
+		Data: map[string]string{
+			configFile: configStr,
+		},
+	}
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte(configStr))
+	return &configMap, nil
+}
+
+func (b *builder) GetStaticJSONConfig() (string, error) {
 	metricsSettings := config.MetricsSettings{
 		PromConnectionInfo: api.PromConnectionInfo{
 			Port: int(b.desired.Processor.Metrics.Server.Port),
@@ -306,8 +329,13 @@ func (b *builder) GetJSONConfig() (string, error) {
 			"port": *advancedConfig.HealthPort,
 		},
 		"pipeline":        b.pipeline.GetStages(),
-		"parameters":      b.pipeline.GetStageParams(),
+		"parameters":      b.pipeline.GetStaticStageParams(),
 		"metricsSettings": metricsSettings,
+		"dynamicParameters": config.DynamicParameters{
+			Namespace: b.info.Namespace,
+			Name:      b.dynamicConfigMapName(),
+			FileName:  configFile,
+		},
 	}
 	if advancedConfig.ProfilePort != nil {
 		config["profile"] = map[string]interface{}{
@@ -322,6 +350,18 @@ func (b *builder) GetJSONConfig() (string, error) {
 	return string(bs), nil
 }
 
+func (b *builder) GetDynamicJSONConfig() (string, error) {
+	config := map[string]interface{}{
+		"parameters": b.pipeline.GetDynamicStageParams(),
+	}
+
+	bs, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	return string(bs), nil
+
+}
 func (b *builder) promService() *corev1.Service {
 	svc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -489,7 +529,13 @@ func buildClusterRoleIngester(useOpenShiftSCC bool) *rbacv1.ClusterRole {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name(ConfKafkaIngester),
 		},
-		Rules: []rbacv1.PolicyRule{},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Verbs:     []string{"get", "watch"},
+				Resources: []string{"configmaps"},
+			},
+		},
 	}
 	if useOpenShiftSCC {
 		cr.Rules = append(cr.Rules, rbacv1.PolicyRule{

--- a/controllers/flp/flp_monolith_objects.go
+++ b/controllers/flp/flp_monolith_objects.go
@@ -39,13 +39,22 @@ func (b *monolithBuilder) daemonSet(annotations map[string]string) *appsv1.Daemo
 	}
 }
 
-func (b *monolithBuilder) configMap() (*corev1.ConfigMap, string, error) {
+func (b *monolithBuilder) staticConfigMap() (*corev1.ConfigMap, string, error) {
 	pipeline := b.generic.NewGRPCPipeline()
 	err := pipeline.AddProcessorStages()
 	if err != nil {
 		return nil, "", err
 	}
-	return b.generic.ConfigMap()
+	return b.generic.StaticConfigMap()
+}
+
+func (b *monolithBuilder) dynamicConfigMap() (*corev1.ConfigMap, error) {
+	pipeline := b.generic.NewGRPCPipeline()
+	err := pipeline.AddProcessorStages()
+	if err != nil {
+		return nil, err
+	}
+	return b.generic.DynamicConfigMap()
 }
 
 func (b *monolithBuilder) promService() *corev1.Service {

--- a/controllers/flp/flp_test.go
+++ b/controllers/flp/flp_test.go
@@ -195,14 +195,14 @@ func TestDaemonSetNoChange(t *testing.T) {
 	ns := "namespace"
 	cfg := getConfig()
 	b := monoBuilder(ns, &cfg)
-	_, digest, err := b.configMap()
+	_, digest, err := b.staticConfigMap()
 	assert.NoError(err)
 	first := b.daemonSet(annotate(digest))
 
 	// Check no change
 	cfg = getConfig()
 	b = monoBuilder(ns, &cfg)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	second := b.daemonSet(annotate(digest))
 
@@ -218,14 +218,14 @@ func TestDaemonSetChanged(t *testing.T) {
 	ns := "namespace"
 	cfg := getConfig()
 	b := monoBuilder(ns, &cfg)
-	_, digest, err := b.configMap()
+	_, digest, err := b.staticConfigMap()
 	assert.NoError(err)
 	first := b.daemonSet(annotate(digest))
 
 	// Check probes enabled change
 	cfg.Processor.Advanced.EnableKubeProbes = ptr.To(true)
 	b = monoBuilder(ns, &cfg)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	second := b.daemonSet(annotate(digest))
 
@@ -256,7 +256,7 @@ func TestDaemonSetChanged(t *testing.T) {
 	// Check log level change
 	cfg.Processor.LogLevel = "info"
 	b = monoBuilder(ns, &cfg)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	third := b.daemonSet(annotate(digest))
 
@@ -270,7 +270,7 @@ func TestDaemonSetChanged(t *testing.T) {
 		corev1.ResourceMemory: resource.MustParse("500Gi"),
 	}
 	b = monoBuilder(ns, &cfg)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	fourth := b.daemonSet(annotate(digest))
 
@@ -284,7 +284,7 @@ func TestDaemonSetChanged(t *testing.T) {
 		corev1.ResourceMemory: resource.MustParse("512Mi"),
 	}
 	b = monoBuilder(ns, &cfg)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	fifth := b.daemonSet(annotate(digest))
 
@@ -305,7 +305,7 @@ func TestDaemonSetChanged(t *testing.T) {
 		},
 	}
 	b = monoBuilder(ns, &cfg)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	sixth := b.daemonSet(annotate(digest))
 
@@ -323,7 +323,7 @@ func TestDaemonSetChanged(t *testing.T) {
 		},
 	}
 	b = monoBuilder(ns, &cfg)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	seventh := b.daemonSet(annotate(digest))
 
@@ -339,14 +339,14 @@ func TestDeploymentNoChange(t *testing.T) {
 	ns := "namespace"
 	cfg := getConfig()
 	b := transfBuilder(ns, &cfg)
-	_, digest, err := b.configMap()
+	_, digest, err := b.staticConfigMap()
 	assert.NoError(err)
 	first := b.deployment(annotate(digest))
 
 	// Check no change
 	cfg = getConfig()
 	b = transfBuilder(ns, &cfg)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	second := b.deployment(annotate(digest))
 
@@ -362,14 +362,14 @@ func TestDeploymentChanged(t *testing.T) {
 	ns := "namespace"
 	cfg := getConfig()
 	b := transfBuilder(ns, &cfg)
-	_, digest, err := b.configMap()
+	_, digest, err := b.staticConfigMap()
 	assert.NoError(err)
 	first := b.deployment(annotate(digest))
 
 	// Check probes enabled change
 	cfg.Processor.Advanced.EnableKubeProbes = ptr.To(true)
 	b = transfBuilder(ns, &cfg)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	second := b.deployment(annotate(digest))
 
@@ -384,7 +384,7 @@ func TestDeploymentChanged(t *testing.T) {
 	// Check log level change
 	cfg.Processor.LogLevel = "info"
 	b = transfBuilder(ns, &cfg)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	third := b.deployment(annotate(digest))
 
@@ -398,7 +398,7 @@ func TestDeploymentChanged(t *testing.T) {
 		corev1.ResourceMemory: resource.MustParse("500Gi"),
 	}
 	b = transfBuilder(ns, &cfg)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	fourth := b.deployment(annotate(digest))
 
@@ -412,7 +412,7 @@ func TestDeploymentChanged(t *testing.T) {
 		corev1.ResourceMemory: resource.MustParse("512Mi"),
 	}
 	b = transfBuilder(ns, &cfg)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	fifth := b.deployment(annotate(digest))
 
@@ -427,7 +427,7 @@ func TestDeploymentChanged(t *testing.T) {
 	cfg2 := cfg
 	cfg2.Processor.KafkaConsumerReplicas = ptr.To(int32(5))
 	b = transfBuilder(ns, &cfg2)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	sixth := b.deployment(annotate(digest))
 
@@ -443,7 +443,7 @@ func TestDeploymentChangedReplicasNoHPA(t *testing.T) {
 	ns := "namespace"
 	cfg := getConfigNoHPA()
 	b := transfBuilder(ns, &cfg)
-	_, digest, err := b.configMap()
+	_, digest, err := b.staticConfigMap()
 	assert.NoError(err)
 	first := b.deployment(annotate(digest))
 
@@ -451,7 +451,7 @@ func TestDeploymentChangedReplicasNoHPA(t *testing.T) {
 	cfg2 := cfg
 	cfg2.Processor.KafkaConsumerReplicas = ptr.To(int32(5))
 	b = transfBuilder(ns, &cfg2)
-	_, digest, err = b.configMap()
+	_, digest, err = b.staticConfigMap()
 	assert.NoError(err)
 	second := b.deployment(annotate(digest))
 
@@ -621,7 +621,7 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiManual(t *testing.T) {
 	cfg := getConfig()
 	loki := cfg.Loki
 	b := monoBuilder(ns, &cfg)
-	cm, digest, err := b.configMap()
+	cm, digest, err := b.staticConfigMap()
 	assert.NoError(err)
 	assert.NotEmpty(t, digest)
 
@@ -637,7 +637,7 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiManual(t *testing.T) {
 	assert.Equal("trace", decoded.LogLevel)
 
 	params := decoded.Parameters
-	assert.Len(params, 6)
+	assert.Len(params, 5)
 	assert.Equal(*cfg.Processor.Advanced.Port, int32(params[0].Ingest.GRPC.Port))
 
 	lokiCfg := params[3].Write.Loki
@@ -671,7 +671,7 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiStack(t *testing.T) {
 	useLokiStack(&cfg)
 	cfg.Agent.Type = flowslatest.AgentEBPF
 	b := monoBuilder(ns, &cfg)
-	cm, digest, err := b.configMap()
+	cm, digest, err := b.staticConfigMap()
 	assert.NoError(err)
 	assert.NotEmpty(t, digest)
 
@@ -687,7 +687,7 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiStack(t *testing.T) {
 	assert.Equal("trace", decoded.LogLevel)
 
 	params := decoded.Parameters
-	assert.Len(params, 6)
+	assert.Len(params, 5)
 
 	lokiCfg := params[3].Write.Loki
 	assert.Equal("https://lokistack-gateway-http.ls-namespace.svc:8080/api/logs/v1/network/", lokiCfg.URL)
@@ -789,10 +789,16 @@ func TestLabels(t *testing.T) {
 }
 
 // This function validate that each stage has its matching parameter
-func validatePipelineConfig(t *testing.T, cm *corev1.ConfigMap) (*config.ConfigFileStruct, string) {
+func validatePipelineConfig(t *testing.T, staticCm *corev1.ConfigMap, dynamicCm *corev1.ConfigMap) (*config.ConfigFileStruct, string) {
 	var cfs config.ConfigFileStruct
-	err := json.Unmarshal([]byte(cm.Data[configFile]), &cfs)
+	err := json.Unmarshal([]byte(staticCm.Data[configFile]), &cfs)
 	assert.NoError(t, err)
+
+	var dynCfs config.HotReloadStruct
+	err = json.Unmarshal([]byte(dynamicCm.Data[configFile]), &dynCfs)
+	assert.NoError(t, err)
+
+	cfs.Parameters = append(cfs.Parameters, dynCfs.Parameters...)
 
 	for _, stage := range cfs.Pipeline {
 		assert.NotEmpty(t, stage.Name)
@@ -818,9 +824,11 @@ func TestPipelineConfig(t *testing.T) {
 	cfg := getConfig()
 	cfg.Processor.LogLevel = "info"
 	b := monoBuilder(ns, &cfg)
-	cm, _, err := b.configMap()
+	scm, _, err := b.staticConfigMap()
 	assert.NoError(err)
-	_, pipeline := validatePipelineConfig(t, cm)
+	dcm, err := b.dynamicConfigMap()
+	assert.NoError(err)
+	_, pipeline := validatePipelineConfig(t, scm, dcm)
 	assert.Equal(
 		`[{"name":"grpc"},{"name":"extract_conntrack","follows":"grpc"},{"name":"enrich","follows":"extract_conntrack"},{"name":"loki","follows":"enrich"},{"name":"prometheus","follows":"enrich"}]`,
 		pipeline,
@@ -829,9 +837,11 @@ func TestPipelineConfig(t *testing.T) {
 	// Kafka Transformer
 	cfg.DeploymentModel = flowslatest.DeploymentModelKafka
 	bt := transfBuilder(ns, &cfg)
-	cm, _, err = bt.configMap()
+	scm, _, err = bt.staticConfigMap()
 	assert.NoError(err)
-	_, pipeline = validatePipelineConfig(t, cm)
+	dcm, err = bt.dynamicConfigMap()
+	assert.NoError(err)
+	_, pipeline = validatePipelineConfig(t, scm, dcm)
 	assert.Equal(
 		`[{"name":"kafka-read"},{"name":"extract_conntrack","follows":"kafka-read"},{"name":"enrich","follows":"extract_conntrack"},{"name":"loki","follows":"enrich"},{"name":"prometheus","follows":"enrich"}]`,
 		pipeline,
@@ -844,9 +854,11 @@ func TestPipelineTraceStage(t *testing.T) {
 	cfg := getConfig()
 
 	b := monoBuilder("namespace", &cfg)
-	cm, _, err := b.configMap()
+	scm, _, err := b.staticConfigMap()
 	assert.NoError(err)
-	_, pipeline := validatePipelineConfig(t, cm)
+	dcm, err := b.dynamicConfigMap()
+	assert.NoError(err)
+	_, pipeline := validatePipelineConfig(t, scm, dcm)
 	assert.Equal(
 		`[{"name":"grpc"},{"name":"extract_conntrack","follows":"grpc"},{"name":"enrich","follows":"extract_conntrack"},{"name":"loki","follows":"enrich"},{"name":"stdout","follows":"enrich"},{"name":"prometheus","follows":"enrich"}]`,
 		pipeline,
@@ -868,9 +880,11 @@ func TestMergeMetricsConfiguration_Default(t *testing.T) {
 	cfg := getConfig()
 
 	b := monoBuilder("namespace", &cfg)
-	cm, _, err := b.configMap()
+	scm, _, err := b.staticConfigMap()
 	assert.NoError(err)
-	cfs, _ := validatePipelineConfig(t, cm)
+	dcm, err := b.dynamicConfigMap()
+	assert.NoError(err)
+	cfs, _ := validatePipelineConfig(t, scm, dcm)
 	names := getSortedMetricsNames(cfs.Parameters[5].Encode.Prom.Metrics)
 	assert.Equal([]string{
 		"namespace_flows_total",
@@ -888,9 +902,11 @@ func TestMergeMetricsConfiguration_DefaultWithFeatures(t *testing.T) {
 	cfg.Agent.EBPF.Features = []flowslatest.AgentFeature{flowslatest.DNSTracking, flowslatest.FlowRTT, flowslatest.PacketDrop}
 
 	b := monoBuilder("namespace", &cfg)
-	cm, _, err := b.configMap()
+	scm, _, err := b.staticConfigMap()
 	assert.NoError(err)
-	cfs, _ := validatePipelineConfig(t, cm)
+	dcm, err := b.dynamicConfigMap()
+	assert.NoError(err)
+	cfs, _ := validatePipelineConfig(t, scm, dcm)
 	names := getSortedMetricsNames(cfs.Parameters[5].Encode.Prom.Metrics)
 	assert.Equal([]string{
 		"namespace_dns_latency_seconds",
@@ -910,9 +926,11 @@ func TestMergeMetricsConfiguration_WithList(t *testing.T) {
 	cfg.Processor.Metrics.IncludeList = &[]flowslatest.FLPMetric{"namespace_egress_bytes_total", "namespace_ingress_bytes_total"}
 
 	b := monoBuilder("namespace", &cfg)
-	cm, _, err := b.configMap()
+	scm, _, err := b.staticConfigMap()
 	assert.NoError(err)
-	cfs, _ := validatePipelineConfig(t, cm)
+	dcm, err := b.dynamicConfigMap()
+	assert.NoError(err)
+	cfs, _ := validatePipelineConfig(t, scm, dcm)
 	names := getSortedMetricsNames(cfs.Parameters[5].Encode.Prom.Metrics)
 	assert.Len(names, 2)
 	assert.Equal("namespace_egress_bytes_total", names[0])
@@ -927,9 +945,11 @@ func TestMergeMetricsConfiguration_EmptyList(t *testing.T) {
 	cfg.Processor.Metrics.IncludeList = &[]flowslatest.FLPMetric{}
 
 	b := monoBuilder("namespace", &cfg)
-	cm, _, err := b.configMap()
+	scm, _, err := b.staticConfigMap()
 	assert.NoError(err)
-	cfs, _ := validatePipelineConfig(t, cm)
+	dcm, err := b.dynamicConfigMap()
+	assert.NoError(err)
+	cfs, _ := validatePipelineConfig(t, scm, dcm)
 	assert.Len(cfs.Parameters, 5)
 }
 
@@ -952,20 +972,22 @@ func TestPipelineWithExporter(t *testing.T) {
 	})
 
 	b := monoBuilder("namespace", &cfg)
-	cm, _, err := b.configMap()
+	scm, _, err := b.staticConfigMap()
 	assert.NoError(err)
-	cfs, pipeline := validatePipelineConfig(t, cm)
+	dcm, err := b.dynamicConfigMap()
+	assert.NoError(err)
+	cfs, pipeline := validatePipelineConfig(t, scm, dcm)
 	assert.Equal(
 		`[{"name":"grpc"},{"name":"extract_conntrack","follows":"grpc"},{"name":"enrich","follows":"extract_conntrack"},{"name":"loki","follows":"enrich"},{"name":"stdout","follows":"enrich"},{"name":"prometheus","follows":"enrich"},{"name":"kafka-export-0","follows":"enrich"},{"name":"IPFIX-export-1","follows":"enrich"}]`,
 		pipeline,
 	)
 
-	assert.Equal("kafka-test", cfs.Parameters[6].Encode.Kafka.Address)
-	assert.Equal("topic-test", cfs.Parameters[6].Encode.Kafka.Topic)
+	assert.Equal("kafka-test", cfs.Parameters[5].Encode.Kafka.Address)
+	assert.Equal("topic-test", cfs.Parameters[5].Encode.Kafka.Topic)
 
-	assert.Equal("ipfix-receiver-test", cfs.Parameters[7].Write.Ipfix.TargetHost)
-	assert.Equal(9999, cfs.Parameters[7].Write.Ipfix.TargetPort)
-	assert.Equal("tcp", cfs.Parameters[7].Write.Ipfix.Transport)
+	assert.Equal("ipfix-receiver-test", cfs.Parameters[6].Write.Ipfix.TargetHost)
+	assert.Equal(9999, cfs.Parameters[6].Write.Ipfix.TargetPort)
+	assert.Equal("tcp", cfs.Parameters[6].Write.Ipfix.Transport)
 }
 
 func TestPipelineWithoutLoki(t *testing.T) {
@@ -975,9 +997,11 @@ func TestPipelineWithoutLoki(t *testing.T) {
 	cfg.Loki.Enable = ptr.To(false)
 
 	b := monoBuilder("namespace", &cfg)
-	cm, _, err := b.configMap()
+	scm, _, err := b.staticConfigMap()
 	assert.NoError(err)
-	_, pipeline := validatePipelineConfig(t, cm)
+	dcm, err := b.dynamicConfigMap()
+	assert.NoError(err)
+	_, pipeline := validatePipelineConfig(t, scm, dcm)
 	assert.Equal(
 		`[{"name":"grpc"},{"name":"extract_conntrack","follows":"grpc"},{"name":"enrich","follows":"extract_conntrack"},{"name":"stdout","follows":"enrich"},{"name":"prometheus","follows":"enrich"}]`,
 		pipeline,

--- a/controllers/flp/flp_transfo_objects.go
+++ b/controllers/flp/flp_transfo_objects.go
@@ -41,13 +41,22 @@ func (b *transfoBuilder) deployment(annotations map[string]string) *appsv1.Deplo
 	}
 }
 
-func (b *transfoBuilder) configMap() (*corev1.ConfigMap, string, error) {
+func (b *transfoBuilder) staticConfigMap() (*corev1.ConfigMap, string, error) {
 	pipeline := b.generic.NewKafkaPipeline()
 	err := pipeline.AddProcessorStages()
 	if err != nil {
 		return nil, "", err
 	}
-	return b.generic.ConfigMap()
+	return b.generic.StaticConfigMap()
+}
+
+func (b *transfoBuilder) dynamicConfigMap() (*corev1.ConfigMap, error) {
+	pipeline := b.generic.NewKafkaPipeline()
+	err := pipeline.AddProcessorStages()
+	if err != nil {
+		return nil, err
+	}
+	return b.generic.DynamicConfigMap()
 }
 
 func (b *transfoBuilder) promService() *corev1.Service {

--- a/controllers/flp/metrics_api_test.go
+++ b/controllers/flp/metrics_api_test.go
@@ -73,7 +73,7 @@ func TestFlowMetricToFLP(t *testing.T) {
 		},
 	})
 	assert.NoError(err)
-	cm, _, err := b.configMap()
+	cm, err := b.dynamicConfigMap()
 	assert.NoError(err)
 	items, err := getConfiguredMetrics(cm)
 	assert.NoError(err)

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/netobserv/network-observability-operator
 
-go 1.21
+go 1.21.0
 
 toolchain go1.21.7
 
 require (
 	github.com/go-logr/logr v1.4.1
-	github.com/netobserv/flowlogs-pipeline v0.1.12-0.20240325101510-5feb3c603334
+	github.com/netobserv/flowlogs-pipeline v0.1.12-0.20240426113456-2ab1f8dd0cc9
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.31.1
 	github.com/openshift/api v0.0.0-20220112145620-704957ce4980
@@ -65,8 +65,8 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
-	golang.org/x/net v0.22.0 // indirect
-	golang.org/x/oauth2 v0.16.0 // indirect
+	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/oauth2 v0.17.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/netobserv/flowlogs-pipeline v0.1.12-0.20240325101510-5feb3c603334 h1:46pTt4NT7s5buSwTe9YS+Vn+62kqFU1+vZ5I1QqcypQ=
-github.com/netobserv/flowlogs-pipeline v0.1.12-0.20240325101510-5feb3c603334/go.mod h1:aiCIZopeZfHuI1/jt/Gg2Cns2y4DOanIVJrOFRergYU=
+github.com/netobserv/flowlogs-pipeline v0.1.12-0.20240426113456-2ab1f8dd0cc9 h1:vw7WsQU+yrHgw4rFRpmGv1o9EdD5ujsiFBmN47Fx/sU=
+github.com/netobserv/flowlogs-pipeline v0.1.12-0.20240426113456-2ab1f8dd0cc9/go.mod h1:m+2/ak4+W++xFapf2HUJUtjwuoKE5Yek0VLVtaAbgJI=
 github.com/netobserv/prometheus-common v0.48.0-netobserv h1:yNde6dteyK69t7l3k8CcR2uM6q+S10xgCap7mofvvV8=
 github.com/netobserv/prometheus-common v0.48.0-netobserv/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5EC6ILDTlAPc=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
@@ -270,11 +270,11 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.22.0 h1:9sGLhx7iRIHEiX0oAJ3MRZMUCElJgy7Br1nO+AMN3Tc=
-golang.org/x/net v0.22.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
+golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
-golang.org/x/oauth2 v0.16.0 h1:aDkGMBSYxElaoP81NpoUoz2oo2R2wHdZpGToUxfyQrQ=
-golang.org/x/oauth2 v0.16.0/go.mod h1:hqZ+0LWXsiVoZpeld6jVt06P3adbS2Uu911W1SsJv2o=
+golang.org/x/oauth2 v0.17.0 h1:6m3ZPmLEFdVxKKWnKq4VqZ60gutO35zm+zrAHVmHyDQ=
+golang.org/x/oauth2 v0.17.0/go.mod h1:OzPDGQiuQMguemayvdylqddI7qcD9lnSDb+1FiwQ5HA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/volumes/builder.go
+++ b/pkg/volumes/builder.go
@@ -54,6 +54,12 @@ func (b *Builder) AddVolume(config *flowslatest.FileReference, volumeName string
 
 // AddToken will add a volume + volume mount for a service account token if defined
 func (b *Builder) AddToken(name string) string {
+	for i := range b.info {
+		if b.info[i].Volume.Name == name {
+			// Token already added
+			return constants.TokensPath + name
+		}
+	}
 	vol := corev1.Volume{
 		Name: name,
 		VolumeSource: corev1.VolumeSource{

--- a/vendor/github.com/netobserv/flowlogs-pipeline/pkg/config/config.go
+++ b/vendor/github.com/netobserv/flowlogs-pipeline/pkg/config/config.go
@@ -27,22 +27,35 @@ import (
 )
 
 type Options struct {
-	PipeLine        string
-	Parameters      string
-	MetricsSettings string
-	Health          Health
-	Profile         Profile
+	PipeLine          string
+	Parameters        string
+	DynamicParameters string
+	MetricsSettings   string
+	Health            Health
+	Profile           Profile
 }
 
 // (nolint => needs refactoring)
 //
 //nolint:revive
 type ConfigFileStruct struct {
-	LogLevel        string          `yaml:"log-level,omitempty" json:"log-level,omitempty"`
-	MetricsSettings MetricsSettings `yaml:"metricsSettings,omitempty" json:"metricsSettings,omitempty"`
-	Pipeline        []Stage         `yaml:"pipeline,omitempty" json:"pipeline,omitempty"`
-	Parameters      []StageParam    `yaml:"parameters,omitempty" json:"parameters,omitempty"`
-	PerfSettings    PerfSettings    `yaml:"perfSettings,omitempty" json:"perfSettings,omitempty"`
+	LogLevel          string            `yaml:"log-level,omitempty" json:"log-level,omitempty"`
+	MetricsSettings   MetricsSettings   `yaml:"metricsSettings,omitempty" json:"metricsSettings,omitempty"`
+	Pipeline          []Stage           `yaml:"pipeline,omitempty" json:"pipeline,omitempty"`
+	Parameters        []StageParam      `yaml:"parameters,omitempty" json:"parameters,omitempty"`
+	PerfSettings      PerfSettings      `yaml:"perfSettings,omitempty" json:"perfSettings,omitempty"`
+	DynamicParameters DynamicParameters `yaml:"dynamicParameters,omitempty" json:"dynamicParameters,omitempty"`
+}
+
+type DynamicParameters struct {
+	Namespace      string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	Name           string `yaml:"name,omitempty" json:"name,omitempty"`
+	FileName       string `yaml:"fileName,omitempty" json:"fileName,omitempty"`
+	KubeConfigPath string `yaml:"kubeConfigPath,omitempty" json:"kubeConfigPath,omitempty" doc:"path to kubeconfig file (optional)"`
+}
+
+type HotReloadStruct struct {
+	Parameters []StageParam `yaml:"parameters,omitempty" json:"parameters,omitempty"`
 }
 
 type Health struct {
@@ -153,6 +166,15 @@ func ParseConfig(opts *Options) (ConfigFileStruct, error) {
 		return out, err
 	}
 	logrus.Debugf("params = %v ", out.Parameters)
+
+	if opts.DynamicParameters != "" {
+		err = JSONUnmarshalStrict([]byte(opts.DynamicParameters), &out.DynamicParameters)
+		if err != nil {
+			logrus.Errorf("error when parsing dynamic pipeline parameters: %v", err)
+			return out, err
+		}
+		logrus.Debugf("dynamicParams = %v ", out.DynamicParameters)
+	}
 
 	if opts.MetricsSettings != "" {
 		err = JSONUnmarshalStrict([]byte(opts.MetricsSettings), &out.MetricsSettings)

--- a/vendor/github.com/netobserv/flowlogs-pipeline/pkg/config/pipeline_builder.go
+++ b/vendor/github.com/netobserv/flowlogs-pipeline/pkg/config/pipeline_builder.go
@@ -192,6 +192,33 @@ func (b *PipelineBuilderStage) GetStageParams() []StageParam {
 	return b.pipeline.config
 }
 
+func isStaticParam(param StageParam) bool {
+	if param.Encode != nil && param.Encode.Type == api.PromType {
+		return false
+	}
+	return true
+}
+
+func (b *PipelineBuilderStage) GetStaticStageParams() []StageParam {
+	res := []StageParam{}
+	for _, param := range b.pipeline.config {
+		if isStaticParam(param) {
+			res = append(res, param)
+		}
+	}
+	return res
+}
+
+func (b *PipelineBuilderStage) GetDynamicStageParams() []StageParam {
+	res := []StageParam{}
+	for _, param := range b.pipeline.config {
+		if !isStaticParam(param) {
+			res = append(res, param)
+		}
+	}
+	return res
+}
+
 // IntoConfigFileStruct injects the current pipeline and params in the provided ConfigFileStruct object.
 func (b *PipelineBuilderStage) IntoConfigFileStruct(cfs *ConfigFileStruct) *ConfigFileStruct {
 	cfs.Pipeline = b.GetStages()

--- a/vendor/github.com/netobserv/flowlogs-pipeline/pkg/utils/kubernetes.go
+++ b/vendor/github.com/netobserv/flowlogs-pipeline/pkg/utils/kubernetes.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	kubeConfigEnvVariable = "KUBECONFIG"
+)
+
+func LoadK8sConfig(kubeConfigPath string) (*rest.Config, error) {
+	// if no config path is provided, load it from the env variable
+	if kubeConfigPath == "" {
+		kubeConfigPath = os.Getenv(kubeConfigEnvVariable)
+	}
+	// otherwise, load it from the $HOME/.kube/config file
+	if kubeConfigPath == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("can't get user home dir: %w", err)
+		}
+		kubeConfigPath = path.Join(homeDir, ".kube", "config")
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err == nil {
+		return config, nil
+	}
+	// fallback: use in-cluster config
+	config, err = rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("can't access kubenetes. Tried using config from: "+
+			"config parameter, %s env, homedir and InClusterConfig. Got: %w",
+			kubeConfigEnvVariable, err)
+	}
+	return config, nil
+}

--- a/vendor/golang.org/x/net/http/httpproxy/proxy.go
+++ b/vendor/golang.org/x/net/http/httpproxy/proxy.go
@@ -149,10 +149,7 @@ func parseProxy(proxy string) (*url.URL, error) {
 	}
 
 	proxyURL, err := url.Parse(proxy)
-	if err != nil ||
-		(proxyURL.Scheme != "http" &&
-			proxyURL.Scheme != "https" &&
-			proxyURL.Scheme != "socks5") {
+	if err != nil || proxyURL.Scheme == "" || proxyURL.Host == "" {
 		// proxy was bogus. Try prepending "http://" to it and
 		// see if that parses correctly. If not, we fall
 		// through and complain about the original one.

--- a/vendor/golang.org/x/net/http2/frame.go
+++ b/vendor/golang.org/x/net/http2/frame.go
@@ -1564,6 +1564,7 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
 		if size > remainSize {
 			hdec.SetEmitEnabled(false)
 			mh.Truncated = true
+			remainSize = 0
 			return
 		}
 		remainSize -= size
@@ -1576,6 +1577,36 @@ func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
 	var hc headersOrContinuation = hf
 	for {
 		frag := hc.HeaderBlockFragment()
+
+		// Avoid parsing large amounts of headers that we will then discard.
+		// If the sender exceeds the max header list size by too much,
+		// skip parsing the fragment and close the connection.
+		//
+		// "Too much" is either any CONTINUATION frame after we've already
+		// exceeded the max header list size (in which case remainSize is 0),
+		// or a frame whose encoded size is more than twice the remaining
+		// header list bytes we're willing to accept.
+		if int64(len(frag)) > int64(2*remainSize) {
+			if VerboseLogs {
+				log.Printf("http2: header list too large")
+			}
+			// It would be nice to send a RST_STREAM before sending the GOAWAY,
+			// but the structure of the server's frame writer makes this difficult.
+			return nil, ConnectionError(ErrCodeProtocol)
+		}
+
+		// Also close the connection after any CONTINUATION frame following an
+		// invalid header, since we stop tracking the size of the headers after
+		// an invalid one.
+		if invalid != nil {
+			if VerboseLogs {
+				log.Printf("http2: invalid header: %v", invalid)
+			}
+			// It would be nice to send a RST_STREAM before sending the GOAWAY,
+			// but the structure of the server's frame writer makes this difficult.
+			return nil, ConnectionError(ErrCodeProtocol)
+		}
+
 		if _, err := hdec.Write(frag); err != nil {
 			return nil, ConnectionError(ErrCodeCompression)
 		}

--- a/vendor/golang.org/x/net/http2/testsync.go
+++ b/vendor/golang.org/x/net/http2/testsync.go
@@ -1,0 +1,331 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package http2
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// testSyncHooks coordinates goroutines in tests.
+//
+// For example, a call to ClientConn.RoundTrip involves several goroutines, including:
+//   - the goroutine running RoundTrip;
+//   - the clientStream.doRequest goroutine, which writes the request; and
+//   - the clientStream.readLoop goroutine, which reads the response.
+//
+// Using testSyncHooks, a test can start a RoundTrip and identify when all these goroutines
+// are blocked waiting for some condition such as reading the Request.Body or waiting for
+// flow control to become available.
+//
+// The testSyncHooks also manage timers and synthetic time in tests.
+// This permits us to, for example, start a request and cause it to time out waiting for
+// response headers without resorting to time.Sleep calls.
+type testSyncHooks struct {
+	// active/inactive act as a mutex and condition variable.
+	//
+	//  - neither chan contains a value: testSyncHooks is locked.
+	//  - active contains a value: unlocked, and at least one goroutine is not blocked
+	//  - inactive contains a value: unlocked, and all goroutines are blocked
+	active   chan struct{}
+	inactive chan struct{}
+
+	// goroutine counts
+	total    int                     // total goroutines
+	condwait map[*sync.Cond]int      // blocked in sync.Cond.Wait
+	blocked  []*testBlockedGoroutine // otherwise blocked
+
+	// fake time
+	now    time.Time
+	timers []*fakeTimer
+
+	// Transport testing: Report various events.
+	newclientconn func(*ClientConn)
+	newstream     func(*clientStream)
+}
+
+// testBlockedGoroutine is a blocked goroutine.
+type testBlockedGoroutine struct {
+	f  func() bool   // blocked until f returns true
+	ch chan struct{} // closed when unblocked
+}
+
+func newTestSyncHooks() *testSyncHooks {
+	h := &testSyncHooks{
+		active:   make(chan struct{}, 1),
+		inactive: make(chan struct{}, 1),
+		condwait: map[*sync.Cond]int{},
+	}
+	h.inactive <- struct{}{}
+	h.now = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	return h
+}
+
+// lock acquires the testSyncHooks mutex.
+func (h *testSyncHooks) lock() {
+	select {
+	case <-h.active:
+	case <-h.inactive:
+	}
+}
+
+// waitInactive waits for all goroutines to become inactive.
+func (h *testSyncHooks) waitInactive() {
+	for {
+		<-h.inactive
+		if !h.unlock() {
+			break
+		}
+	}
+}
+
+// unlock releases the testSyncHooks mutex.
+// It reports whether any goroutines are active.
+func (h *testSyncHooks) unlock() (active bool) {
+	// Look for a blocked goroutine which can be unblocked.
+	blocked := h.blocked[:0]
+	unblocked := false
+	for _, b := range h.blocked {
+		if !unblocked && b.f() {
+			unblocked = true
+			close(b.ch)
+		} else {
+			blocked = append(blocked, b)
+		}
+	}
+	h.blocked = blocked
+
+	// Count goroutines blocked on condition variables.
+	condwait := 0
+	for _, count := range h.condwait {
+		condwait += count
+	}
+
+	if h.total > condwait+len(blocked) {
+		h.active <- struct{}{}
+		return true
+	} else {
+		h.inactive <- struct{}{}
+		return false
+	}
+}
+
+// goRun starts a new goroutine.
+func (h *testSyncHooks) goRun(f func()) {
+	h.lock()
+	h.total++
+	h.unlock()
+	go func() {
+		defer func() {
+			h.lock()
+			h.total--
+			h.unlock()
+		}()
+		f()
+	}()
+}
+
+// blockUntil indicates that a goroutine is blocked waiting for some condition to become true.
+// It waits until f returns true before proceeding.
+//
+// Example usage:
+//
+//	h.blockUntil(func() bool {
+//		// Is the context done yet?
+//		select {
+//		case <-ctx.Done():
+//		default:
+//			return false
+//		}
+//		return true
+//	})
+//	// Wait for the context to become done.
+//	<-ctx.Done()
+//
+// The function f passed to blockUntil must be non-blocking and idempotent.
+func (h *testSyncHooks) blockUntil(f func() bool) {
+	if f() {
+		return
+	}
+	ch := make(chan struct{})
+	h.lock()
+	h.blocked = append(h.blocked, &testBlockedGoroutine{
+		f:  f,
+		ch: ch,
+	})
+	h.unlock()
+	<-ch
+}
+
+// broadcast is sync.Cond.Broadcast.
+func (h *testSyncHooks) condBroadcast(cond *sync.Cond) {
+	h.lock()
+	delete(h.condwait, cond)
+	h.unlock()
+	cond.Broadcast()
+}
+
+// broadcast is sync.Cond.Wait.
+func (h *testSyncHooks) condWait(cond *sync.Cond) {
+	h.lock()
+	h.condwait[cond]++
+	h.unlock()
+}
+
+// newTimer creates a new fake timer.
+func (h *testSyncHooks) newTimer(d time.Duration) timer {
+	h.lock()
+	defer h.unlock()
+	t := &fakeTimer{
+		hooks: h,
+		when:  h.now.Add(d),
+		c:     make(chan time.Time),
+	}
+	h.timers = append(h.timers, t)
+	return t
+}
+
+// afterFunc creates a new fake AfterFunc timer.
+func (h *testSyncHooks) afterFunc(d time.Duration, f func()) timer {
+	h.lock()
+	defer h.unlock()
+	t := &fakeTimer{
+		hooks: h,
+		when:  h.now.Add(d),
+		f:     f,
+	}
+	h.timers = append(h.timers, t)
+	return t
+}
+
+func (h *testSyncHooks) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(ctx)
+	t := h.afterFunc(d, cancel)
+	return ctx, func() {
+		t.Stop()
+		cancel()
+	}
+}
+
+func (h *testSyncHooks) timeUntilEvent() time.Duration {
+	h.lock()
+	defer h.unlock()
+	var next time.Time
+	for _, t := range h.timers {
+		if next.IsZero() || t.when.Before(next) {
+			next = t.when
+		}
+	}
+	if d := next.Sub(h.now); d > 0 {
+		return d
+	}
+	return 0
+}
+
+// advance advances time and causes synthetic timers to fire.
+func (h *testSyncHooks) advance(d time.Duration) {
+	h.lock()
+	defer h.unlock()
+	h.now = h.now.Add(d)
+	timers := h.timers[:0]
+	for _, t := range h.timers {
+		t := t // remove after go.mod depends on go1.22
+		t.mu.Lock()
+		switch {
+		case t.when.After(h.now):
+			timers = append(timers, t)
+		case t.when.IsZero():
+			// stopped timer
+		default:
+			t.when = time.Time{}
+			if t.c != nil {
+				close(t.c)
+			}
+			if t.f != nil {
+				h.total++
+				go func() {
+					defer func() {
+						h.lock()
+						h.total--
+						h.unlock()
+					}()
+					t.f()
+				}()
+			}
+		}
+		t.mu.Unlock()
+	}
+	h.timers = timers
+}
+
+// A timer wraps a time.Timer, or a synthetic equivalent in tests.
+// Unlike time.Timer, timer is single-use: The timer channel is closed when the timer expires.
+type timer interface {
+	C() <-chan time.Time
+	Stop() bool
+	Reset(d time.Duration) bool
+}
+
+// timeTimer implements timer using real time.
+type timeTimer struct {
+	t *time.Timer
+	c chan time.Time
+}
+
+// newTimeTimer creates a new timer using real time.
+func newTimeTimer(d time.Duration) timer {
+	ch := make(chan time.Time)
+	t := time.AfterFunc(d, func() {
+		close(ch)
+	})
+	return &timeTimer{t, ch}
+}
+
+// newTimeAfterFunc creates an AfterFunc timer using real time.
+func newTimeAfterFunc(d time.Duration, f func()) timer {
+	return &timeTimer{
+		t: time.AfterFunc(d, f),
+	}
+}
+
+func (t timeTimer) C() <-chan time.Time        { return t.c }
+func (t timeTimer) Stop() bool                 { return t.t.Stop() }
+func (t timeTimer) Reset(d time.Duration) bool { return t.t.Reset(d) }
+
+// fakeTimer implements timer using fake time.
+type fakeTimer struct {
+	hooks *testSyncHooks
+
+	mu   sync.Mutex
+	when time.Time      // when the timer will fire
+	c    chan time.Time // closed when the timer fires; mutually exclusive with f
+	f    func()         // called when the timer fires; mutually exclusive with c
+}
+
+func (t *fakeTimer) C() <-chan time.Time { return t.c }
+
+func (t *fakeTimer) Stop() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	stopped := t.when.IsZero()
+	t.when = time.Time{}
+	return stopped
+}
+
+func (t *fakeTimer) Reset(d time.Duration) bool {
+	if t.c != nil || t.f == nil {
+		panic("fakeTimer only supports Reset on AfterFunc timers")
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.hooks.lock()
+	defer t.hooks.unlock()
+	active := !t.when.IsZero()
+	t.when = t.hooks.now.Add(d)
+	if !active {
+		t.hooks.timers = append(t.hooks.timers, t)
+	}
+	return active
+}

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -147,6 +147,12 @@ type Transport struct {
 	// waiting for their turn.
 	StrictMaxConcurrentStreams bool
 
+	// IdleConnTimeout is the maximum amount of time an idle
+	// (keep-alive) connection will remain idle before closing
+	// itself.
+	// Zero means no limit.
+	IdleConnTimeout time.Duration
+
 	// ReadIdleTimeout is the timeout after which a health check using ping
 	// frame will be carried out if no frame is received on the connection.
 	// Note that a ping response will is considered a received frame, so if
@@ -178,6 +184,8 @@ type Transport struct {
 
 	connPoolOnce  sync.Once
 	connPoolOrDef ClientConnPool // non-nil version of ConnPool
+
+	syncHooks *testSyncHooks
 }
 
 func (t *Transport) maxHeaderListSize() uint32 {
@@ -302,7 +310,7 @@ type ClientConn struct {
 	readerErr  error         // set before readerDone is closed
 
 	idleTimeout time.Duration // or 0 for never
-	idleTimer   *time.Timer
+	idleTimer   timer
 
 	mu              sync.Mutex // guards following
 	cond            *sync.Cond // hold mu; broadcast on flow/closed changes
@@ -344,6 +352,60 @@ type ClientConn struct {
 	werr error        // first write error that has occurred
 	hbuf bytes.Buffer // HPACK encoder writes into this
 	henc *hpack.Encoder
+
+	syncHooks *testSyncHooks // can be nil
+}
+
+// Hook points used for testing.
+// Outside of tests, cc.syncHooks is nil and these all have minimal implementations.
+// Inside tests, see the testSyncHooks function docs.
+
+// goRun starts a new goroutine.
+func (cc *ClientConn) goRun(f func()) {
+	if cc.syncHooks != nil {
+		cc.syncHooks.goRun(f)
+		return
+	}
+	go f()
+}
+
+// condBroadcast is cc.cond.Broadcast.
+func (cc *ClientConn) condBroadcast() {
+	if cc.syncHooks != nil {
+		cc.syncHooks.condBroadcast(cc.cond)
+	}
+	cc.cond.Broadcast()
+}
+
+// condWait is cc.cond.Wait.
+func (cc *ClientConn) condWait() {
+	if cc.syncHooks != nil {
+		cc.syncHooks.condWait(cc.cond)
+	}
+	cc.cond.Wait()
+}
+
+// newTimer creates a new time.Timer, or a synthetic timer in tests.
+func (cc *ClientConn) newTimer(d time.Duration) timer {
+	if cc.syncHooks != nil {
+		return cc.syncHooks.newTimer(d)
+	}
+	return newTimeTimer(d)
+}
+
+// afterFunc creates a new time.AfterFunc timer, or a synthetic timer in tests.
+func (cc *ClientConn) afterFunc(d time.Duration, f func()) timer {
+	if cc.syncHooks != nil {
+		return cc.syncHooks.afterFunc(d, f)
+	}
+	return newTimeAfterFunc(d, f)
+}
+
+func (cc *ClientConn) contextWithTimeout(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+	if cc.syncHooks != nil {
+		return cc.syncHooks.contextWithTimeout(ctx, d)
+	}
+	return context.WithTimeout(ctx, d)
 }
 
 // clientStream is the state for a single HTTP/2 stream. One of these
@@ -425,7 +487,7 @@ func (cs *clientStream) abortStreamLocked(err error) {
 	// TODO(dneil): Clean up tests where cs.cc.cond is nil.
 	if cs.cc.cond != nil {
 		// Wake up writeRequestBody if it is waiting on flow control.
-		cs.cc.cond.Broadcast()
+		cs.cc.condBroadcast()
 	}
 }
 
@@ -435,7 +497,7 @@ func (cs *clientStream) abortRequestBodyWrite() {
 	defer cc.mu.Unlock()
 	if cs.reqBody != nil && cs.reqBodyClosed == nil {
 		cs.closeReqBodyLocked()
-		cc.cond.Broadcast()
+		cc.condBroadcast()
 	}
 }
 
@@ -445,10 +507,10 @@ func (cs *clientStream) closeReqBodyLocked() {
 	}
 	cs.reqBodyClosed = make(chan struct{})
 	reqBodyClosed := cs.reqBodyClosed
-	go func() {
+	cs.cc.goRun(func() {
 		cs.reqBody.Close()
 		close(reqBodyClosed)
-	}()
+	})
 }
 
 type stickyErrWriter struct {
@@ -537,15 +599,6 @@ func authorityAddr(scheme string, authority string) (addr string) {
 	return net.JoinHostPort(host, port)
 }
 
-var retryBackoffHook func(time.Duration) *time.Timer
-
-func backoffNewTimer(d time.Duration) *time.Timer {
-	if retryBackoffHook != nil {
-		return retryBackoffHook(d)
-	}
-	return time.NewTimer(d)
-}
-
 // RoundTripOpt is like RoundTrip, but takes options.
 func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
 	if !(req.URL.Scheme == "https" || (req.URL.Scheme == "http" && t.AllowHTTP)) {
@@ -573,13 +626,27 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
 				backoff := float64(uint(1) << (uint(retry) - 1))
 				backoff += backoff * (0.1 * mathrand.Float64())
 				d := time.Second * time.Duration(backoff)
-				timer := backoffNewTimer(d)
+				var tm timer
+				if t.syncHooks != nil {
+					tm = t.syncHooks.newTimer(d)
+					t.syncHooks.blockUntil(func() bool {
+						select {
+						case <-tm.C():
+						case <-req.Context().Done():
+						default:
+							return false
+						}
+						return true
+					})
+				} else {
+					tm = newTimeTimer(d)
+				}
 				select {
-				case <-timer.C:
+				case <-tm.C():
 					t.vlogf("RoundTrip retrying after failure: %v", roundTripErr)
 					continue
 				case <-req.Context().Done():
-					timer.Stop()
+					tm.Stop()
 					err = req.Context().Err()
 				}
 			}
@@ -658,6 +725,9 @@ func canRetryError(err error) bool {
 }
 
 func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse bool) (*ClientConn, error) {
+	if t.syncHooks != nil {
+		return t.newClientConn(nil, singleUse, t.syncHooks)
+	}
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, err
@@ -666,7 +736,7 @@ func (t *Transport) dialClientConn(ctx context.Context, addr string, singleUse b
 	if err != nil {
 		return nil, err
 	}
-	return t.newClientConn(tconn, singleUse)
+	return t.newClientConn(tconn, singleUse, nil)
 }
 
 func (t *Transport) newTLSConfig(host string) *tls.Config {
@@ -732,10 +802,10 @@ func (t *Transport) maxEncoderHeaderTableSize() uint32 {
 }
 
 func (t *Transport) NewClientConn(c net.Conn) (*ClientConn, error) {
-	return t.newClientConn(c, t.disableKeepAlives())
+	return t.newClientConn(c, t.disableKeepAlives(), nil)
 }
 
-func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, error) {
+func (t *Transport) newClientConn(c net.Conn, singleUse bool, hooks *testSyncHooks) (*ClientConn, error) {
 	cc := &ClientConn{
 		t:                     t,
 		tconn:                 c,
@@ -750,10 +820,15 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
 		wantSettingsAck:       true,
 		pings:                 make(map[[8]byte]chan struct{}),
 		reqHeaderMu:           make(chan struct{}, 1),
+		syncHooks:             hooks,
+	}
+	if hooks != nil {
+		hooks.newclientconn(cc)
+		c = cc.tconn
 	}
 	if d := t.idleConnTimeout(); d != 0 {
 		cc.idleTimeout = d
-		cc.idleTimer = time.AfterFunc(d, cc.onIdleTimeout)
+		cc.idleTimer = cc.afterFunc(d, cc.onIdleTimeout)
 	}
 	if VerboseLogs {
 		t.vlogf("http2: Transport creating client conn %p to %v", cc, c.RemoteAddr())
@@ -818,7 +893,7 @@ func (t *Transport) newClientConn(c net.Conn, singleUse bool) (*ClientConn, erro
 		return nil, cc.werr
 	}
 
-	go cc.readLoop()
+	cc.goRun(cc.readLoop)
 	return cc, nil
 }
 
@@ -826,7 +901,7 @@ func (cc *ClientConn) healthCheck() {
 	pingTimeout := cc.t.pingTimeout()
 	// We don't need to periodically ping in the health check, because the readLoop of ClientConn will
 	// trigger the healthCheck again if there is no frame received.
-	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
+	ctx, cancel := cc.contextWithTimeout(context.Background(), pingTimeout)
 	defer cancel()
 	cc.vlogf("http2: Transport sending health check")
 	err := cc.Ping(ctx)
@@ -1056,7 +1131,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
 	// Wait for all in-flight streams to complete or connection to close
 	done := make(chan struct{})
 	cancelled := false // guarded by cc.mu
-	go func() {
+	cc.goRun(func() {
 		cc.mu.Lock()
 		defer cc.mu.Unlock()
 		for {
@@ -1068,9 +1143,9 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
 			if cancelled {
 				break
 			}
-			cc.cond.Wait()
+			cc.condWait()
 		}
-	}()
+	})
 	shutdownEnterWaitStateHook()
 	select {
 	case <-done:
@@ -1080,7 +1155,7 @@ func (cc *ClientConn) Shutdown(ctx context.Context) error {
 		cc.mu.Lock()
 		// Free the goroutine above
 		cancelled = true
-		cc.cond.Broadcast()
+		cc.condBroadcast()
 		cc.mu.Unlock()
 		return ctx.Err()
 	}
@@ -1118,7 +1193,7 @@ func (cc *ClientConn) closeForError(err error) {
 	for _, cs := range cc.streams {
 		cs.abortStreamLocked(err)
 	}
-	cc.cond.Broadcast()
+	cc.condBroadcast()
 	cc.mu.Unlock()
 	cc.closeConn()
 }
@@ -1215,6 +1290,10 @@ func (cc *ClientConn) decrStreamReservationsLocked() {
 }
 
 func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
+	return cc.roundTrip(req, nil)
+}
+
+func (cc *ClientConn) roundTrip(req *http.Request, streamf func(*clientStream)) (*http.Response, error) {
 	ctx := req.Context()
 	cs := &clientStream{
 		cc:                   cc,
@@ -1229,9 +1308,23 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
 		respHeaderRecv:       make(chan struct{}),
 		donec:                make(chan struct{}),
 	}
-	go cs.doRequest(req)
+	cc.goRun(func() {
+		cs.doRequest(req)
+	})
 
 	waitDone := func() error {
+		if cc.syncHooks != nil {
+			cc.syncHooks.blockUntil(func() bool {
+				select {
+				case <-cs.donec:
+				case <-ctx.Done():
+				case <-cs.reqCancel:
+				default:
+					return false
+				}
+				return true
+			})
+		}
 		select {
 		case <-cs.donec:
 			return nil
@@ -1292,7 +1385,24 @@ func (cc *ClientConn) RoundTrip(req *http.Request) (*http.Response, error) {
 		return err
 	}
 
+	if streamf != nil {
+		streamf(cs)
+	}
+
 	for {
+		if cc.syncHooks != nil {
+			cc.syncHooks.blockUntil(func() bool {
+				select {
+				case <-cs.respHeaderRecv:
+				case <-cs.abort:
+				case <-ctx.Done():
+				case <-cs.reqCancel:
+				default:
+					return false
+				}
+				return true
+			})
+		}
 		select {
 		case <-cs.respHeaderRecv:
 			return handleResponseHeaders()
@@ -1348,6 +1458,21 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
 	if cc.reqHeaderMu == nil {
 		panic("RoundTrip on uninitialized ClientConn") // for tests
 	}
+	var newStreamHook func(*clientStream)
+	if cc.syncHooks != nil {
+		newStreamHook = cc.syncHooks.newstream
+		cc.syncHooks.blockUntil(func() bool {
+			select {
+			case cc.reqHeaderMu <- struct{}{}:
+				<-cc.reqHeaderMu
+			case <-cs.reqCancel:
+			case <-ctx.Done():
+			default:
+				return false
+			}
+			return true
+		})
+	}
 	select {
 	case cc.reqHeaderMu <- struct{}{}:
 	case <-cs.reqCancel:
@@ -1371,6 +1496,10 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
 		cc.doNotReuse = true
 	}
 	cc.mu.Unlock()
+
+	if newStreamHook != nil {
+		newStreamHook(cs)
+	}
 
 	// TODO(bradfitz): this is a copy of the logic in net/http. Unify somewhere?
 	if !cc.t.disableCompression() &&
@@ -1452,15 +1581,30 @@ func (cs *clientStream) writeRequest(req *http.Request) (err error) {
 	var respHeaderTimer <-chan time.Time
 	var respHeaderRecv chan struct{}
 	if d := cc.responseHeaderTimeout(); d != 0 {
-		timer := time.NewTimer(d)
+		timer := cc.newTimer(d)
 		defer timer.Stop()
-		respHeaderTimer = timer.C
+		respHeaderTimer = timer.C()
 		respHeaderRecv = cs.respHeaderRecv
 	}
 	// Wait until the peer half-closes its end of the stream,
 	// or until the request is aborted (via context, error, or otherwise),
 	// whichever comes first.
 	for {
+		if cc.syncHooks != nil {
+			cc.syncHooks.blockUntil(func() bool {
+				select {
+				case <-cs.peerClosed:
+				case <-respHeaderTimer:
+				case <-respHeaderRecv:
+				case <-cs.abort:
+				case <-ctx.Done():
+				case <-cs.reqCancel:
+				default:
+					return false
+				}
+				return true
+			})
+		}
 		select {
 		case <-cs.peerClosed:
 			return nil
@@ -1609,7 +1753,7 @@ func (cc *ClientConn) awaitOpenSlotForStreamLocked(cs *clientStream) error {
 			return nil
 		}
 		cc.pendingRequests++
-		cc.cond.Wait()
+		cc.condWait()
 		cc.pendingRequests--
 		select {
 		case <-cs.abort:
@@ -1871,8 +2015,24 @@ func (cs *clientStream) awaitFlowControl(maxBytes int) (taken int32, err error) 
 			cs.flow.take(take)
 			return take, nil
 		}
-		cc.cond.Wait()
+		cc.condWait()
 	}
+}
+
+func validateHeaders(hdrs http.Header) string {
+	for k, vv := range hdrs {
+		if !httpguts.ValidHeaderFieldName(k) {
+			return fmt.Sprintf("name %q", k)
+		}
+		for _, v := range vv {
+			if !httpguts.ValidHeaderFieldValue(v) {
+				// Don't include the value in the error,
+				// because it may be sensitive.
+				return fmt.Sprintf("value for header %q", k)
+			}
+		}
+	}
+	return ""
 }
 
 var errNilRequestURL = errors.New("http2: Request.URI is nil")
@@ -1912,19 +2072,14 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
 		}
 	}
 
-	// Check for any invalid headers and return an error before we
+	// Check for any invalid headers+trailers and return an error before we
 	// potentially pollute our hpack state. (We want to be able to
 	// continue to reuse the hpack encoder for future requests)
-	for k, vv := range req.Header {
-		if !httpguts.ValidHeaderFieldName(k) {
-			return nil, fmt.Errorf("invalid HTTP header name %q", k)
-		}
-		for _, v := range vv {
-			if !httpguts.ValidHeaderFieldValue(v) {
-				// Don't include the value in the error, because it may be sensitive.
-				return nil, fmt.Errorf("invalid HTTP header value for header %q", k)
-			}
-		}
+	if err := validateHeaders(req.Header); err != "" {
+		return nil, fmt.Errorf("invalid HTTP header %s", err)
+	}
+	if err := validateHeaders(req.Trailer); err != "" {
+		return nil, fmt.Errorf("invalid HTTP trailer %s", err)
 	}
 
 	enumerateHeaders := func(f func(name, value string)) {
@@ -2143,7 +2298,7 @@ func (cc *ClientConn) forgetStreamID(id uint32) {
 	}
 	// Wake up writeRequestBody via clientStream.awaitFlowControl and
 	// wake up RoundTrip if there is a pending request.
-	cc.cond.Broadcast()
+	cc.condBroadcast()
 
 	closeOnIdle := cc.singleUse || cc.doNotReuse || cc.t.disableKeepAlives() || cc.goAway != nil
 	if closeOnIdle && cc.streamsReserved == 0 && len(cc.streams) == 0 {
@@ -2231,7 +2386,7 @@ func (rl *clientConnReadLoop) cleanup() {
 			cs.abortStreamLocked(err)
 		}
 	}
-	cc.cond.Broadcast()
+	cc.condBroadcast()
 	cc.mu.Unlock()
 }
 
@@ -2266,10 +2421,9 @@ func (rl *clientConnReadLoop) run() error {
 	cc := rl.cc
 	gotSettings := false
 	readIdleTimeout := cc.t.ReadIdleTimeout
-	var t *time.Timer
+	var t timer
 	if readIdleTimeout != 0 {
-		t = time.AfterFunc(readIdleTimeout, cc.healthCheck)
-		defer t.Stop()
+		t = cc.afterFunc(readIdleTimeout, cc.healthCheck)
 	}
 	for {
 		f, err := cc.fr.ReadFrame()
@@ -2684,7 +2838,7 @@ func (rl *clientConnReadLoop) processData(f *DataFrame) error {
 		})
 		return nil
 	}
-	if !cs.firstByte {
+	if !cs.pastHeaders {
 		cc.logf("protocol error: received DATA before a HEADERS frame")
 		rl.endStreamError(cs, StreamError{
 			StreamID: f.StreamID,
@@ -2867,7 +3021,7 @@ func (rl *clientConnReadLoop) processSettingsNoWrite(f *SettingsFrame) error {
 			for _, cs := range cc.streams {
 				cs.flow.add(delta)
 			}
-			cc.cond.Broadcast()
+			cc.condBroadcast()
 
 			cc.initialWindowSize = s.Val
 		case SettingHeaderTableSize:
@@ -2922,7 +3076,7 @@ func (rl *clientConnReadLoop) processWindowUpdate(f *WindowUpdateFrame) error {
 
 		return ConnectionError(ErrCodeFlowControl)
 	}
-	cc.cond.Broadcast()
+	cc.condBroadcast()
 	return nil
 }
 
@@ -2964,24 +3118,38 @@ func (cc *ClientConn) Ping(ctx context.Context) error {
 		}
 		cc.mu.Unlock()
 	}
-	errc := make(chan error, 1)
-	go func() {
+	var pingError error
+	errc := make(chan struct{})
+	cc.goRun(func() {
 		cc.wmu.Lock()
 		defer cc.wmu.Unlock()
-		if err := cc.fr.WritePing(false, p); err != nil {
-			errc <- err
+		if pingError = cc.fr.WritePing(false, p); pingError != nil {
+			close(errc)
 			return
 		}
-		if err := cc.bw.Flush(); err != nil {
-			errc <- err
+		if pingError = cc.bw.Flush(); pingError != nil {
+			close(errc)
 			return
 		}
-	}()
+	})
+	if cc.syncHooks != nil {
+		cc.syncHooks.blockUntil(func() bool {
+			select {
+			case <-c:
+			case <-errc:
+			case <-ctx.Done():
+			case <-cc.readerDone:
+			default:
+				return false
+			}
+			return true
+		})
+	}
 	select {
 	case <-c:
 		return nil
-	case err := <-errc:
-		return err
+	case <-errc:
+		return pingError
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-cc.readerDone:
@@ -3150,9 +3318,17 @@ func (rt noDialH2RoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 }
 
 func (t *Transport) idleConnTimeout() time.Duration {
+	// to keep things backwards compatible, we use non-zero values of
+	// IdleConnTimeout, followed by using the IdleConnTimeout on the underlying
+	// http1 transport, followed by 0
+	if t.IdleConnTimeout != 0 {
+		return t.IdleConnTimeout
+	}
+
 	if t.t1 != nil {
 		return t.t1.IdleConnTimeout
 	}
+
 	return 0
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -109,8 +109,8 @@ github.com/munnerz/goautoneg
 # github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 ## explicit
 github.com/mwitkow/go-conntrack
-# github.com/netobserv/flowlogs-pipeline v0.1.12-0.20240325101510-5feb3c603334
-## explicit; go 1.21
+# github.com/netobserv/flowlogs-pipeline v0.1.12-0.20240426113456-2ab1f8dd0cc9
+## explicit; go 1.21.0
 github.com/netobserv/flowlogs-pipeline/pkg/api
 github.com/netobserv/flowlogs-pipeline/pkg/config
 github.com/netobserv/flowlogs-pipeline/pkg/utils
@@ -214,7 +214,7 @@ go.uber.org/zap/zapcore
 # golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 ## explicit; go 1.20
 golang.org/x/exp/maps
-# golang.org/x/net v0.22.0
+# golang.org/x/net v0.23.0
 ## explicit; go 1.18
 golang.org/x/net/context
 golang.org/x/net/html
@@ -227,7 +227,7 @@ golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 golang.org/x/net/internal/timeseries
 golang.org/x/net/trace
-# golang.org/x/oauth2 v0.16.0
+# golang.org/x/oauth2 v0.17.0
 ## explicit; go 1.18
 golang.org/x/oauth2
 golang.org/x/oauth2/clientcredentials


### PR DESCRIPTION
## Description

Added support to FLP dynamic configmap

## Dependencies

[FLP PR](https://github.com/netobserv/flowlogs-pipeline/pull/607)

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [X] Does this PR require a product release notes entry?
  * [X] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
