### PR TITLE
NETOBSERV-1665: use v1 for conversionReviewVersions

### DIFF
--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -15,8 +15,7 @@ spec:
           namespace: netobserv
           path: /convert
       conversionReviewVersions:
-      - v1beta1
-      - v1beta2
+      - v1
   group: flows.netobserv.io
   names:
     kind: FlowCollector

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -1335,8 +1335,7 @@ spec:
   version: 1.6.0-community
   webhookdefinitions:
   - admissionReviewVersions:
-    - v1beta1
-    - v1beta2
+    - v1
     containerPort: 443
     conversionCRDs:
     - flowcollectors.flows.netobserv.io

--- a/config/crd/patches/webhook_in_flowcollectors.yaml
+++ b/config/crd/patches/webhook_in_flowcollectors.yaml
@@ -13,5 +13,4 @@ spec:
           name: webhook-service
           path: /convert
       conversionReviewVersions:
-      - v1beta1
-      - v1beta2
+      - v1


### PR DESCRIPTION
Note we're talking here about versions of ConversionReview (ie. apiextension), NOT versions of our CRDs

- Use same versions for flowcollector and flowmetrics
- Use just v1 as the only other (v1beta1) was dropped a while ago (kube 1.22 / 2021)
