### PR TITLE
NETOBSERV-1626: add configmaps to service account

### DIFF
--- a/controllers/flp/flp_transfo_objects.go
+++ b/controllers/flp/flp_transfo_objects.go
@@ -86,7 +86,7 @@ func (b *transfoBuilder) autoScaler() *ascv2.HorizontalPodAutoscaler {
 // The operator needs to have at least the same permissions as flowlogs-pipeline in order to grant them
 //+kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=create;delete;patch;update;get;watch;list
-//+kubebuilder:rbac:groups=core,resources=pods;services;nodes,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=pods;services;nodes;configmaps,verbs=get;list;watch
 
 func BuildClusterRoleTransformer() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
@@ -96,7 +96,7 @@ func BuildClusterRoleTransformer() *rbacv1.ClusterRole {
 		Rules: []rbacv1.PolicyRule{{
 			APIGroups: []string{""},
 			Verbs:     []string{"list", "get", "watch"},
-			Resources: []string{"pods", "services", "nodes"},
+			Resources: []string{"pods", "services", "nodes", "configmaps"},
 		}, {
 			APIGroups: []string{"apps"},
 			Verbs:     []string{"list", "get", "watch"},


### PR DESCRIPTION
## Description

```shell
time=2024-04-30T15:31:14Z level=error msg=Cannot get dynamic config: configmaps "flowlogs-pipeline-transformer-config-dynamic" is forbidden: User "system:serviceaccount:netobserv:flowlogs-pipeline-transformer" cannot get resource "configmaps" in API group "" in the namespace "netobserv"
```

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
