### PR TITLE
NETOBSERV-1672: add cluster & zone to predefined metrics (#665) [1.6 backport]

### DIFF
--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -409,7 +409,7 @@ func (b *builder) getPromConfig(ctx context.Context) cfg.PrometheusConfig {
 
 	allMetricNames := metrics.GetAllNames()
 	includeList := metrics.GetIncludeList(b.desired)
-	allMetrics := metrics.GetDefinitions(allMetricNames)
+	allMetrics := metrics.GetDefinitions(allMetricNames, nil)
 	for i := range allMetrics {
 		mSpec := allMetrics[i].Spec
 		enabled := slices.Contains(includeList, mSpec.MetricName)

--- a/pkg/dashboards/dashboard_test.go
+++ b/pkg/dashboards/dashboard_test.go
@@ -12,7 +12,7 @@ import (
 func TestCreateFlowMetricsDashboard_All(t *testing.T) {
 	assert := assert.New(t)
 
-	defs := metrics.GetDefinitions(metrics.GetAllNames())
+	defs := metrics.GetDefinitions(metrics.GetAllNames(), nil)
 	js := CreateFlowMetricsDashboards(defs)
 
 	d, err := FromBytes([]byte(js["Main"]))
@@ -87,7 +87,7 @@ func TestCreateFlowMetricsDashboard_All(t *testing.T) {
 func TestCreateFlowMetricsDashboard_OnlyNodeIngressBytes(t *testing.T) {
 	assert := assert.New(t)
 
-	defs := metrics.GetDefinitions([]string{"node_ingress_bytes_total"})
+	defs := metrics.GetDefinitions([]string{"node_ingress_bytes_total"}, nil)
 	js := CreateFlowMetricsDashboards(defs)
 
 	d, err := FromBytes([]byte(js["Main"]))
@@ -106,7 +106,7 @@ func TestCreateFlowMetricsDashboard_OnlyNodeIngressBytes(t *testing.T) {
 func TestCreateFlowMetricsDashboard_DefaultList(t *testing.T) {
 	assert := assert.New(t)
 
-	defs := metrics.GetDefinitions(metrics.DefaultIncludeList)
+	defs := metrics.GetDefinitions(metrics.DefaultIncludeList, nil)
 	js := CreateFlowMetricsDashboards(defs)
 
 	d, err := FromBytes([]byte(js["Main"]))

--- a/pkg/metrics/predefined_metrics_test.go
+++ b/pkg/metrics/predefined_metrics_test.go
@@ -43,7 +43,23 @@ func TestIncludeExclude(t *testing.T) {
 func TestGetDefinitions(t *testing.T) {
 	assert := assert.New(t)
 
-	res := GetDefinitions([]string{"namespace_flows_total", "node_ingress_bytes_total", "workload_egress_packets_total"})
+	res := GetDefinitions([]string{"namespace_flows_total", "node_ingress_bytes_total", "workload_egress_packets_total"}, nil)
+	assert.Len(res, 3)
+	assert.Equal("node_ingress_bytes_total", res[0].Spec.MetricName)
+	assert.Equal("Bytes", res[0].Spec.ValueField)
+	assert.Equal([]string{"K8S_ClusterName", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_HostName", "DstK8S_HostName"}, res[0].Spec.Labels)
+	assert.Equal("namespace_flows_total", res[1].Spec.MetricName)
+	assert.Empty(res[1].Spec.ValueField)
+	assert.Equal([]string{"K8S_ClusterName", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel"}, res[1].Spec.Labels)
+	assert.Equal("workload_egress_packets_total", res[2].Spec.MetricName)
+	assert.Equal("Packets", res[2].Spec.ValueField)
+	assert.Equal([]string{"K8S_ClusterName", "SrcK8S_Zone", "DstK8S_Zone", "SrcK8S_Namespace", "DstK8S_Namespace", "K8S_FlowLayer", "SrcSubnetLabel", "DstSubnetLabel", "SrcK8S_OwnerName", "DstK8S_OwnerName", "SrcK8S_OwnerType", "DstK8S_OwnerType", "SrcK8S_Type", "DstK8S_Type"}, res[2].Spec.Labels)
+}
+
+func TestGetDefinitionsRemoveZoneCluster(t *testing.T) {
+	assert := assert.New(t)
+
+	res := GetDefinitions([]string{"namespace_flows_total", "node_ingress_bytes_total", "workload_egress_packets_total"}, []string{"K8S_ClusterName", "SrcK8S_Zone", "DstK8S_Zone"})
 	assert.Len(res, 3)
 	assert.Equal("node_ingress_bytes_total", res[0].Spec.MetricName)
 	assert.Equal("Bytes", res[0].Spec.ValueField)


### PR DESCRIPTION
cf https://github.com/netobserv/network-observability-operator/pull/665