### PR TITLE
NETOBSERV-1672: add cluster & zone to predefined metrics

### DIFF
--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -409,7 +409,7 @@ func (b *builder) getPromConfig(ctx context.Context) cfg.PrometheusConfig {
 
 	allMetricNames := metrics.GetAllNames()
 	includeList := metrics.GetIncludeList(b.desired)
-	allMetrics := metrics.GetDefinitions(allMetricNames)
+	allMetrics := metrics.GetDefinitions(allMetricNames, nil)
 	for i := range allMetrics {
 		mSpec := allMetrics[i].Spec
 		enabled := slices.Contains(includeList, mSpec.MetricName)

--- a/pkg/dashboards/dashboard_test.go
+++ b/pkg/dashboards/dashboard_test.go
@@ -12,7 +12,7 @@ import (
 func TestCreateFlowMetricsDashboard_All(t *testing.T) {
 	assert := assert.New(t)
 
-	defs := metrics.GetDefinitions(metrics.GetAllNames())
+	defs := metrics.GetDefinitions(metrics.GetAllNames(), nil)
 	js := CreateFlowMetricsDashboards(defs)
 
 	d, err := FromBytes([]byte(js["Main"]))
@@ -87,7 +87,7 @@ func TestCreateFlowMetricsDashboard_All(t *testing.T) {
 func TestCreateFlowMetricsDashboard_OnlyNodeIngressBytes(t *testing.T) {
 	assert := assert.New(t)
 
-	defs := metrics.GetDefinitions([]string{"node_ingress_bytes_total"})
+	defs := metrics.GetDefinitions([]string{"node_ingress_bytes_total"}, nil)
 	js := CreateFlowMetricsDashboards(defs)
 
 	d, err := FromBytes([]byte(js["Main"]))
@@ -106,7 +106,7 @@ func TestCreateFlowMetricsDashboard_OnlyNodeIngressBytes(t *testing.T) {
 func TestCreateFlowMetricsDashboard_DefaultList(t *testing.T) {
 	assert := assert.New(t)
 
-	defs := metrics.GetDefinitions(metrics.DefaultIncludeList)
+	defs := metrics.GetDefinitions(metrics.DefaultIncludeList, nil)
 	js := CreateFlowMetricsDashboards(defs)
 
 	d, err := FromBytes([]byte(js["Main"]))

--- a/pkg/metrics/predefined_metrics.go
+++ b/pkg/metrics/predefined_metrics.go
@@ -24,9 +24,9 @@ const (
 var (
 	latencyBuckets = []string{".005", ".01", ".02", ".03", ".04", ".05", ".075", ".1", ".25", "1"}
 	mapLabels      = map[string][]string{
-		tagNodes:      {"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_HostName", "DstK8S_HostName"},
-		tagNamespaces: {"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel"},
-		tagWorkloads:  {"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel", "SrcK8S_OwnerName", "DstK8S_OwnerName", "SrcK8S_OwnerType", "DstK8S_OwnerType", "SrcK8S_Type", "DstK8S_Type"},
+		tagNodes:      {"K8S_ClusterName", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_HostName", "DstK8S_HostName"},
+		tagNamespaces: {"K8S_ClusterName", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel"},
+		tagWorkloads:  {"K8S_ClusterName", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel", "SrcK8S_OwnerName", "DstK8S_OwnerName", "SrcK8S_OwnerType", "DstK8S_OwnerType", "SrcK8S_Type", "DstK8S_Type"},
 	}
 	mapValueFields = map[string]string{
 		tagBytes:   "Bytes",
@@ -265,7 +265,7 @@ func MergePredefined(fm []metricslatest.FlowMetric, fc *flowslatest.FlowCollecto
 		toRemove = append(toRemove, "SrcK8S_Zone", "DstK8S_Zone")
 	}
 	if !helper.IsMultiClusterEnabled(&fc.Processor) {
-		toRemove = append(toRemove, "K8S_Clustername")
+		toRemove = append(toRemove, "K8S_ClusterName")
 	}
 	predefined := GetDefinitions(names, toRemove)
 	return append(predefined, fm...)

--- a/pkg/metrics/predefined_metrics.go
+++ b/pkg/metrics/predefined_metrics.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	flowslatest "github.com/netobserv/network-observability-operator/apis/flowcollector/v1beta2"
@@ -23,9 +24,9 @@ const (
 var (
 	latencyBuckets = []string{".005", ".01", ".02", ".03", ".04", ".05", ".075", ".1", ".25", "1"}
 	mapLabels      = map[string][]string{
-		tagNodes:      {"SrcK8S_HostName", "DstK8S_HostName"},
-		tagNamespaces: {"SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel"},
-		tagWorkloads:  {"SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel", "SrcK8S_OwnerName", "DstK8S_OwnerName", "SrcK8S_OwnerType", "DstK8S_OwnerType", "SrcK8S_Type", "DstK8S_Type"},
+		tagNodes:      {"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_HostName", "DstK8S_HostName"},
+		tagNamespaces: {"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel"},
+		tagWorkloads:  {"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel", "SrcK8S_OwnerName", "DstK8S_OwnerName", "SrcK8S_OwnerType", "DstK8S_OwnerType", "SrcK8S_Type", "DstK8S_Type"},
 	}
 	mapValueFields = map[string]string{
 		tagBytes:   "Bytes",
@@ -197,16 +198,28 @@ func GetAllNames() []string {
 	return names
 }
 
-func GetDefinitions(names []string) []metricslatest.FlowMetric {
+func GetDefinitions(names []string, toRemove []string) []metricslatest.FlowMetric {
 	ret := []metricslatest.FlowMetric{}
 	for i := range predefinedMetrics {
 		for _, name := range names {
 			if predefinedMetrics[i].MetricName == name {
-				ret = append(ret, metricslatest.FlowMetric{Spec: predefinedMetrics[i].FlowMetricSpec})
+				spec := predefinedMetrics[i].FlowMetricSpec
+				spec.Labels = removeLabels(spec.Labels, toRemove)
+				ret = append(ret, metricslatest.FlowMetric{Spec: spec})
 			}
 		}
 	}
 	return ret
+}
+
+func removeLabels(initial []string, toRemove []string) []string {
+	var labels []string
+	for _, lbl := range initial {
+		if !slices.Contains(toRemove, lbl) {
+			labels = append(labels, lbl)
+		}
+	}
+	return labels
 }
 
 func GetIncludeList(spec *flowslatest.FlowCollectorSpec) []string {
@@ -247,6 +260,13 @@ func removeMetricsByPattern(list []string, search string) []string {
 
 func MergePredefined(fm []metricslatest.FlowMetric, fc *flowslatest.FlowCollectorSpec) []metricslatest.FlowMetric {
 	names := GetIncludeList(fc)
-	predefined := GetDefinitions(names)
+	var toRemove []string
+	if !helper.IsZoneEnabled(&fc.Processor) {
+		toRemove = append(toRemove, "SrcK8S_Zone", "DstK8S_Zone")
+	}
+	if !helper.IsMultiClusterEnabled(&fc.Processor) {
+		toRemove = append(toRemove, "K8S_Clustername")
+	}
+	predefined := GetDefinitions(names, toRemove)
 	return append(predefined, fm...)
 }

--- a/pkg/metrics/predefined_metrics_test.go
+++ b/pkg/metrics/predefined_metrics_test.go
@@ -43,7 +43,23 @@ func TestIncludeExclude(t *testing.T) {
 func TestGetDefinitions(t *testing.T) {
 	assert := assert.New(t)
 
-	res := GetDefinitions([]string{"namespace_flows_total", "node_ingress_bytes_total", "workload_egress_packets_total"})
+	res := GetDefinitions([]string{"namespace_flows_total", "node_ingress_bytes_total", "workload_egress_packets_total"}, nil)
+	assert.Len(res, 3)
+	assert.Equal("node_ingress_bytes_total", res[0].Spec.MetricName)
+	assert.Equal("Bytes", res[0].Spec.ValueField)
+	assert.Equal([]string{"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_HostName", "DstK8S_HostName"}, res[0].Spec.Labels)
+	assert.Equal("namespace_flows_total", res[1].Spec.MetricName)
+	assert.Empty(res[1].Spec.ValueField)
+	assert.Equal([]string{"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel"}, res[1].Spec.Labels)
+	assert.Equal("workload_egress_packets_total", res[2].Spec.MetricName)
+	assert.Equal("Packets", res[2].Spec.ValueField)
+	assert.Equal([]string{"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel", "SrcK8S_OwnerName", "DstK8S_OwnerName", "SrcK8S_OwnerType", "DstK8S_OwnerType", "SrcK8S_Type", "DstK8S_Type"}, res[2].Spec.Labels)
+}
+
+func TestGetDefinitionsRemoveZoneCluster(t *testing.T) {
+	assert := assert.New(t)
+
+	res := GetDefinitions([]string{"namespace_flows_total", "node_ingress_bytes_total", "workload_egress_packets_total"}, []string{"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone"})
 	assert.Len(res, 3)
 	assert.Equal("node_ingress_bytes_total", res[0].Spec.MetricName)
 	assert.Equal("Bytes", res[0].Spec.ValueField)

--- a/pkg/metrics/predefined_metrics_test.go
+++ b/pkg/metrics/predefined_metrics_test.go
@@ -47,19 +47,19 @@ func TestGetDefinitions(t *testing.T) {
 	assert.Len(res, 3)
 	assert.Equal("node_ingress_bytes_total", res[0].Spec.MetricName)
 	assert.Equal("Bytes", res[0].Spec.ValueField)
-	assert.Equal([]string{"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_HostName", "DstK8S_HostName"}, res[0].Spec.Labels)
+	assert.Equal([]string{"K8S_ClusterName", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_HostName", "DstK8S_HostName"}, res[0].Spec.Labels)
 	assert.Equal("namespace_flows_total", res[1].Spec.MetricName)
 	assert.Empty(res[1].Spec.ValueField)
-	assert.Equal([]string{"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel"}, res[1].Spec.Labels)
+	assert.Equal([]string{"K8S_ClusterName", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel"}, res[1].Spec.Labels)
 	assert.Equal("workload_egress_packets_total", res[2].Spec.MetricName)
 	assert.Equal("Packets", res[2].Spec.ValueField)
-	assert.Equal([]string{"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel", "SrcK8S_OwnerName", "DstK8S_OwnerName", "SrcK8S_OwnerType", "DstK8S_OwnerType", "SrcK8S_Type", "DstK8S_Type"}, res[2].Spec.Labels)
+	assert.Equal([]string{"K8S_ClusterName", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel", "SrcK8S_OwnerName", "DstK8S_OwnerName", "SrcK8S_OwnerType", "DstK8S_OwnerType", "SrcK8S_Type", "DstK8S_Type"}, res[2].Spec.Labels)
 }
 
 func TestGetDefinitionsRemoveZoneCluster(t *testing.T) {
 	assert := assert.New(t)
 
-	res := GetDefinitions([]string{"namespace_flows_total", "node_ingress_bytes_total", "workload_egress_packets_total"}, []string{"K8S_Clustername", "SrcK8S_Zone", "DstK8S_Zone"})
+	res := GetDefinitions([]string{"namespace_flows_total", "node_ingress_bytes_total", "workload_egress_packets_total"}, []string{"K8S_ClusterName", "SrcK8S_Zone", "DstK8S_Zone"})
 	assert.Len(res, 3)
 	assert.Equal("node_ingress_bytes_total", res[0].Spec.MetricName)
 	assert.Equal("Bytes", res[0].Spec.ValueField)


### PR DESCRIPTION

## Description

Add cluster & zone to predefined metrics
They're only added when those features are enabled.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
