### PR TITLE
NETOBSERV-1647: Do not load loki cert when loki disabled [Backport 1.6]

### DIFF
--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -15,8 +15,7 @@ spec:
           namespace: netobserv
           path: /convert
       conversionReviewVersions:
-      - v1beta1
-      - v1beta2
+      - v1
   group: flows.netobserv.io
   names:
     kind: FlowCollector

--- a/config/crd/patches/webhook_in_flowcollectors.yaml
+++ b/config/crd/patches/webhook_in_flowcollectors.yaml
@@ -13,5 +13,4 @@ spec:
           name: webhook-service
           path: /convert
       conversionReviewVersions:
-      - v1beta1
-      - v1beta2
+      - v1

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -204,15 +204,18 @@ func (b *builder) podTemplate(cmDigest string) *corev1.PodTemplateSpec {
 	}
 
 	// ensure volumes are up to date
+	// TODO/FIXME: why? The same is done in `getLokiConfig`, why doing it in two places? If there's a reason it should be commented
 	loki := b.info.Loki
-	if loki.TLS.Enable && !loki.TLS.InsecureSkipVerify {
-		b.volumes.AddCACertificate(&loki.TLS, "loki-certs")
-	}
-	if loki.StatusTLS.Enable && !loki.StatusTLS.InsecureSkipVerify {
-		b.volumes.AddMutualTLSCertificates(&loki.StatusTLS, "loki-status-certs")
-	}
-	if loki.UseHostToken() {
-		b.volumes.AddToken(constants.PluginName)
+	if helper.UseLoki(b.desired) {
+		if loki.TLS.Enable && !loki.TLS.InsecureSkipVerify {
+			b.volumes.AddCACertificate(&loki.TLS, "loki-certs")
+		}
+		if loki.StatusTLS.Enable && !loki.StatusTLS.InsecureSkipVerify {
+			b.volumes.AddMutualTLSCertificates(&loki.StatusTLS, "loki-status-certs")
+		}
+		if loki.UseHostToken() {
+			b.volumes.AddToken(constants.PluginName)
+		}
 	}
 
 	return &corev1.PodTemplateSpec{

--- a/controllers/consoleplugin/consoleplugin_reconciler.go
+++ b/controllers/consoleplugin/consoleplugin_reconciler.go
@@ -100,13 +100,15 @@ func (r *CPReconciler) Reconcile(ctx context.Context, desired *flowslatest.FlowC
 			return err
 		}
 
-		// Watch for Loki certificates if necessary; we'll ignore in that case the returned digest, as we don't need to restart pods on cert rotation
-		// because certificate is always reloaded from file
-		if _, err = r.Watcher.ProcessCACert(ctx, r.Client, &r.Loki.TLS, r.Namespace); err != nil {
-			return err
-		}
-		if _, _, err = r.Watcher.ProcessMTLSCerts(ctx, r.Client, &r.Loki.StatusTLS, r.Namespace); err != nil {
-			return err
+		if helper.UseLoki(&desired.Spec) {
+			// Watch for Loki certificates if necessary; we'll ignore in that case the returned digest, as we don't need to restart pods on cert rotation
+			// because certificate is always reloaded from file
+			if _, err = r.Watcher.ProcessCACert(ctx, r.Client, &r.Loki.TLS, r.Namespace); err != nil {
+				return err
+			}
+			if _, _, err = r.Watcher.ProcessMTLSCerts(ctx, r.Client, &r.Loki.StatusTLS, r.Namespace); err != nil {
+				return err
+			}
 		}
 	} else {
 		// delete any existing owned object


### PR DESCRIPTION
cf https://github.com/netobserv/network-observability-operator/pull/669

also includes backport of https://github.com/netobserv/network-observability-operator/pull/662 to fix flaky CI