### PR TITLE
H&H: Allow using Test Console (standalone) from operator 🤘

### DIFF
--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -45,13 +45,12 @@ const metricsPort = 9002
 const metricsPortName = "metrics"
 
 type builder struct {
-	info           *reconcilers.Instance
-	labels         map[string]string
-	selector       map[string]string
-	desired        *flowslatest.FlowCollectorSpec
-	advanced       *flowslatest.AdvancedPluginConfig
-	volumes        volumes.Builder
-	useTestConsole bool
+	info     *reconcilers.Instance
+	labels   map[string]string
+	selector map[string]string
+	desired  *flowslatest.FlowCollectorSpec
+	advanced *flowslatest.AdvancedPluginConfig
+	volumes  volumes.Builder
 }
 
 func newBuilder(info *reconcilers.Instance, desired *flowslatest.FlowCollectorSpec) builder {
@@ -66,9 +65,8 @@ func newBuilder(info *reconcilers.Instance, desired *flowslatest.FlowCollectorSp
 		selector: map[string]string{
 			"app": constants.PluginName,
 		},
-		desired:        desired,
-		advanced:       &advanced,
-		useTestConsole: helper.UseTestConsolePlugin(desired),
+		desired:  desired,
+		advanced: &advanced,
 	}
 }
 
@@ -194,7 +192,7 @@ func (b *builder) podTemplate(cmDigest string) *corev1.PodTemplateSpec {
 		},
 	}
 
-	if !b.useTestConsole {
+	if !helper.UseTestConsolePlugin(b.desired) {
 		volumes = append(volumes, corev1.Volume{
 			Name: secretName,
 			VolumeSource: corev1.VolumeSource{
@@ -499,7 +497,7 @@ func (b *builder) configMap(ctx context.Context) (*corev1.ConfigMap, string, err
 			Port: int(*b.advanced.Port),
 		},
 	}
-	if b.useTestConsole {
+	if helper.UseTestConsolePlugin(b.desired) {
 		config.Server.AuthCheck = "none"
 	} else {
 		config.Server.CertPath = "/var/serving-cert/tls.crt"

--- a/controllers/consoleplugin/consoleplugin_reconciler.go
+++ b/controllers/consoleplugin/consoleplugin_reconciler.go
@@ -67,11 +67,13 @@ func (r *CPReconciler) Reconcile(ctx context.Context, desired *flowslatest.FlowC
 		return err
 	}
 
-	if err = r.checkAutoPatch(ctx, desired); err != nil {
-		return err
+	if r.AvailableAPIs.HasConsolePlugin() {
+		if err = r.checkAutoPatch(ctx, desired); err != nil {
+			return err
+		}
 	}
 
-	if helper.UseConsolePlugin(&desired.Spec) {
+	if helper.UseConsolePlugin(&desired.Spec) && (r.AvailableAPIs.HasConsolePlugin() || helper.UseTestConsolePlugin(&desired.Spec)) {
 		// Create object builder
 		builder := newBuilder(r.Instance, &desired.Spec)
 
@@ -79,8 +81,10 @@ func (r *CPReconciler) Reconcile(ctx context.Context, desired *flowslatest.FlowC
 			return err
 		}
 
-		if err = r.reconcilePlugin(ctx, &builder, &desired.Spec); err != nil {
-			return err
+		if r.AvailableAPIs.HasConsolePlugin() {
+			if err = r.reconcilePlugin(ctx, &builder, &desired.Spec); err != nil {
+				return err
+			}
 		}
 
 		cmDigest, err := r.reconcileConfigMap(ctx, &builder)

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -45,6 +45,8 @@ const (
 	LokiCRWriter  = "netobserv-writer"
 	LokiCRBWriter = "netobserv-writer-flp"
 	LokiCRReader  = "netobserv-reader"
+
+	EnvTestConsole = "TEST_CONSOLE"
 )
 
 var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstK8S_Type", "K8S_FlowLayer", "FlowDirection"}

--- a/controllers/flowcollector_controller.go
+++ b/controllers/flowcollector_controller.go
@@ -133,14 +133,11 @@ func (r *FlowCollectorReconciler) reconcile(ctx context.Context, clh *helper.Cli
 	r.watcher.Reset(ns)
 
 	// Create reconcilers
-	var cpReconciler consoleplugin.CPReconciler
-	if r.mgr.HasConsolePlugin() {
-		cpReconciler = consoleplugin.NewReconciler(reconcilersInfo.NewInstance(r.mgr.Config.ConsolePluginImage, r.status))
-	}
+	cpReconciler := consoleplugin.NewReconciler(reconcilersInfo.NewInstance(r.mgr.Config.ConsolePluginImage, r.status))
 
 	// Check namespace changed
 	if ns != previousNamespace {
-		if previousNamespace != "" && r.mgr.HasConsolePlugin() {
+		if previousNamespace != "" {
 			// Namespace updated, clean up previous namespace
 			log.FromContext(ctx).
 				Info("FlowCollector namespace change detected: cleaning up previous namespace", "old", previousNamespace, "new", ns)
@@ -160,11 +157,9 @@ func (r *FlowCollectorReconciler) reconcile(ctx context.Context, clh *helper.Cli
 	}
 
 	// Console plugin
-	if r.mgr.HasConsolePlugin() {
-		err := cpReconciler.Reconcile(ctx, desired)
-		if err != nil {
-			return r.status.Error("ReconcileConsolePluginFailed", err)
-		}
+	err := cpReconciler.Reconcile(ctx, desired)
+	if err != nil {
+		return r.status.Error("ReconcileConsolePluginFailed", err)
 	}
 
 	return nil

--- a/pkg/helper/flowcollector.go
+++ b/pkg/helper/flowcollector.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
@@ -83,7 +84,9 @@ func UseConsolePlugin(spec *flowslatest.FlowCollectorSpec) bool {
 func UseTestConsolePlugin(spec *flowslatest.FlowCollectorSpec) bool {
 	if spec.ConsolePlugin.Advanced != nil {
 		env := spec.ConsolePlugin.Advanced.Env[constants.EnvTestConsole]
-		return env == "true"
+		// Use ParseBool to allow common variants ("true", "True", "1"...) and ignore non-bools
+		b, err := strconv.ParseBool(env)
+		return err == nil && b
 	}
 	return false
 }

--- a/pkg/helper/flowcollector.go
+++ b/pkg/helper/flowcollector.go
@@ -80,6 +80,14 @@ func UseConsolePlugin(spec *flowslatest.FlowCollectorSpec) bool {
 		(spec.ConsolePlugin.Enable == nil || *spec.ConsolePlugin.Enable)
 }
 
+func UseTestConsolePlugin(spec *flowslatest.FlowCollectorSpec) bool {
+	if spec.ConsolePlugin.Advanced != nil {
+		env := spec.ConsolePlugin.Advanced.Env[constants.EnvTestConsole]
+		return env == "true"
+	}
+	return false
+}
+
 func IsAgentFeatureEnabled(spec *flowslatest.FlowCollectorEBPF, feature flowslatest.AgentFeature) bool {
 	for _, f := range spec.Features {
 		if f == feature {


### PR DESCRIPTION
## Description

To be used with a standalone plugin build image such as: `quay.io/jotak/network-observability-standalone-frontend:riviera2024`

Set `spec.consolePlugin.advanced.env.TEST_CONSOLE` `"true"`

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
