### PR TITLE
NETOBSERV-1647: Do not load loki cert when loki disabled

### DIFF
--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -209,15 +209,18 @@ func (b *builder) podTemplate(cmDigest string) *corev1.PodTemplateSpec {
 	}
 
 	// ensure volumes are up to date
+	// TODO/FIXME: why? The same is done in `getLokiConfig`, why doing it in two places? If there's a reason it should be commented
 	loki := b.info.Loki
-	if loki.TLS.Enable && !loki.TLS.InsecureSkipVerify {
-		b.volumes.AddCACertificate(&loki.TLS, "loki-certs")
-	}
-	if loki.StatusTLS.Enable && !loki.StatusTLS.InsecureSkipVerify {
-		b.volumes.AddMutualTLSCertificates(&loki.StatusTLS, "loki-status-certs")
-	}
-	if loki.UseHostToken() {
-		b.volumes.AddToken(constants.PluginName)
+	if helper.UseLoki(b.desired) {
+		if loki.TLS.Enable && !loki.TLS.InsecureSkipVerify {
+			b.volumes.AddCACertificate(&loki.TLS, "loki-certs")
+		}
+		if loki.StatusTLS.Enable && !loki.StatusTLS.InsecureSkipVerify {
+			b.volumes.AddMutualTLSCertificates(&loki.StatusTLS, "loki-status-certs")
+		}
+		if loki.UseHostToken() {
+			b.volumes.AddToken(constants.PluginName)
+		}
 	}
 
 	return &corev1.PodTemplateSpec{

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -208,21 +208,6 @@ func (b *builder) podTemplate(cmDigest string) *corev1.PodTemplateSpec {
 		})
 	}
 
-	// ensure volumes are up to date
-	// TODO/FIXME: why? The same is done in `getLokiConfig`, why doing it in two places? If there's a reason it should be commented
-	loki := b.info.Loki
-	if helper.UseLoki(b.desired) {
-		if loki.TLS.Enable && !loki.TLS.InsecureSkipVerify {
-			b.volumes.AddCACertificate(&loki.TLS, "loki-certs")
-		}
-		if loki.StatusTLS.Enable && !loki.StatusTLS.InsecureSkipVerify {
-			b.volumes.AddMutualTLSCertificates(&loki.StatusTLS, "loki-status-certs")
-		}
-		if loki.UseHostToken() {
-			b.volumes.AddToken(constants.PluginName)
-		}
-	}
-
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: b.labels,

--- a/controllers/consoleplugin/consoleplugin_reconciler.go
+++ b/controllers/consoleplugin/consoleplugin_reconciler.go
@@ -104,13 +104,15 @@ func (r *CPReconciler) Reconcile(ctx context.Context, desired *flowslatest.FlowC
 			return err
 		}
 
-		// Watch for Loki certificates if necessary; we'll ignore in that case the returned digest, as we don't need to restart pods on cert rotation
-		// because certificate is always reloaded from file
-		if _, err = r.Watcher.ProcessCACert(ctx, r.Client, &r.Loki.TLS, r.Namespace); err != nil {
-			return err
-		}
-		if _, _, err = r.Watcher.ProcessMTLSCerts(ctx, r.Client, &r.Loki.StatusTLS, r.Namespace); err != nil {
-			return err
+		if helper.UseLoki(&desired.Spec) {
+			// Watch for Loki certificates if necessary; we'll ignore in that case the returned digest, as we don't need to restart pods on cert rotation
+			// because certificate is always reloaded from file
+			if _, err = r.Watcher.ProcessCACert(ctx, r.Client, &r.Loki.TLS, r.Namespace); err != nil {
+				return err
+			}
+			if _, _, err = r.Watcher.ProcessMTLSCerts(ctx, r.Client, &r.Loki.StatusTLS, r.Namespace); err != nil {
+				return err
+			}
 		}
 	} else {
 		// delete any existing owned object

--- a/controllers/consoleplugin/consoleplugin_test.go
+++ b/controllers/consoleplugin/consoleplugin_test.go
@@ -111,7 +111,9 @@ func getAutoScalerSpecs() (ascv2.HorizontalPodAutoscaler, flowslatest.FlowCollec
 
 func getBuilder(spec *flowslatest.FlowCollectorSpec, lk *helper.LokiConfig) builder {
 	info := reconcilers.Common{Namespace: testNamespace, Loki: lk}
-	return newBuilder(info.NewInstance(testImage, status.Instance{}), spec)
+	b := newBuilder(info.NewInstance(testImage, status.Instance{}), spec)
+	_, _, _ = b.configMap(context.Background()) // build configmap to update builder's volumes
+	return b
 }
 
 func TestContainerUpdateCheck(t *testing.T) {


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
