### PR TITLE
enable ebpf metrics by default while keep the knob in case we need to disable

### DIFF
--- a/apis/flowcollector/v1beta1/flowcollector_types.go
+++ b/apis/flowcollector/v1beta1/flowcollector_types.go
@@ -173,7 +173,8 @@ type EBPFMetrics struct {
 	// +optional
 	Server MetricsServerConfig `json:"server,omitempty"`
 
-	// Set `enable` to `true` to enable eBPF agent metrics collection.
+	// Set `enable` to `false` to disable eBPF agent metrics collection, by default it's `true`.
+	// +optional
 	Enable *bool `json:"enable,omitempty"`
 
 	// `disableAlerts` is a list of alerts that should be disabled.

--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -180,7 +180,8 @@ type EBPFMetrics struct {
 	// +optional
 	Server MetricsServerConfig `json:"server,omitempty"`
 
-	// Set `enable` to `true` to enable eBPF agent metrics collection.
+	// Set `enable` to `false` to disable eBPF agent metrics collection, by default it's `true`.
+	// +optional
 	Enable *bool `json:"enable,omitempty"`
 
 	// `disableAlerts` is a list of alerts that should be disabled.

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -280,8 +280,8 @@ spec:
                               type: string
                             type: array
                           enable:
-                            description: Set `enable` to `true` to enable eBPF agent
-                              metrics collection.
+                            description: Set `enable` to `false` to disable eBPF agent
+                              metrics collection, by default it's `true`.
                             type: boolean
                           server:
                             description: Metrics server endpoint configuration for
@@ -3666,8 +3666,8 @@ spec:
                               type: string
                             type: array
                           enable:
-                            description: Set `enable` to `true` to enable eBPF agent
-                              metrics collection.
+                            description: Set `enable` to `false` to disable eBPF agent
+                              metrics collection, by default it's `true`.
                             type: boolean
                           server:
                             description: Metrics server endpoint configuration for

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -264,7 +264,6 @@ metadata:
                 "kafkaBatchSize": 1048576,
                 "logLevel": "info",
                 "metrics": {
-                  "enable": false,
                   "server": {
                     "port": 9400
                   }

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -252,7 +252,7 @@ spec:
                                 type: string
                               type: array
                             enable:
-                              description: Set `enable` to `true` to enable eBPF agent metrics collection.
+                              description: Set `enable` to `false` to disable eBPF agent metrics collection, by default it's `true`.
                               type: boolean
                             server:
                               description: Metrics server endpoint configuration for Prometheus scraper
@@ -3378,7 +3378,7 @@ spec:
                                 type: string
                               type: array
                             enable:
-                              description: Set `enable` to `true` to enable eBPF agent metrics collection.
+                              description: Set `enable` to `false` to disable eBPF agent metrics collection, by default it's `true`.
                               type: boolean
                             server:
                               description: Metrics server endpoint configuration for Prometheus scraper

--- a/config/samples/flows_v1beta2_flowcollector.yaml
+++ b/config/samples/flows_v1beta2_flowcollector.yaml
@@ -29,7 +29,6 @@ spec:
       #  sourcePorts: 53
       #  enable: true
       metrics:
-        enable: false
         server:
           port: 9400
       # Custom optionnal resources configuration

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -546,7 +546,7 @@ Possible values are:<br>
         <td><b>enable</b></td>
         <td>boolean</td>
         <td>
-          Set `enable` to `true` to enable eBPF agent metrics collection.<br/>
+          Set `enable` to `false` to disable eBPF agent metrics collection, by default it's `true`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7627,7 +7627,7 @@ Possible values are:<br>
         <td><b>enable</b></td>
         <td>boolean</td>
         <td>
-          Set `enable` to `true` to enable eBPF agent metrics collection.<br/>
+          Set `enable` to `false` to disable eBPF agent metrics collection, by default it's `true`.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/helper/flowcollector.go
+++ b/pkg/helper/flowcollector.go
@@ -112,7 +112,7 @@ func IsZoneEnabled(spec *flowslatest.FlowCollectorFLP) bool {
 }
 
 func IsEBPFMetricsEnabled(spec *flowslatest.FlowCollectorEBPF) bool {
-	return spec.Metrics.Enable != nil && *spec.Metrics.Enable
+	return spec.Metrics.Enable == nil || *spec.Metrics.Enable
 }
 
 func IsSubnetLabelsEnabled(spec *flowslatest.FlowCollectorFLP) bool {


### PR DESCRIPTION

## Description
enable ebpf metrics by default while still keeping the config in case we need to disable it

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
