### PR TITLE
NETOBSERV-1689 Allow multi-tenant Prometheus queries

### DIFF
--- a/controllers/consoleplugin/config/config.go
+++ b/controllers/consoleplugin/config/config.go
@@ -40,6 +40,7 @@ type LokiConfig struct {
 
 type PrometheusConfig struct {
 	URL              string       `yaml:"url" json:"url"`
+	DevURL           string       `yaml:"devUrl,omitempty" json:"devUrl,omitempty"`
 	Timeout          api.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 	TokenPath        string       `yaml:"tokenPath,omitempty" json:"tokenPath,omitempty"`
 	SkipTLS          bool         `yaml:"skipTls,omitempty" json:"skipTls,omitempty"`

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -380,7 +380,8 @@ func (b *builder) getPromConfig(ctx context.Context) cfg.PrometheusConfig {
 	}
 	if b.desired.Prometheus.Querier.Mode == "" || b.desired.Prometheus.Querier.Mode == flowslatest.PromModeAuto {
 		if b.info.UseOpenShiftSCC /* aka IsOpenShift */ {
-			config.URL = "https://thanos-querier.openshift-monitoring.svc:9091/"
+			config.URL = "https://thanos-querier.openshift-monitoring.svc:9091/"    // requires cluster-monitoringv-view cluster role
+			config.DevURL = "https://thanos-querier.openshift-monitoring.svc:9092/" // restricted to a particular namespace
 			config.ForwardUserToken = true
 			tls = flowslatest.ClientTLS{
 				Enable: true,

--- a/controllers/flp/flp_pipeline_builder.go
+++ b/controllers/flp/flp_pipeline_builder.go
@@ -224,14 +224,12 @@ func (b *PipelineBuilder) AddProcessorStages() error {
 	}
 
 	if len(flpMetrics) > 0 {
-		namespaceStage := b.addPromMetricsNamespace(enrichedStage, &flpMetrics)
-
 		// prometheus stage (encode) configuration
 		promEncode := api.PromEncode{
 			Prefix:  "netobserv_",
 			Metrics: flpMetrics,
 		}
-		namespaceStage.EncodePrometheus("prometheus", promEncode)
+		enrichedStage.EncodePrometheus("prometheus", promEncode)
 	}
 
 	b.addCustomExportStages(&enrichedStage, flpMetrics)
@@ -439,24 +437,6 @@ func (b *PipelineBuilder) addTransformFilter(lastStage config.PipelineBuilderSta
 			Rules: transformFilterRules,
 		})
 	}
-	return lastStage
-}
-
-func (b *PipelineBuilder) addPromMetricsNamespace(lastStage config.PipelineBuilderStage, flpMetrics *[]api.MetricsItem) config.PipelineBuilderStage {
-	// developer console namespace hack until https://issues.redhat.com/browse/NETOBSERV-1701 implementation
-	lastStage = lastStage.TransformGeneric("namespace-transform", api.TransformGeneric{
-		Policy: "preserve_original_keys",
-		Rules: []api.GenericTransformRule{{
-			Input:  "SrcK8S_Namespace",
-			Output: "namespace",
-		}},
-	})
-
-	for i := range *flpMetrics {
-		fm := (*flpMetrics)[i]
-		fm.Labels = append(fm.Labels, "namespace")
-	}
-
 	return lastStage
 }
 

--- a/controllers/flp/flp_pipeline_builder.go
+++ b/controllers/flp/flp_pipeline_builder.go
@@ -224,12 +224,14 @@ func (b *PipelineBuilder) AddProcessorStages() error {
 	}
 
 	if len(flpMetrics) > 0 {
+		namespaceStage := b.addPromMetricsNamespace(enrichedStage, &flpMetrics)
+
 		// prometheus stage (encode) configuration
 		promEncode := api.PromEncode{
 			Prefix:  "netobserv_",
 			Metrics: flpMetrics,
 		}
-		enrichedStage.EncodePrometheus("prometheus", promEncode)
+		namespaceStage.EncodePrometheus("prometheus", promEncode)
 	}
 
 	b.addCustomExportStages(&enrichedStage, flpMetrics)
@@ -437,6 +439,24 @@ func (b *PipelineBuilder) addTransformFilter(lastStage config.PipelineBuilderSta
 			Rules: transformFilterRules,
 		})
 	}
+	return lastStage
+}
+
+func (b *PipelineBuilder) addPromMetricsNamespace(lastStage config.PipelineBuilderStage, flpMetrics *[]api.MetricsItem) config.PipelineBuilderStage {
+	// developer console namespace hack until https://issues.redhat.com/browse/NETOBSERV-1701 implementation
+	lastStage = lastStage.TransformGeneric("namespace-transform", api.TransformGeneric{
+		Policy: "preserve_original_keys",
+		Rules: []api.GenericTransformRule{{
+			Input:  "SrcK8S_Namespace",
+			Output: "namespace",
+		}},
+	})
+
+	for i := range *flpMetrics {
+		fm := (*flpMetrics)[i]
+		fm.Labels = append(fm.Labels, "namespace")
+	}
+
 	return lastStage
 }
 


### PR DESCRIPTION
## Description

- Append `namespace` using `metricRelabelConfigs` in prometheus metrics
- Add `devUrl` to console config

/!\ this doesn't work with user workload monitoring, you need to enable cluster monitoring
```
make set-release-kind-downstream
```

User need to have permission to `metrics.k8s.io/pods`. Example for user `test` in `netobserv` namespace:
```
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: metrics
  namespace: netobserv
rules:
  - verbs:
      - create
    apiGroups:
      - metrics.k8s.io
    resources:
      - pods
---
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: metrics
  namespace: netobserv
subjects:
  - kind: User
    apiGroup: rbac.authorization.k8s.io
    name: test
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: metrics
```

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
