### PR TITLE
NETOBSERV-1705: do not send zone/cluster labels config...

### DIFF
--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -400,9 +400,8 @@ func (b *builder) getPromConfig(ctx context.Context) cfg.PrometheusConfig {
 
 	config.TokenPath = b.volumes.AddToken(constants.PluginName)
 
-	allMetricNames := metrics.GetAllNames()
 	includeList := metrics.GetIncludeList(b.desired)
-	allMetrics := metrics.GetDefinitions(allMetricNames, nil)
+	allMetrics := metrics.GetDefinitions(b.desired, true)
 	for i := range allMetrics {
 		mSpec := allMetrics[i].Spec
 		enabled := slices.Contains(includeList, mSpec.MetricName)

--- a/pkg/dashboards/dashboard_test.go
+++ b/pkg/dashboards/dashboard_test.go
@@ -5,6 +5,7 @@ import (
 
 	metricslatest "github.com/netobserv/network-observability-operator/apis/flowmetrics/v1alpha1"
 	"github.com/netobserv/network-observability-operator/pkg/metrics"
+	"github.com/netobserv/network-observability-operator/pkg/test/util"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -12,7 +13,7 @@ import (
 func TestCreateFlowMetricsDashboard_All(t *testing.T) {
 	assert := assert.New(t)
 
-	defs := metrics.GetDefinitions(metrics.GetAllNames(), nil)
+	defs := metrics.GetDefinitions(util.SpecForMetrics(), true)
 	js := CreateFlowMetricsDashboards(defs)
 
 	d, err := FromBytes([]byte(js["Main"]))
@@ -87,7 +88,7 @@ func TestCreateFlowMetricsDashboard_All(t *testing.T) {
 func TestCreateFlowMetricsDashboard_OnlyNodeIngressBytes(t *testing.T) {
 	assert := assert.New(t)
 
-	defs := metrics.GetDefinitions([]string{"node_ingress_bytes_total"}, nil)
+	defs := metrics.GetDefinitions(util.SpecForMetrics("node_ingress_bytes_total"), false)
 	js := CreateFlowMetricsDashboards(defs)
 
 	d, err := FromBytes([]byte(js["Main"]))
@@ -106,7 +107,7 @@ func TestCreateFlowMetricsDashboard_OnlyNodeIngressBytes(t *testing.T) {
 func TestCreateFlowMetricsDashboard_DefaultList(t *testing.T) {
 	assert := assert.New(t)
 
-	defs := metrics.GetDefinitions(metrics.DefaultIncludeList, nil)
+	defs := metrics.GetDefinitions(util.SpecForMetrics(), false)
 	js := CreateFlowMetricsDashboards(defs)
 
 	d, err := FromBytes([]byte(js["Main"]))

--- a/pkg/metrics/predefined_metrics_test.go
+++ b/pkg/metrics/predefined_metrics_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	flowslatest "github.com/netobserv/network-observability-operator/apis/flowcollector/v1beta2"
+	"github.com/netobserv/network-observability-operator/pkg/test/util"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
 )
 
 func TestIncludeExclude(t *testing.T) {
@@ -43,7 +45,7 @@ func TestIncludeExclude(t *testing.T) {
 func TestGetDefinitions(t *testing.T) {
 	assert := assert.New(t)
 
-	res := GetDefinitions([]string{"namespace_flows_total", "node_ingress_bytes_total", "workload_egress_packets_total"}, nil)
+	res := GetDefinitions(util.SpecForMetrics("namespace_flows_total", "node_ingress_bytes_total", "workload_egress_packets_total"), false)
 	assert.Len(res, 3)
 	assert.Equal("node_ingress_bytes_total", res[0].Spec.MetricName)
 	assert.Equal("Bytes", res[0].Spec.ValueField)
@@ -59,7 +61,10 @@ func TestGetDefinitions(t *testing.T) {
 func TestGetDefinitionsRemoveZoneCluster(t *testing.T) {
 	assert := assert.New(t)
 
-	res := GetDefinitions([]string{"namespace_flows_total", "node_ingress_bytes_total", "workload_egress_packets_total"}, []string{"K8S_ClusterName", "SrcK8S_Zone", "DstK8S_Zone"})
+	spec := util.SpecForMetrics("namespace_flows_total", "node_ingress_bytes_total", "workload_egress_packets_total")
+	spec.Processor.AddZone = ptr.To(false)
+	spec.Processor.MultiClusterDeployment = ptr.To(false)
+	res := GetDefinitions(spec, false)
 	assert.Len(res, 3)
 	assert.Equal("node_ingress_bytes_total", res[0].Spec.MetricName)
 	assert.Equal("Bytes", res[0].Spec.ValueField)

--- a/pkg/test/util/utils.go
+++ b/pkg/test/util/utils.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	flowslatest "github.com/netobserv/network-observability-operator/apis/flowcollector/v1beta2"
+	"k8s.io/utils/ptr"
+)
+
+func SpecForMetrics(metrics ...string) *flowslatest.FlowCollectorSpec {
+	fc := flowslatest.FlowCollectorSpec{
+		Agent: flowslatest.FlowCollectorAgent{
+			EBPF: flowslatest.FlowCollectorEBPF{
+				Privileged: true,
+				Features:   []flowslatest.AgentFeature{flowslatest.FlowRTT, flowslatest.DNSTracking, flowslatest.PacketDrop},
+			},
+		},
+		Processor: flowslatest.FlowCollectorFLP{
+			Metrics:                flowslatest.FLPMetrics{},
+			AddZone:                ptr.To(true),
+			MultiClusterDeployment: ptr.To(true),
+		},
+	}
+	if len(metrics) > 0 {
+		var conv []flowslatest.FLPMetric
+		for _, m := range metrics {
+			conv = append(conv, flowslatest.FLPMetric(m))
+		}
+		fc.Processor.Metrics.IncludeList = &conv
+	}
+	return &fc
+}


### PR DESCRIPTION
do not send zone/cluster labels config to the console plugin when the related features are disabled. Else, the console plugin assumes that they are available, regardless of the features knobs

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
