### PR TITLE
NETOBSERV-1649: add drop cause & state labels to metrics

### DIFF
--- a/pkg/metrics/predefined_metrics.go
+++ b/pkg/metrics/predefined_metrics.go
@@ -46,6 +46,7 @@ var (
 	DefaultIncludeListLokiDisabled = []string{
 		"node_ingress_bytes_total",
 		"workload_ingress_bytes_total",
+		"workload_ingress_packets_total",
 		"workload_flows_total",
 		"workload_drop_bytes_total",
 		"workload_drop_packets_total",
@@ -111,6 +112,8 @@ func init() {
 			tags: []string{group, "rtt"},
 		})
 		// Drops metrics
+		dropLabels := labels
+		dropLabels = append(dropLabels, "PktDropLatestState", "PktDropLatestDropCause")
 		predefinedMetrics = append(predefinedMetrics, taggedMetricDefinition{
 			FlowMetricSpec: metricslatest.FlowMetricSpec{
 				MetricName: fmt.Sprintf("%s_drop_packets_total", groupTrimmed),
@@ -119,7 +122,7 @@ func init() {
 				Filters: []metricslatest.MetricFilter{
 					{Field: "PktDropPackets", MatchType: metricslatest.MatchPresence},
 				},
-				Labels: labels,
+				Labels: dropLabels,
 				Charts: dropCharts(group, "pps"),
 			},
 			tags: []string{group, tagPackets, "drops"},
@@ -132,7 +135,7 @@ func init() {
 				Filters: []metricslatest.MetricFilter{
 					{Field: "PktDropBytes", MatchType: metricslatest.MatchPresence},
 				},
-				Labels: labels,
+				Labels: dropLabels,
 				Charts: dropCharts(group, "Bps"),
 			},
 			tags: []string{group, tagBytes, "drop"},


### PR DESCRIPTION
## Description

Add more metrics info to make prometheus datasource suiting for replacing loki datasource in overview page

- Add drop cause & TCP state labels to the drop metrics
- When only prometheus is enabled, turn on "workload_ingress_packets_total" by default

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
