### PR TITLE
NETOBSERV-1642: Ovs monitoring feature

### DIFF
--- a/apis/flowcollector/v1beta1/flowcollector_types.go
+++ b/apis/flowcollector/v1beta1/flowcollector_types.go
@@ -150,14 +150,16 @@ type FlowCollectorIPFIX struct {
 // Agent feature, can be one of:<br>
 // - `PacketDrop`, to track packet drops.<br>
 // - `DNSTracking`, to track specific information on DNS traffic.<br>
-// - `FlowRTT`, to track TCP latency. [Unsupported (*)].<br>
-// +kubebuilder:validation:Enum:="PacketDrop";"DNSTracking";"FlowRTT"
+// - `FlowRTT`, to track TCP latency [Unsupported (*)].<br>
+// - `NetworkEvents`, to track Network events.<br>
+// +kubebuilder:validation:Enum:="PacketDrop";"DNSTracking";"FlowRTT";"NetworkEvents"
 type AgentFeature string
 
 const (
-	PacketDrop  AgentFeature = "PacketDrop"
-	DNSTracking AgentFeature = "DNSTracking"
-	FlowRTT     AgentFeature = "FlowRTT"
+	PacketDrop    AgentFeature = "PacketDrop"
+	DNSTracking   AgentFeature = "DNSTracking"
+	FlowRTT       AgentFeature = "FlowRTT"
+	NetworkEvents AgentFeature = "NetworkEvents"
 )
 
 // Name of an eBPF agent alert.
@@ -325,6 +327,8 @@ type FlowCollectorEBPF struct {
 	// If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported.<br>
 	// - `DNSTracking`: enable the DNS tracking feature.<br>
 	// - `FlowRTT`: enable flow latency (sRTT) extraction in the eBPF agent from TCP traffic.<br>
+	// - `NetworkEvents`: enable the Network events monitoring feature. This feature requires mounting
+	// the kernel debug filesystem, so the eBPF pod has to run as privileged.
 	// +optional
 	Features []AgentFeature `json:"features,omitempty"`
 

--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -175,13 +175,15 @@ type FlowCollectorIPFIX struct {
 // - `PacketDrop`, to track packet drops.<br>
 // - `DNSTracking`, to track specific information on DNS traffic.<br>
 // - `FlowRTT`, to track TCP latency.<br>
-// +kubebuilder:validation:Enum:="PacketDrop";"DNSTracking";"FlowRTT"
+// - `NetworkEvents`, to track Network events.<br>
+// +kubebuilder:validation:Enum:="PacketDrop";"DNSTracking";"FlowRTT";"NetworkEvents"
 type AgentFeature string
 
 const (
-	PacketDrop  AgentFeature = "PacketDrop"
-	DNSTracking AgentFeature = "DNSTracking"
-	FlowRTT     AgentFeature = "FlowRTT"
+	PacketDrop    AgentFeature = "PacketDrop"
+	DNSTracking   AgentFeature = "DNSTracking"
+	FlowRTT       AgentFeature = "FlowRTT"
+	NetworkEvents AgentFeature = "NetworkEvents"
 )
 
 // Name of an eBPF agent alert.
@@ -349,6 +351,8 @@ type FlowCollectorEBPF struct {
 	// If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported.<br>
 	// - `DNSTracking`: enable the DNS tracking feature.<br>
 	// - `FlowRTT`: enable flow latency (sRTT) extraction in the eBPF agent from TCP traffic.<br>
+	// - `NetworkEvents`: enable the Network events monitoring feature.  This feature requires mounting
+	// the kernel debug filesystem, so the eBPF pod has to run as privileged.
 	// +optional
 	Features []AgentFeature `json:"features,omitempty"`
 

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -133,16 +133,20 @@ spec:
                           If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported.<br>
                           - `DNSTracking`: enable the DNS tracking feature.<br>
                           - `FlowRTT`: enable flow latency (sRTT) extraction in the eBPF agent from TCP traffic.<br>
+                          - `NetworkEvents`: enable the Network events monitoring feature. This feature requires mounting
+                          the kernel debug filesystem, so the eBPF pod has to run as privileged.
                         items:
                           description: |-
                             Agent feature, can be one of:<br>
                             - `PacketDrop`, to track packet drops.<br>
                             - `DNSTracking`, to track specific information on DNS traffic.<br>
-                            - `FlowRTT`, to track TCP latency. [Unsupported (*)].<br>
+                            - `FlowRTT`, to track TCP latency [Unsupported (*)].<br>
+                            - `NetworkEvents`, to track Network events.<br>
                           enum:
                           - PacketDrop
                           - DNSTracking
                           - FlowRTT
+                          - NetworkEvents
                           type: string
                         type: array
                       flowFilter:
@@ -3710,16 +3714,20 @@ spec:
                           If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported.<br>
                           - `DNSTracking`: enable the DNS tracking feature.<br>
                           - `FlowRTT`: enable flow latency (sRTT) extraction in the eBPF agent from TCP traffic.<br>
+                          - `NetworkEvents`: enable the Network events monitoring feature.  This feature requires mounting
+                          the kernel debug filesystem, so the eBPF pod has to run as privileged.
                         items:
                           description: |-
                             Agent feature, can be one of:<br>
                             - `PacketDrop`, to track packet drops.<br>
                             - `DNSTracking`, to track specific information on DNS traffic.<br>
                             - `FlowRTT`, to track TCP latency.<br>
+                            - `NetworkEvents`, to track Network events.<br>
                           enum:
                           - PacketDrop
                           - DNSTracking
                           - FlowRTT
+                          - NetworkEvents
                           type: string
                         type: array
                       flowFilter:

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -118,16 +118,20 @@ spec:
                             If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported.<br>
                             - `DNSTracking`: enable the DNS tracking feature.<br>
                             - `FlowRTT`: enable flow latency (sRTT) extraction in the eBPF agent from TCP traffic.<br>
+                            - `NetworkEvents`: enable the Network events monitoring feature. This feature requires mounting
+                            the kernel debug filesystem, so the eBPF pod has to run as privileged.
                           items:
                             description: |-
                               Agent feature, can be one of:<br>
                               - `PacketDrop`, to track packet drops.<br>
                               - `DNSTracking`, to track specific information on DNS traffic.<br>
-                              - `FlowRTT`, to track TCP latency. [Unsupported (*)].<br>
+                              - `FlowRTT`, to track TCP latency [Unsupported (*)].<br>
+                              - `NetworkEvents`, to track Network events.<br>
                             enum:
                               - PacketDrop
                               - DNSTracking
                               - FlowRTT
+                              - NetworkEvents
                             type: string
                           type: array
                         flowFilter:
@@ -3416,16 +3420,20 @@ spec:
                             If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported.<br>
                             - `DNSTracking`: enable the DNS tracking feature.<br>
                             - `FlowRTT`: enable flow latency (sRTT) extraction in the eBPF agent from TCP traffic.<br>
+                            - `NetworkEvents`: enable the Network events monitoring feature.  This feature requires mounting
+                            the kernel debug filesystem, so the eBPF pod has to run as privileged.
                           items:
                             description: |-
                               Agent feature, can be one of:<br>
                               - `PacketDrop`, to track packet drops.<br>
                               - `DNSTracking`, to track specific information on DNS traffic.<br>
                               - `FlowRTT`, to track TCP latency.<br>
+                              - `NetworkEvents`, to track Network events.<br>
                             enum:
                               - PacketDrop
                               - DNSTracking
                               - FlowRTT
+                              - NetworkEvents
                             type: string
                           type: array
                         flowFilter:

--- a/config/samples/flows_v1beta2_flowcollector.yaml
+++ b/config/samples/flows_v1beta2_flowcollector.yaml
@@ -22,6 +22,7 @@ spec:
       # - "PacketDrop"
       # - "DNSTracking"
       # - "FlowRTT"
+      # - "NetworkEvents"
       interfaces: []
       excludeInterfaces: ["lo"]
       kafkaBatchSize: 1048576

--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -517,6 +517,14 @@ columns:
     default: true
     width: 5
     feature: flowRTT
+  - id: NetworkEvents
+    name: Network Events
+    tooltip: Network events flow monitor
+    field: NetworkEvents
+    filter: network_events
+    default: true
+    width: 15
+    feature: networkEvents
 filters:
   - id: cluster_name
     name: Cluster
@@ -892,7 +900,10 @@ filters:
     name: Flow RTT
     component: number
     hint: Specify a TCP smoothed Round Trip Time in nanoseconds.
-
+  - id: network_events
+    name: Network events flow monitoring
+    component: text
+    hint: Specify a single network event.
 # Fields definition, used to generate documentation
 # The "cardinalityWarn" property relates to how the field is suitable for usage as a metric label wrt cardinality; it may have 3 values: fine, careful, avoid
 fields:
@@ -1118,6 +1129,10 @@ fields:
   - name: TimeFlowRttNs
     type: number
     description: TCP Smoothed Round Trip Time (SRTT), in nanoseconds
+    cardinalityWarn: avoid
+  - name: NetworkEvents
+    type: string
+    description: Network events flow monitoring
     cardinalityWarn: avoid
   - name: K8S_ClusterName
     type: string

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -449,6 +449,10 @@ func (b *builder) setFrontendConfig(fconf *cfg.FrontendConfig) error {
 		fconf.Features = append(fconf.Features, "flowRTT")
 	}
 
+	if helper.IsNetworkEventsEnabled(&b.desired.Agent.EBPF) {
+		fconf.Features = append(fconf.Features, "networkEvents")
+	}
+
 	if b.desired.Agent.EBPF.Advanced != nil {
 		if v, ok := b.desired.Agent.EBPF.Advanced.Env[ebpf.EnvDedupeJustMark]; ok {
 			dedupJustMark, err = strconv.ParseBool(v)

--- a/controllers/flp/flp_pipeline_builder.go
+++ b/controllers/flp/flp_pipeline_builder.go
@@ -369,6 +369,16 @@ func (b *PipelineBuilder) addConnectionTracking(lastStage config.PipelineBuilder
 		outputFields = append(outputFields, outDNSTrackingFields...)
 	}
 
+	if helper.IsNetworkEventsEnabled(&b.desired.Agent.EBPF) {
+		outNetworkEventsFlowFields := []api.OutputField{
+			{
+				Name:      "NetworkEvents",
+				Operation: "last",
+			},
+		}
+		outputFields = append(outputFields, outNetworkEventsFlowFields...)
+	}
+
 	if helper.IsFlowRTTEnabled(&b.desired.Agent.EBPF) {
 		outputFields = append(outputFields, api.OutputField{
 			Name:      "MaxTimeFlowRttNs",

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -289,7 +289,9 @@ Otherwise it is matched as a case-sensitive string.<br/>
 the kernel debug filesystem, so the eBPF pod has to run as privileged.
 If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported.<br>
 - `DNSTracking`: enable the DNS tracking feature.<br>
-- `FlowRTT`: enable flow latency (sRTT) extraction in the eBPF agent from TCP traffic.<br><br/>
+- `FlowRTT`: enable flow latency (sRTT) extraction in the eBPF agent from TCP traffic.<br>
+- `NetworkEvents`: enable the Network events monitoring feature. This feature requires mounting
+the kernel debug filesystem, so the eBPF pod has to run as privileged.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -5944,7 +5946,9 @@ Otherwise it is matched as a case-sensitive string.<br/>
 the kernel debug filesystem, so the eBPF pod has to run as privileged.
 If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported.<br>
 - `DNSTracking`: enable the DNS tracking feature.<br>
-- `FlowRTT`: enable flow latency (sRTT) extraction in the eBPF agent from TCP traffic.<br><br/>
+- `FlowRTT`: enable flow latency (sRTT) extraction in the eBPF agent from TCP traffic.<br>
+- `NetworkEvents`: enable the Network events monitoring feature.  This feature requires mounting
+the kernel debug filesystem, so the eBPF pod has to run as privileged.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/helper/flowcollector.go
+++ b/pkg/helper/flowcollector.go
@@ -119,6 +119,10 @@ func IsFlowRTTEnabled(spec *flowslatest.FlowCollectorEBPF) bool {
 	return IsAgentFeatureEnabled(spec, flowslatest.FlowRTT)
 }
 
+func IsNetworkEventsEnabled(spec *flowslatest.FlowCollectorEBPF) bool {
+	return IsAgentFeatureEnabled(spec, flowslatest.NetworkEvents)
+}
+
 func IsMultiClusterEnabled(spec *flowslatest.FlowCollectorFLP) bool {
 	return spec.MultiClusterDeployment != nil && *spec.MultiClusterDeployment
 }


### PR DESCRIPTION
## Description

changes to support ovs monitoring config and console bits

FC config to enable ovs monitoring fearure
```yaml
agent:
    type: eBPF
    ebpf:   
      privileged: true
      features:
       - "OvsMonitor"

```
## Dependencies

https://github.com/netobserv/netobserv-ebpf-agent/pull/286

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
