### PR TITLE
NETOBSERV-1632: metrics API, allow empty unit

### DIFF
--- a/apis/flowmetrics/v1alpha1/flowmetric_types.go
+++ b/apis/flowmetrics/v1alpha1/flowmetric_types.go
@@ -144,7 +144,7 @@ type Chart struct {
 	Title string `json:"title"`
 
 	// Unit of this chart. Only a few units are currently supported. Leave empty to use generic number.
-	// +kubebuilder:validation:Enum:="bytes";"seconds";"Bps";"pps";"percent"
+	// +kubebuilder:validation:Enum:="bytes";"seconds";"Bps";"pps";"percent";""
 	// +optional
 	Unit Unit `json:"unit,omitempty"`
 

--- a/bundle/manifests/flows.netobserv.io_flowmetrics.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowmetrics.yaml
@@ -130,6 +130,7 @@ spec:
                       - Bps
                       - pps
                       - percent
+                      - ""
                       type: string
                   required:
                   - dashboardName

--- a/config/crd/bases/flows.netobserv.io_flowmetrics.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowmetrics.yaml
@@ -120,6 +120,7 @@ spec:
                       - Bps
                       - pps
                       - percent
+                      - ""
                       type: string
                   required:
                   - dashboardName

--- a/docs/FlowMetric.md
+++ b/docs/FlowMetric.md
@@ -239,7 +239,7 @@ If `sectionName` is omitted or empty, the chart is placed in the global top sect
         <td>
           Unit of this chart. Only a few units are currently supported. Leave empty to use generic number.<br/>
           <br/>
-            <i>Enum</i>: bytes, seconds, Bps, pps, percent<br/>
+            <i>Enum</i>: bytes, seconds, Bps, pps, percent, <br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
