### PR TITLE
NETOBSERV-1734: change subnets order priority

### DIFF
--- a/controllers/flp/flp_pipeline_builder.go
+++ b/controllers/flp/flp_pipeline_builder.go
@@ -61,7 +61,8 @@ func (b *PipelineBuilder) AddProcessorStages() error {
 	addZone := helper.IsZoneEnabled(&b.desired.Processor)
 
 	// Get all subnet labels
-	allLabels := append(b.detectedSubnets, b.desired.Processor.SubnetLabels.CustomLabels...)
+	allLabels := b.desired.Processor.SubnetLabels.CustomLabels
+	allLabels = append(allLabels, b.detectedSubnets...)
 	flpLabels := subnetLabelsToFLP(allLabels)
 
 	rules := api.NetworkTransformRules{


### PR DESCRIPTION
## Description

Make sure auto-detected openshift labels are appended at the end of the subnets list, so that they have lower priority. It makes it possible to override in-cluster subnets.

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
