### PR TITLE
NETOBSERV-1731: hide metrics enable setting from form

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -517,6 +517,9 @@ spec:
       - path: agent.ebpf.flowFilter
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - path: agent.ebpf.metrics.enable
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: to use Kafka as a broker as part of the flow collection pipeline.
         displayName: Kafka configuration
         path: kafka
@@ -603,6 +606,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - path: processor.subnetLabels.openShiftAutoDetect
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Log level
         path: processor.logLevel
         x-descriptors:
@@ -732,8 +738,6 @@ spec:
         path: agent.ebpf.metrics
       - displayName: Disable alerts
         path: agent.ebpf.metrics.disableAlerts
-      - displayName: Enable
-        path: agent.ebpf.metrics.enable
       - displayName: Server
         path: agent.ebpf.metrics.server
       - displayName: Port
@@ -788,8 +792,6 @@ spec:
         path: processor.subnetLabels
       - displayName: Custom labels
         path: processor.subnetLabels.customLabels
-      - displayName: Open shift auto detect
-        path: processor.subnetLabels.openShiftAutoDetect
       - displayName: Prometheus
         path: prometheus
       - displayName: Querier

--- a/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
@@ -39,6 +39,7 @@ spec:
       name: flowcollectors.flows.netobserv.io
       version: v1beta2
       specDescriptors:
+        # Reference: https://github.com/openshift/console/blob/master/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md
         # ROOT
         - description: defines the desired type of deployment for flow processing.
           path: deploymentModel
@@ -86,6 +87,9 @@ spec:
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:hidden
         - path: agent.ebpf.flowFilter
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:hidden
+        - path: agent.ebpf.metrics.enable
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:hidden
         # KAFKA
@@ -170,6 +174,9 @@ spec:
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
             - urn:alm:descriptor:com.tectonic.ui:advanced
+        - path: processor.subnetLabels.openShiftAutoDetect
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:hidden
         - path: processor.logLevel
           x-descriptors:
             - urn:alm:descriptor:com.tectonic.ui:advanced


### PR DESCRIPTION
## Description

Same with subnet labels / openshift auto-detect ([NETOBSERV-1734](https://issues.redhat.com//browse/NETOBSERV-1734))

This is to avoid confusion, since nillable bools are not managed properly in OLM forms They can be access from YAML

A longer-term solution will be to replace all our nillable bools with enums in a next API version

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
