### PR TITLE
NETOBSERV-1447: Added a check to log a warning if some labels are used in metric defi…

### DIFF
--- a/apis/flowmetrics/v1alpha1/flowmetric_webhook.go
+++ b/apis/flowmetrics/v1alpha1/flowmetric_webhook.go
@@ -61,6 +61,16 @@ func (r *FlowMetricWebhook) ValidateDelete(_ context.Context, _ runtime.Object) 
 	return nil, nil
 }
 
+func checkFlowMetricCartinality(fMetric *FlowMetric) {
+	for _, label := range fMetric.Spec.Labels {
+		if helper.LabelIsHighCardinality(label) {
+			//No warning level logging as info since it is not an error
+			flowmetriclog.Info("Warning: metric label has high cardinality, please limit it by using some filters", "labelName", label)
+			return
+		}
+	}
+}
+
 func validateFlowMetric(_ context.Context, fMetric *FlowMetric) error {
 	var str []string
 	var allErrs field.ErrorList
@@ -95,5 +105,6 @@ func validateFlowMetric(_ context.Context, fMetric *FlowMetric) error {
 			schema.GroupKind{Group: GroupVersion.Group, Kind: FlowMetric{}.Kind},
 			fMetric.Name, allErrs)
 	}
+	checkFlowMetricCartinality(fMetric)
 	return nil
 }

--- a/controllers/consoleplugin/config/config.go
+++ b/controllers/consoleplugin/config/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	flowslatest "github.com/netobserv/network-observability-operator/apis/flowcollector/v1beta2"
+	"gopkg.in/yaml.v2"
 )
 
 type ServerConfig struct {
@@ -109,8 +110,17 @@ type PluginConfig struct {
 }
 
 //go:embed static-frontend-config.yaml
-var staticFrontendConfig []byte
+var rawStaticFrontendConfig []byte
+var staticFrontendConfig *FrontendConfig
 
-func LoadStaticFrontendConfig() []byte {
-	return staticFrontendConfig
+func LoadStaticFrontendConfig() (FrontendConfig, error) {
+	if staticFrontendConfig == nil {
+		cfg := FrontendConfig{}
+		err := yaml.Unmarshal(rawStaticFrontendConfig, &cfg)
+		if err != nil {
+			return cfg, err
+		}
+		staticFrontendConfig = &cfg
+	}
+	return *staticFrontendConfig, nil
 }

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -423,7 +423,8 @@ func (b *builder) configMap() (*corev1.ConfigMap, string, error) {
 	b.setLokiConfig(&config.Loki)
 
 	// configure frontend from embedded static file
-	err := yaml.Unmarshal(cfg.LoadStaticFrontendConfig(), &config.Frontend)
+	var err error
+	config.Frontend, err = cfg.LoadStaticFrontendConfig()
 	if err != nil {
 		return nil, "", err
 	}

--- a/controllers/consoleplugin/consoleplugin_test.go
+++ b/controllers/consoleplugin/consoleplugin_test.go
@@ -505,8 +505,7 @@ func TestHTTPClientConfig(t *testing.T) {
 }
 
 func TestNoMissingFields(t *testing.T) {
-	var cfg config.FrontendConfig
-	err := yaml.Unmarshal(config.LoadStaticFrontendConfig(), &cfg)
+	cfg, err := config.LoadStaticFrontendConfig()
 	assert.NoError(t, err)
 
 	hasField := func(name string) bool {
@@ -537,8 +536,7 @@ func TestNoMissingFields(t *testing.T) {
 }
 
 func TestFieldsCardinalityWarns(t *testing.T) {
-	var cfg config.FrontendConfig
-	err := yaml.Unmarshal(config.LoadStaticFrontendConfig(), &cfg)
+	cfg, err := config.LoadStaticFrontendConfig()
 	assert.NoError(t, err)
 
 	allowed := []config.CardinalityWarn{config.CardinalityWarnAvoid, config.CardinalityWarnCareful, config.CardinalityWarnFine}

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/netobserv/network-observability-operator/controllers/consoleplugin/config"
 
-	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -93,13 +92,12 @@ func UnstructuredDuration(in *metav1.Duration) string {
 }
 
 func FindFilter(labels []string, isNumber bool) bool {
-	var cfg config.FrontendConfig
 	type filter struct {
 		exists bool
 		isNum  bool
 	}
 
-	err := yaml.Unmarshal(config.LoadStaticFrontendConfig(), &cfg)
+	cfg, err := config.LoadStaticFrontendConfig()
 	if err != nil {
 		return false
 	}
@@ -123,4 +121,18 @@ func FindFilter(labels []string, isNumber bool) bool {
 	}
 
 	return true
+}
+
+func LabelIsHighCardinality(label string) bool {
+	frontendCfg, err := config.LoadStaticFrontendConfig()
+	if err != nil {
+		return false
+	}
+	for _, cfgLabel := range frontendCfg.Fields {
+		if label == cfgLabel.Name {
+			return cfgLabel.CardinalityWarn == config.CardinalityWarnCareful ||
+				cfgLabel.CardinalityWarn == config.CardinalityWarnAvoid
+		}
+	}
+	return false
 }

--- a/pkg/helper/helpers_test.go
+++ b/pkg/helper/helpers_test.go
@@ -156,3 +156,10 @@ func TestCRDDefault(t *testing.T) {
 	assert.Equal(t, "app: netobserv-flowcollector\n", GetFieldDefaultString([]string{"spec", "processor", "debug"}, "lokiStaticLabels"))
 
 }
+
+func TestLabelCardinality(t *testing.T) {
+	assert.True(t, LabelIsHighCardinality("SrcK8S_Name"))
+	assert.True(t, LabelIsHighCardinality("DstK8S_Name"))
+	assert.True(t, LabelIsHighCardinality("TimeReceived"))
+	assert.False(t, LabelIsHighCardinality("SrcK8S_OwnerName"))
+}


### PR DESCRIPTION
## Description

Added a check to log a warning if some labels are used in metric definition

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [X] Does this PR require a product release notes entry?
  * [X] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
