### PR TITLE
NETOBSERV-1647: do not get Loki certificates when Loki is disabled

### DIFF
--- a/controllers/flp/flp_controller.go
+++ b/controllers/flp/flp_controller.go
@@ -253,17 +253,19 @@ func reconcileMonitoringCerts(ctx context.Context, info *reconcilers.Common, tls
 }
 
 func reconcileLokiRoles(ctx context.Context, r *reconcilers.Common, b *builder) error {
-	roles := loki.ClusterRoles(b.desired.Loki.Mode)
-	if len(roles) > 0 {
-		for i := range roles {
-			if err := r.ReconcileClusterRole(ctx, &roles[i]); err != nil {
+	if helper.UseLoki(b.desired) {
+		roles := loki.ClusterRoles(b.desired.Loki.Mode)
+		if len(roles) > 0 {
+			for i := range roles {
+				if err := r.ReconcileClusterRole(ctx, &roles[i]); err != nil {
+					return err
+				}
+			}
+			// Binding
+			crb := loki.ClusterRoleBinding(b.name(), b.name(), b.info.Namespace)
+			if err := r.ReconcileClusterRoleBinding(ctx, crb); err != nil {
 				return err
 			}
-		}
-		// Binding
-		crb := loki.ClusterRoleBinding(b.name(), b.name(), b.info.Namespace)
-		if err := r.ReconcileClusterRoleBinding(ctx, crb); err != nil {
-			return err
 		}
 	}
 	return nil

--- a/controllers/flp/flp_monolith_reconciler.go
+++ b/controllers/flp/flp_monolith_reconciler.go
@@ -115,10 +115,12 @@ func (r *monolithReconciler) reconcile(ctx context.Context, desired *flowslatest
 		return err
 	}
 
-	// Watch for Loki certificate if necessary; we'll ignore in that case the returned digest, as we don't need to restart pods on cert rotation
-	// because certificate is always reloaded from file
-	if _, err = r.Watcher.ProcessCACert(ctx, r.Client, &r.Loki.TLS, r.Namespace); err != nil {
-		return err
+	if helper.UseLoki(&desired.Spec) {
+		// Watch for Loki certificate if necessary; we'll ignore in that case the returned digest, as we don't need to restart pods on cert rotation
+		// because certificate is always reloaded from file
+		if _, err = r.Watcher.ProcessCACert(ctx, r.Client, &r.Loki.TLS, r.Namespace); err != nil {
+			return err
+		}
 	}
 
 	// Watch for Kafka exporter certificate if necessary; need to restart pods in case of cert rotation

--- a/controllers/flp/flp_transfo_reconciler.go
+++ b/controllers/flp/flp_transfo_reconciler.go
@@ -116,10 +116,12 @@ func (r *transformerReconciler) reconcile(ctx context.Context, desired *flowslat
 		return err
 	}
 
-	// Watch for Loki certificate if necessary; we'll ignore in that case the returned digest, as we don't need to restart pods on cert rotation
-	// because certificate is always reloaded from file
-	if _, err = r.Watcher.ProcessCACert(ctx, r.Client, &r.Loki.TLS, r.Namespace); err != nil {
-		return err
+	if helper.UseLoki(&desired.Spec) {
+		// Watch for Loki certificate if necessary; we'll ignore in that case the returned digest, as we don't need to restart pods on cert rotation
+		// because certificate is always reloaded from file
+		if _, err = r.Watcher.ProcessCACert(ctx, r.Client, &r.Loki.TLS, r.Namespace); err != nil {
+			return err
+		}
 	}
 
 	// Watch for Kafka certificate if necessary; need to restart pods in case of cert rotation


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
