### PR TITLE
NETOBSERV-1758: fix error with monitoring ctrl w/o openshift

### DIFF
--- a/controllers/monitoring/monitoring_controller.go
+++ b/controllers/monitoring/monitoring_controller.go
@@ -119,7 +119,8 @@ func (r *Reconciler) reconcile(ctx context.Context, clh *helper.Client, desired 
 		}
 	}
 
-	if r.mgr.HasSvcMonitor() {
+	// Dashboards
+	if r.mgr.IsOpenShift() && r.mgr.HasSvcMonitor() {
 		// List custom metrics
 		fm := metricslatest.FlowMetricList{}
 		if err := r.Client.List(ctx, &fm, &client.ListOptions{Namespace: ns}); err != nil {

--- a/pkg/test/envtest.go
+++ b/pkg/test/envtest.go
@@ -13,6 +13,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	osv1 "github.com/openshift/api/console/v1"
 	operatorsv1 "github.com/openshift/api/operator/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	ascv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +33,7 @@ import (
 	_ "github.com/openshift/api/config/v1/zz_generated.crd-manifests"
 	_ "github.com/openshift/api/console/v1/zz_generated.crd-manifests"
 	_ "github.com/openshift/api/operator/v1/zz_generated.crd-manifests"
+	_ "github.com/openshift/api/security/v1/zz_generated.crd-manifests"
 
 	// nolint:staticcheck
 	flowsv1beta1 "github.com/netobserv/network-observability-operator/apis/flowcollector/v1beta1"
@@ -63,6 +65,7 @@ func PrepareEnvTest(controllers []manager.Registerer, namespaces []string, baseP
 				filepath.Join(basePath, "..", "vendor", "github.com", "openshift", "api", "console", "v1", "zz_generated.crd-manifests"),
 				filepath.Join(basePath, "..", "vendor", "github.com", "openshift", "api", "config", "v1", "zz_generated.crd-manifests"),
 				filepath.Join(basePath, "..", "vendor", "github.com", "openshift", "api", "operator", "v1", "zz_generated.crd-manifests"),
+				filepath.Join(basePath, "..", "vendor", "github.com", "openshift", "api", "security", "v1", "zz_generated.crd-manifests"),
 				filepath.Join(basePath, "..", "test-assets"),
 			},
 			CleanUpAfterUse: true,
@@ -107,6 +110,9 @@ func PrepareEnvTest(controllers []manager.Registerer, namespaces []string, baseP
 	Expect(err).NotTo(HaveOccurred())
 
 	err = monitoringv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = securityv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})

--- a/vendor/github.com/openshift/api/security/v1/zz_generated.crd-manifests/0000_03_config-operator_01_securitycontextconstraints.crd.yaml
+++ b/vendor/github.com/openshift/api/security/v1/zz_generated.crd-manifests/0000_03_config-operator_01_securitycontextconstraints.crd.yaml
@@ -1,0 +1,366 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
+  name: securitycontextconstraints.security.openshift.io
+spec:
+  group: security.openshift.io
+  names:
+    kind: SecurityContextConstraints
+    listKind: SecurityContextConstraintsList
+    plural: securitycontextconstraints
+    singular: securitycontextconstraints
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Determines if a container can request to be run as privileged
+      jsonPath: .allowPrivilegedContainer
+      name: Priv
+      type: string
+    - description: A list of capabilities that can be requested to add to the container
+      jsonPath: .allowedCapabilities
+      name: Caps
+      type: string
+    - description: Strategy that will dictate what labels will be set in the SecurityContext
+      jsonPath: .seLinuxContext.type
+      name: SELinux
+      type: string
+    - description: Strategy that will dictate what RunAsUser is used in the SecurityContext
+      jsonPath: .runAsUser.type
+      name: RunAsUser
+      type: string
+    - description: Strategy that will dictate what fs group is used by the SecurityContext
+      jsonPath: .fsGroup.type
+      name: FSGroup
+      type: string
+    - description: Strategy that will dictate what supplemental groups are used by
+        the SecurityContext
+      jsonPath: .supplementalGroups.type
+      name: SupGroup
+      type: string
+    - description: Sort order of SCCs
+      jsonPath: .priority
+      name: Priority
+      type: string
+    - description: Force containers to run with a read only root file system
+      jsonPath: .readOnlyRootFilesystem
+      name: ReadOnlyRootFS
+      type: string
+    - description: White list of allowed volume plugins
+      jsonPath: .volumes
+      name: Volumes
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "SecurityContextConstraints governs the ability to make requests
+          that affect the SecurityContext that will be applied to a container. For
+          historical reasons SCC was exposed under the core Kubernetes API group.
+          That exposure is deprecated and will be removed in a future release - users
+          should instead use the security.openshift.io group to manage SecurityContextConstraints.
+          \n Compatibility level 1: Stable within a major release for a minimum of
+          12 months or 3 minor releases (whichever is longer)."
+        properties:
+          allowHostDirVolumePlugin:
+            description: AllowHostDirVolumePlugin determines if the policy allow containers
+              to use the HostDir volume plugin
+            type: boolean
+          allowHostIPC:
+            description: AllowHostIPC determines if the policy allows host ipc in
+              the containers.
+            type: boolean
+          allowHostNetwork:
+            description: AllowHostNetwork determines if the policy allows the use
+              of HostNetwork in the pod spec.
+            type: boolean
+          allowHostPID:
+            description: AllowHostPID determines if the policy allows host pid in
+              the containers.
+            type: boolean
+          allowHostPorts:
+            description: AllowHostPorts determines if the policy allows host ports
+              in the containers.
+            type: boolean
+          allowPrivilegeEscalation:
+            description: AllowPrivilegeEscalation determines if a pod can request
+              to allow privilege escalation. If unspecified, defaults to true.
+            nullable: true
+            type: boolean
+          allowPrivilegedContainer:
+            description: AllowPrivilegedContainer determines if a container can request
+              to be run as privileged.
+            type: boolean
+          allowedCapabilities:
+            description: AllowedCapabilities is a list of capabilities that can be
+              requested to add to the container. Capabilities in this field maybe
+              added at the pod author's discretion. You must not list a capability
+              in both AllowedCapabilities and RequiredDropCapabilities. To allow all
+              capabilities you may use '*'.
+            items:
+              description: Capability represent POSIX capabilities type
+              type: string
+            nullable: true
+            type: array
+          allowedFlexVolumes:
+            description: AllowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty
+              or nil indicates that all Flexvolumes may be used.  This parameter is
+              effective only when the usage of the Flexvolumes is allowed in the "Volumes"
+              field.
+            items:
+              description: AllowedFlexVolume represents a single Flexvolume that is
+                allowed to be used.
+              properties:
+                driver:
+                  description: Driver is the name of the Flexvolume driver.
+                  type: string
+              required:
+              - driver
+              type: object
+            nullable: true
+            type: array
+          allowedUnsafeSysctls:
+            description: "AllowedUnsafeSysctls is a list of explicitly allowed unsafe
+              sysctls, defaults to none. Each entry is either a plain sysctl name
+              or ends in \"*\" in which case it is considered as a prefix of allowed
+              sysctls. Single * means all unsafe sysctls are allowed. Kubelet has
+              to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
+              \n Examples: e.g. \"foo/*\" allows \"foo/bar\", \"foo/baz\", etc. e.g.
+              \"foo.*\" allows \"foo.bar\", \"foo.baz\", etc."
+            items:
+              type: string
+            nullable: true
+            type: array
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          defaultAddCapabilities:
+            description: DefaultAddCapabilities is the default set of capabilities
+              that will be added to the container unless the pod spec specifically
+              drops the capability.  You may not list a capabiility in both DefaultAddCapabilities
+              and RequiredDropCapabilities.
+            items:
+              description: Capability represent POSIX capabilities type
+              type: string
+            nullable: true
+            type: array
+          defaultAllowPrivilegeEscalation:
+            description: DefaultAllowPrivilegeEscalation controls the default setting
+              for whether a process can gain more privileges than its parent process.
+            nullable: true
+            type: boolean
+          forbiddenSysctls:
+            description: "ForbiddenSysctls is a list of explicitly forbidden sysctls,
+              defaults to none. Each entry is either a plain sysctl name or ends in
+              \"*\" in which case it is considered as a prefix of forbidden sysctls.
+              Single * means all sysctls are forbidden. \n Examples: e.g. \"foo/*\"
+              forbids \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" forbids \"foo.bar\",
+              \"foo.baz\", etc."
+            items:
+              type: string
+            nullable: true
+            type: array
+          fsGroup:
+            description: FSGroup is the strategy that will dictate what fs group is
+              used by the SecurityContext.
+            nullable: true
+            properties:
+              ranges:
+                description: Ranges are the allowed ranges of fs groups.  If you would
+                  like to force a single fs group then supply a single range with
+                  the same start and end.
+                items:
+                  description: 'IDRange provides a min/max of an allowed range of
+                    IDs. TODO: this could be reused for UIDs.'
+                  properties:
+                    max:
+                      description: Max is the end of the range, inclusive.
+                      format: int64
+                      type: integer
+                    min:
+                      description: Min is the start of the range, inclusive.
+                      format: int64
+                      type: integer
+                  type: object
+                type: array
+              type:
+                description: Type is the strategy that will dictate what FSGroup is
+                  used in the SecurityContext.
+                type: string
+            type: object
+          groups:
+            description: The groups that have permission to use this security context
+              constraints
+            items:
+              type: string
+            nullable: true
+            type: array
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          priority:
+            description: Priority influences the sort order of SCCs when evaluating
+              which SCCs to try first for a given pod request based on access in the
+              Users and Groups fields.  The higher the int, the higher priority. An
+              unset value is considered a 0 priority. If scores for multiple SCCs
+              are equal they will be sorted from most restrictive to least restrictive.
+              If both priorities and restrictions are equal the SCCs will be sorted
+              by name.
+            format: int32
+            nullable: true
+            type: integer
+          readOnlyRootFilesystem:
+            description: ReadOnlyRootFilesystem when set to true will force containers
+              to run with a read only root file system.  If the container specifically
+              requests to run with a non-read only root file system the SCC should
+              deny the pod. If set to false the container may run with a read only
+              root file system if it wishes but it will not be forced to.
+            type: boolean
+          requiredDropCapabilities:
+            description: RequiredDropCapabilities are the capabilities that will be
+              dropped from the container.  These are required to be dropped and cannot
+              be added.
+            items:
+              description: Capability represent POSIX capabilities type
+              type: string
+            nullable: true
+            type: array
+          runAsUser:
+            description: RunAsUser is the strategy that will dictate what RunAsUser
+              is used in the SecurityContext.
+            nullable: true
+            properties:
+              type:
+                description: Type is the strategy that will dictate what RunAsUser
+                  is used in the SecurityContext.
+                type: string
+              uid:
+                description: UID is the user id that containers must run as.  Required
+                  for the MustRunAs strategy if not using namespace/service account
+                  allocated uids.
+                format: int64
+                type: integer
+              uidRangeMax:
+                description: UIDRangeMax defines the max value for a strategy that
+                  allocates by range.
+                format: int64
+                type: integer
+              uidRangeMin:
+                description: UIDRangeMin defines the min value for a strategy that
+                  allocates by range.
+                format: int64
+                type: integer
+            type: object
+          seLinuxContext:
+            description: SELinuxContext is the strategy that will dictate what labels
+              will be set in the SecurityContext.
+            nullable: true
+            properties:
+              seLinuxOptions:
+                description: seLinuxOptions required to run as; required for MustRunAs
+                properties:
+                  level:
+                    description: Level is SELinux level label that applies to the
+                      container.
+                    type: string
+                  role:
+                    description: Role is a SELinux role label that applies to the
+                      container.
+                    type: string
+                  type:
+                    description: Type is a SELinux type label that applies to the
+                      container.
+                    type: string
+                  user:
+                    description: User is a SELinux user label that applies to the
+                      container.
+                    type: string
+                type: object
+              type:
+                description: Type is the strategy that will dictate what SELinux context
+                  is used in the SecurityContext.
+                type: string
+            type: object
+          seccompProfiles:
+            description: "SeccompProfiles lists the allowed profiles that may be set
+              for the pod or container's seccomp annotations.  An unset (nil) or empty
+              value means that no profiles may be specifid by the pod or container.\tThe
+              wildcard '*' may be used to allow all profiles.  When used to generate
+              a value for a pod the first non-wildcard profile will be used as the
+              default."
+            items:
+              type: string
+            nullable: true
+            type: array
+          supplementalGroups:
+            description: SupplementalGroups is the strategy that will dictate what
+              supplemental groups are used by the SecurityContext.
+            nullable: true
+            properties:
+              ranges:
+                description: Ranges are the allowed ranges of supplemental groups.  If
+                  you would like to force a single supplemental group then supply
+                  a single range with the same start and end.
+                items:
+                  description: 'IDRange provides a min/max of an allowed range of
+                    IDs. TODO: this could be reused for UIDs.'
+                  properties:
+                    max:
+                      description: Max is the end of the range, inclusive.
+                      format: int64
+                      type: integer
+                    min:
+                      description: Min is the start of the range, inclusive.
+                      format: int64
+                      type: integer
+                  type: object
+                type: array
+              type:
+                description: Type is the strategy that will dictate what supplemental
+                  groups is used in the SecurityContext.
+                type: string
+            type: object
+          users:
+            description: The users who have permissions to use this security context
+              constraints
+            items:
+              type: string
+            nullable: true
+            type: array
+          volumes:
+            description: Volumes is a white list of allowed volume plugins.  FSType
+              corresponds directly with the field names of a VolumeSource (azureFile,
+              configMap, emptyDir).  To allow all volumes you may use "*". To allow
+              no volumes, set to ["none"].
+            items:
+              description: FS Type gives strong typing to different file systems that
+                are used by volumes.
+              type: string
+            nullable: true
+            type: array
+        required:
+        - allowHostDirVolumePlugin
+        - allowHostIPC
+        - allowHostNetwork
+        - allowHostPID
+        - allowHostPorts
+        - allowPrivilegedContainer
+        - allowedCapabilities
+        - defaultAddCapabilities
+        - priority
+        - readOnlyRootFilesystem
+        - requiredDropCapabilities
+        - volumes
+        type: object
+    served: true
+    storage: true

--- a/vendor/github.com/openshift/api/security/v1/zz_generated.crd-manifests/doc.go
+++ b/vendor/github.com/openshift/api/security/v1/zz_generated.crd-manifests/doc.go
@@ -1,0 +1,1 @@
+package security_v1_crdmanifests

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -157,6 +157,7 @@ github.com/openshift/api/console/v1/zz_generated.crd-manifests
 github.com/openshift/api/operator/v1
 github.com/openshift/api/operator/v1/zz_generated.crd-manifests
 github.com/openshift/api/security/v1
+github.com/openshift/api/security/v1/zz_generated.crd-manifests
 # github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors


### PR DESCRIPTION
There was a wrong assumption that if ServiceMonitor api is installed then it's openshift. ServiceMonitor is an API from upstream prometheus. Fix it so openshift dashboards are only installed when running on openshift.

Add openshift security v1 API to envtests as this is used to detect openshift.

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
