### PR TITLE
NETOBSERV-1755 Add filter for TCP flags

### DIFF
--- a/apis/flowcollector/v1beta1/flowcollector_types.go
+++ b/apis/flowcollector/v1beta1/flowcollector_types.go
@@ -210,6 +210,11 @@ type EBPFFlowFilter struct {
 	// +optional
 	Direction string `json:"direction,omitempty"`
 
+	// `tcpFlags` defines the TCP flags to filter flows by.
+	// +kubebuilder:validation:Enum:="SYN";"SYN-ACK";"ACK";"FIN";"RST";"URG";"ECE";"CWR";"FIN-ACK";"RST-ACK"
+	// +optional
+	TCPFlags string `json:"tcpFlags,omitempty"`
+
 	// SourcePorts defines the source ports to filter flows by.
 	// To filter a single port, set a single port as an integer value. For example sourcePorts: 80.
 	// To filter a range of ports, use a "start-end" range, string format. For example sourcePorts: "80-100".

--- a/apis/flowcollector/v1beta1/zz_generated.conversion.go
+++ b/apis/flowcollector/v1beta1/zz_generated.conversion.go
@@ -491,6 +491,7 @@ func autoConvert_v1beta1_EBPFFlowFilter_To_v1beta2_EBPFFlowFilter(in *EBPFFlowFi
 	out.Action = in.Action
 	out.Protocol = in.Protocol
 	out.Direction = in.Direction
+	out.TCPFlags = in.TCPFlags
 	out.SourcePorts = in.SourcePorts
 	out.DestPorts = in.DestPorts
 	out.Ports = in.Ports
@@ -511,6 +512,7 @@ func autoConvert_v1beta2_EBPFFlowFilter_To_v1beta1_EBPFFlowFilter(in *v1beta2.EB
 	out.Action = in.Action
 	out.Protocol = in.Protocol
 	out.Direction = in.Direction
+	out.TCPFlags = in.TCPFlags
 	out.SourcePorts = in.SourcePorts
 	out.DestPorts = in.DestPorts
 	out.Ports = in.Ports

--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -215,6 +215,11 @@ type EBPFFlowFilter struct {
 	// +optional
 	Direction string `json:"direction,omitempty"`
 
+	// `tcpFlags` defines the TCP flags to filter flows by.
+	// +kubebuilder:validation:Enum:="SYN";"SYN-ACK";"ACK";"FIN";"RST";"URG";"ECE";"CWR";"FIN-ACK";"RST-ACK"
+	// +optional
+	TCPFlags string `json:"tcpFlags,omitempty"`
+
 	// `sourcePorts` defines the source ports to filter flows by.
 	// To filter a single port, set a single port as an integer value. For example: `sourcePorts: 80`.
 	// To filter a range of ports, use a "start-end" range in string format. For example: `sourcePorts: "80-100"`.

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -222,6 +222,21 @@ spec:
                               To filter a single port, set a single port as an integer value. For example sourcePorts: 80.
                               To filter a range of ports, use a "start-end" range, string format. For example sourcePorts: "80-100".
                             x-kubernetes-int-or-string: true
+                          tcpFlags:
+                            description: '`tcpFlags` defines the TCP flags to filter
+                              flows by.'
+                            enum:
+                            - SYN
+                            - SYN-ACK
+                            - ACK
+                            - FIN
+                            - RST
+                            - URG
+                            - ECE
+                            - CWR
+                            - FIN-ACK
+                            - RST-ACK
+                            type: string
                         type: object
                       imagePullPolicy:
                         default: IfNotPresent
@@ -3785,6 +3800,21 @@ spec:
                               To filter a single port, set a single port as an integer value. For example: `sourcePorts: 80`.
                               To filter a range of ports, use a "start-end" range in string format. For example: `sourcePorts: "80-100"`.
                             x-kubernetes-int-or-string: true
+                          tcpFlags:
+                            description: '`tcpFlags` defines the TCP flags to filter
+                              flows by.'
+                            enum:
+                            - SYN
+                            - SYN-ACK
+                            - ACK
+                            - FIN
+                            - RST
+                            - URG
+                            - ECE
+                            - CWR
+                            - FIN-ACK
+                            - RST-ACK
+                            type: string
                         type: object
                       imagePullPolicy:
                         default: IfNotPresent

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -200,6 +200,20 @@ spec:
                                 To filter a single port, set a single port as an integer value. For example sourcePorts: 80.
                                 To filter a range of ports, use a "start-end" range, string format. For example sourcePorts: "80-100".
                               x-kubernetes-int-or-string: true
+                            tcpFlags:
+                              description: '`tcpFlags` defines the TCP flags to filter flows by.'
+                              enum:
+                                - SYN
+                                - SYN-ACK
+                                - ACK
+                                - FIN
+                                - RST
+                                - URG
+                                - ECE
+                                - CWR
+                                - FIN-ACK
+                                - RST-ACK
+                              type: string
                           type: object
                         imagePullPolicy:
                           default: IfNotPresent
@@ -3484,6 +3498,20 @@ spec:
                                 To filter a single port, set a single port as an integer value. For example: `sourcePorts: 80`.
                                 To filter a range of ports, use a "start-end" range in string format. For example: `sourcePorts: "80-100"`.
                               x-kubernetes-int-or-string: true
+                            tcpFlags:
+                              description: '`tcpFlags` defines the TCP flags to filter flows by.'
+                              enum:
+                                - SYN
+                                - SYN-ACK
+                                - ACK
+                                - FIN
+                                - RST
+                                - URG
+                                - ECE
+                                - CWR
+                                - FIN-ACK
+                                - RST-ACK
+                              type: string
                           type: object
                         imagePullPolicy:
                           default: IfNotPresent

--- a/config/samples/flows_v1beta2_flowcollector.yaml
+++ b/config/samples/flows_v1beta2_flowcollector.yaml
@@ -23,9 +23,10 @@ spec:
       excludeInterfaces: ["lo"]
       kafkaBatchSize: 1048576
       #flowFilter:
+      #  tcpFlags: "SYN"
       #  action: Accept
       #  cidr: 0.0.0.0/0
-      #  protocol: UDP
+      #  protocol: TCP
       #  sourcePorts: 53
       #  enable: true
       metrics:

--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -396,6 +396,13 @@ columns:
     filter: icmp_code
     default: false
     width: 10
+  - id: TCPFlags
+    name: TCP Flags
+    tooltip: Logical OR combination of unique TCP flags comprised in the flow, as per RFC-9293, with additional custom values.
+    field: Flags
+    filter: tcp_flags
+    default: false
+    width: 10
   - id: FlowDirection
     name: Node Direction
     tooltip: The interpreted direction of the flow observed at the Node observation point.
@@ -790,6 +797,24 @@ filters:
     name: ICMP code
     component: number
     hint: Specify an ICMP code value as integer number.
+  - id: tcp_flags
+    name: TCP flags
+    component: autocomplete
+    hint: Specify a TCP flags value as integer number.
+    examples: |-
+      Logical OR combination of unique TCP flags comprised in the flow, as per RFC-9293, with additional custom flags
+      users can specify either numeric value or string representation of the flags as follows :
+      - FIN or 1,
+      - SYN or 2,
+      - RST or 4,
+      - PSH or 8,
+      - ACK or 16,
+      - URG or 32,
+      - ECE or 64,
+      - CWR or 128,
+      - SYN_ACK or 256,
+      - FIN_ACK or 512,
+      - RST_ACK or 1024,
   - id: node_direction
     name: Node Direction
     component: autocomplete

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -75,6 +75,7 @@ const (
 	envFilterICMPType             = "FILTER_ICMP_TYPE"
 	envFilterICMPCode             = "FILTER_ICMP_CODE"
 	envFilterPeerIPAddress        = "FILTER_PEER_IP"
+	envFilterTCPFlags             = "FILTER_TCP_FLAGS"
 	envListSeparator              = ","
 )
 
@@ -495,6 +496,13 @@ func (c *AgentController) configureFlowFilter(filter *flowslatest.EBPFFlowFilter
 		config = append(config, corev1.EnvVar{Name: envFilterPeerIPAddress,
 			Value: filter.PeerIP})
 	}
+
+	if filter.TCPFlags != "" {
+		config = append(config, corev1.EnvVar{Name: envFilterTCPFlags,
+			Value: filter.TCPFlags,
+		})
+	}
+
 	return config
 }
 

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -520,6 +520,15 @@ To filter a single port, set a single port as an integer value. For example sour
 To filter a range of ports, use a "start-end" range, string format. For example sourcePorts: "80-100".<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>tcpFlags</b></td>
+        <td>enum</td>
+        <td>
+          `tcpFlags` defines the TCP flags to filter flows by.<br/>
+          <br/>
+            <i>Enum</i>: SYN, SYN-ACK, ACK, FIN, RST, URG, ECE, CWR, FIN-ACK, RST-ACK<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -7911,6 +7920,15 @@ To filter a range of ports, use a "start-end" range in string format. For exampl
           `sourcePorts` defines the source ports to filter flows by.
 To filter a single port, set a single port as an integer value. For example: `sourcePorts: 80`.
 To filter a range of ports, use a "start-end" range in string format. For example: `sourcePorts: "80-100"`.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>tcpFlags</b></td>
+        <td>enum</td>
+        <td>
+          `tcpFlags` defines the TCP flags to filter flows by.<br/>
+          <br/>
+            <i>Enum</i>: SYN, SYN-ACK, ACK, FIN, RST, URG, ECE, CWR, FIN-ACK, RST-ACK<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
## Description
using flow filter with TCP flags we can detect TCP syn flood
also extend console plugin filter and column to suppirt TCP flags field

![image (1)](https://github.com/netobserv/network-observability-operator/assets/12748167/c991472e-10c3-49dd-82e3-ac76590cdff3)


## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
https://github.com/netobserv/netobserv-ebpf-agent/pull/367
## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
