### PR TITLE
NETOBSERV-1765: add flowmetrics examples for SYN-flood detection

### DIFF
--- a/config/samples/flowmetrics/flows_with_flags_per_destination.yaml
+++ b/config/samples/flowmetrics/flows_with_flags_per_destination.yaml
@@ -1,0 +1,11 @@
+# This metric counts flows per destination host and resource, with TCP flags. Combined with alerts, it can be used to detect
+# undesired behaviours such as SYN-flood attacks targetting workloads in cluster.
+# More examples in https://github.com/netobserv/network-observability-operator/tree/main/config/samples/flowmetrics
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: flows-with-flags-per-destination
+spec:
+  metricName: flows_with_flags_per_destination_total
+  type: Counter
+  labels: [SrcSubnetLabel,DstSubnetLabel,DstK8S_Name,DstK8S_Type,DstK8S_HostName,DstK8S_Namespace,Flags]

--- a/config/samples/flowmetrics/flows_with_flags_per_source.yaml
+++ b/config/samples/flowmetrics/flows_with_flags_per_source.yaml
@@ -1,0 +1,11 @@
+# This metric counts flows per source host and resource, with TCP flags. Combined with alerts, it can be used to detect
+# undesired behaviours such as SYN-flood attacks originating from the cluster.
+# More examples in https://github.com/netobserv/network-observability-operator/tree/main/config/samples/flowmetrics
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: flows-with-flags-per-source
+spec:
+  metricName: flows_with_flags_per_source_total
+  type: Counter
+  labels: [DstSubnetLabel,SrcSubnetLabel,SrcK8S_Name,SrcK8S_Type,SrcK8S_HostName,SrcK8S_Namespace,Flags]


### PR DESCRIPTION
## Description

Example of alert to use with these metrics:

```yaml
apiVersion: monitoring.openshift.io/v1
kind: AlertingRule
# or, as PrometheusRule:
# apiVersion: monitoring.coreos.com/v1
# kind: PrometheusRule
metadata:
  name: netobserv-alerts
  namespace: netobserv
spec:
  groups:
  - name: NetObservAlerts
    rules:
    - alert: SYNFlood-in
      annotations:
        message: |-
          {{ $labels.job }}: incoming SYN-flood attack suspected to Host={{ $labels.DstK8S_HostName}}, Namespace={{ $labels.DstK8S_Namespace }}, Resource={{ $labels.DstK8S_Name }}. This is characterized by a high volume of SYN-only flows with different source IPs and/or ports.
        summary: "Incoming SYN-flood"
      expr: sum(rate(netobserv_flows_with_flags_per_destination_total{Flags="2"}[1m])) by (job, DstK8S_HostName, DstK8S_Namespace, DstK8S_Name) > 300      
      for: 15s
      labels:
        severity: warning
    - alert: SYNFlood-out
      annotations:
        message: |-
          {{ $labels.job }}: outgoing SYN-flood attack suspected from Host={{ $labels.SrcK8S_HostName}}, Namespace={{ $labels.SrcK8S_Namespace }}, Resource={{ $labels.SrcK8S_Name }}. This is characterized by a high volume of SYN-only flows with different source IPs and/or ports.
        summary: "Outgoing SYN-flood"
      expr: sum(rate(netobserv_flows_with_flags_per_source_total{Flags="2"}[1m])) by (job, SrcK8S_HostName, SrcK8S_Namespace, SrcK8S_Name) > 300      
      for: 15s
      labels:
        severity: warning

```

![Capture d’écran du 2024-07-23 16-12-02](https://github.com/user-attachments/assets/2c4f5b5b-0dd1-4891-aac7-24e59942b932)


## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
