### PR TITLE
NETOBSERV-1746: Adapt health dashboard to flows metrics enabled

### DIFF
--- a/controllers/monitoring/monitoring_controller.go
+++ b/controllers/monitoring/monitoring_controller.go
@@ -139,7 +139,8 @@ func (r *Reconciler) reconcile(ctx context.Context, clh *helper.Client, desired 
 
 		// Build desired dashboards
 		cms := buildFlowMetricsDashboards(allMetrics)
-		if desiredHealthDashboardCM, del, err := buildHealthDashboard(ns); err != nil {
+		nsFlowsMetric := getNamespacedFlowsMetric(allMetrics)
+		if desiredHealthDashboardCM, del, err := buildHealthDashboard(ns, nsFlowsMetric); err != nil {
 			return err
 		} else if !del {
 			cms = append(cms, desiredHealthDashboardCM)
@@ -161,6 +162,15 @@ func (r *Reconciler) reconcile(ctx context.Context, clh *helper.Client, desired 
 	}
 
 	return nil
+}
+
+func getNamespacedFlowsMetric(metrics []metricslatest.FlowMetric) string {
+	for i := range metrics {
+		if metrics[i].Spec.MetricName == "namespace_flows_total" {
+			return "netobserv_namespace_flows_total"
+		}
+	}
+	return "netobserv_workload_flows_total"
 }
 
 func filterOwned(list *corev1.ConfigMapList) {

--- a/controllers/monitoring/monitoring_objects.go
+++ b/controllers/monitoring/monitoring_objects.go
@@ -102,8 +102,8 @@ func buildFlowMetricsDashboards(metrics []metricslatest.FlowMetric) []*corev1.Co
 	return cms
 }
 
-func buildHealthDashboard(namespace string) (*corev1.ConfigMap, bool, error) {
-	dashboard, err := dashboards.CreateHealthDashboard(namespace)
+func buildHealthDashboard(namespace, nsFlowsMetric string) (*corev1.ConfigMap, bool, error) {
+	dashboard, err := dashboards.CreateHealthDashboard(namespace, nsFlowsMetric)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/dashboards/dashboard_test.go
+++ b/pkg/dashboards/dashboard_test.go
@@ -164,7 +164,7 @@ func TestCreateFlowMetricsDashboard_DefaultList(t *testing.T) {
 func TestCreateHealthDashboard_Default(t *testing.T) {
 	assert := assert.New(t)
 
-	js, err := CreateHealthDashboard("netobserv")
+	js, err := CreateHealthDashboard("netobserv", "netobserv_namespace_flows_total")
 	assert.NoError(err)
 
 	d, err := FromBytes([]byte(js))


### PR DESCRIPTION
Switch to using "workload_flows_total" when needed

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
