### PR TITLE
NETOBSERV-1772: allow prom label remapping

### DIFF
--- a/apis/flowmetrics/v1alpha1/flowmetric_types.go
+++ b/apis/flowmetrics/v1alpha1/flowmetric_types.go
@@ -93,6 +93,10 @@ type FlowMetricSpec struct {
 	// +optional
 	Labels []string `json:"labels"`
 
+	// `remap` allows to use different names for the generated metric labels than the flow fields. Use the origin flow fields as keys, and the desired label names as values.
+	// +optional
+	Remap map[string]string `json:"remap"`
+
 	// Filter for ingress, egress or any direction flows.
 	// When set to `Ingress`, it is equivalent to adding the regular expression filter on `FlowDirection`: `0|2`.
 	// When set to `Egress`, it is equivalent to adding the regular expression filter on `FlowDirection`: `1|2`.

--- a/apis/flowmetrics/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/flowmetrics/v1alpha1/zz_generated.deepcopy.go
@@ -117,6 +117,13 @@ func (in *FlowMetricSpec) DeepCopyInto(out *FlowMetricSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Remap != nil {
+		in, out := &in.Remap, &out.Remap
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Buckets != nil {
 		in, out := &in.Buckets, &out.Buckets
 		*out = make([]string, len(*in))

--- a/bundle/manifests/flows.netobserv.io_flowmetrics.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowmetrics.yaml
@@ -211,6 +211,13 @@ spec:
                 description: Name of the metric. In Prometheus, it is automatically
                   prefixed with "netobserv_".
                 type: string
+              remap:
+                additionalProperties:
+                  type: string
+                description: '`remap` allows to use different names for the generated
+                  metric labels than the flow fields. Use the origin flow fields as
+                  keys, and the desired label names as values.'
+                type: object
               type:
                 description: |-
                   Metric type: "Counter" or "Histogram".

--- a/config/crd/bases/flows.netobserv.io_flowmetrics.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowmetrics.yaml
@@ -201,6 +201,13 @@ spec:
                 description: Name of the metric. In Prometheus, it is automatically
                   prefixed with "netobserv_".
                 type: string
+              remap:
+                additionalProperties:
+                  type: string
+                description: '`remap` allows to use different names for the generated
+                  metric labels than the flow fields. Use the origin flow fields as
+                  keys, and the desired label names as values.'
+                type: object
               type:
                 description: |-
                   Metric type: "Counter" or "Histogram".

--- a/config/samples/flowmetrics/dns_requests.yaml
+++ b/config/samples/flowmetrics/dns_requests.yaml
@@ -1,0 +1,25 @@
+# Metric tracking DNS requests
+# More examples in https://github.com/netobserv/network-observability-operator/tree/main/config/samples/flowmetrics
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: dns-requests
+spec:
+  metricName: dns_requests_total
+  type: Counter
+  labels: [SrcK8S_Namespace,SrcK8S_OwnerName,DstK8S_Name,DnsFlagsResponseCode]
+  remap:
+    SrcK8S_Namespace: client_namespace
+    SrcK8S_OwnerName: client
+    DstK8S_Name: server
+    DnsFlagsResponseCode: code
+  filters:
+  - field: SrcK8S_Type
+    value: Pod
+  - field: DstK8S_Type
+    value: Pod
+  - field: DstK8S_Namespace
+    value: "openshift-dns"
+  - field: DstPort
+    value: "^53$|^5353$"
+    matchType: MatchRegex

--- a/config/samples/flowmetrics/dns_responses.yaml
+++ b/config/samples/flowmetrics/dns_responses.yaml
@@ -1,0 +1,25 @@
+# Metric tracking DNS responses
+# More examples in https://github.com/netobserv/network-observability-operator/tree/main/config/samples/flowmetrics
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: dns-responses
+spec:
+  metricName: dns_responses_total
+  type: Counter
+  labels: [DstK8S_Namespace,DstK8S_OwnerName,SrcK8S_Name,DnsFlagsResponseCode]
+  remap:
+    DstK8S_Namespace: client_namespace
+    DstK8S_OwnerName: client
+    SrcK8S_Name: server
+    DnsFlagsResponseCode: code
+  filters:
+  - field: DstK8S_Type
+    value: Pod
+  - field: SrcK8S_Type
+    value: Pod
+  - field: SrcK8S_Namespace
+    value: "openshift-dns"
+  - field: SrcPort
+    value: "^53$|^5353$"
+    matchType: MatchRegex

--- a/controllers/consoleplugin/config/config.go
+++ b/controllers/consoleplugin/config/config.go
@@ -135,7 +135,7 @@ type PluginConfig struct {
 var rawStaticFrontendConfig []byte
 var staticFrontendConfig *FrontendConfig
 
-func LoadStaticFrontendConfig() (FrontendConfig, error) {
+func GetStaticFrontendConfig() (FrontendConfig, error) {
 	if staticFrontendConfig == nil {
 		cfg := FrontendConfig{}
 		err := yaml.Unmarshal(rawStaticFrontendConfig, &cfg)

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -513,7 +513,7 @@ func (b *builder) configMap(ctx context.Context) (*corev1.ConfigMap, string, err
 
 	// configure frontend from embedded static file
 	var err error
-	config.Frontend, err = cfg.LoadStaticFrontendConfig()
+	config.Frontend, err = cfg.GetStaticFrontendConfig()
 	if err != nil {
 		return nil, "", err
 	}

--- a/controllers/consoleplugin/consoleplugin_test.go
+++ b/controllers/consoleplugin/consoleplugin_test.go
@@ -515,7 +515,7 @@ func TestHTTPClientConfig(t *testing.T) {
 }
 
 func TestNoMissingFields(t *testing.T) {
-	cfg, err := config.LoadStaticFrontendConfig()
+	cfg, err := config.GetStaticFrontendConfig()
 	assert.NoError(t, err)
 
 	hasField := func(name string) bool {
@@ -546,7 +546,7 @@ func TestNoMissingFields(t *testing.T) {
 }
 
 func TestFieldsCardinalityWarns(t *testing.T) {
-	cfg, err := config.LoadStaticFrontendConfig()
+	cfg, err := config.GetStaticFrontendConfig()
 	assert.NoError(t, err)
 
 	allowed := []config.CardinalityWarn{config.CardinalityWarnAvoid, config.CardinalityWarnCareful, config.CardinalityWarnFine}

--- a/controllers/flp/flp_pipeline_builder.go
+++ b/controllers/flp/flp_pipeline_builder.go
@@ -250,6 +250,7 @@ func flowMetricToFLP(flowMetric *metricslatest.FlowMetricSpec) (*api.MetricsItem
 		Type:     api.MetricEncodeOperationEnum(strings.ToLower(string(flowMetric.Type))),
 		Filters:  []api.MetricsFilter{},
 		Labels:   flowMetric.Labels,
+		Remap:    flowMetric.Remap,
 		ValueKey: flowMetric.ValueField,
 	}
 	for _, f := range metrics.GetFilters(flowMetric) {

--- a/docs/FlowMetric.md
+++ b/docs/FlowMetric.md
@@ -164,6 +164,13 @@ Refer to the documentation for the list of available fields: https://docs.opensh
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>remap</b></td>
+        <td>map[string]string</td>
+        <td>
+          `remap` allows to use different names for the generated metric labels than the flow fields. Use the origin flow fields as keys, and the desired label names as values.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>valueField</b></td>
         <td>string</td>
         <td>

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/netobserv/network-observability-operator
 
-go 1.22.0
+go 1.22.3
 
 toolchain go1.22.4
 
 require (
 	github.com/go-logr/logr v1.4.2
-	github.com/netobserv/flowlogs-pipeline v1.6.2-community.0.20240902140418-72029f57586d
+	github.com/netobserv/flowlogs-pipeline v1.6.1-crc0.0.20240910083052-f8f7471f1ea6
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.1
 	github.com/openshift/api v0.0.0-20240722135205-ae4f370f361f
@@ -68,7 +68,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.28.0 // indirect
-	golang.org/x/oauth2 v0.21.0 // indirect
+	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sys v0.24.0 // indirect
 	golang.org/x/term v0.23.0 // indirect
 	golang.org/x/text v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/netobserv/flowlogs-pipeline v1.6.2-community.0.20240902140418-72029f57586d h1:SHDs4krgAgQIItjSzYqW5+/2uM/UL05gq1UIJy4Qrvg=
-github.com/netobserv/flowlogs-pipeline v1.6.2-community.0.20240902140418-72029f57586d/go.mod h1:tL3a1xfTmWuD5JroQdtPVi7Ah9FVvmWzPwZ/MQLnlzs=
+github.com/netobserv/flowlogs-pipeline v1.6.1-crc0.0.20240910083052-f8f7471f1ea6 h1:lr7wSAF5a3fQ3PO6qjRIyF5if8AjibUCuV80uKZb5aw=
+github.com/netobserv/flowlogs-pipeline v1.6.1-crc0.0.20240910083052-f8f7471f1ea6/go.mod h1:R5fRUXHd6Nmb9/rdiwL6mZECO7USHypD8etz3oHZWtI=
 github.com/netobserv/prometheus-common v0.55.0-netobserv h1:Fapr74g0S3gRh/kTTyv9Ytm4DJJfFuUTEToiU/np9eg=
 github.com/netobserv/prometheus-common v0.55.0-netobserv/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
 github.com/onsi/ginkgo/v2 v2.20.2 h1:7NVCeyIWROIAheY21RLS+3j2bb52W0W82tkberYytp4=
@@ -162,8 +162,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.28.0 h1:a9JDOJc5GMUJ0+UDqmLT86WiEy7iWyIhz8gz8E4e5hE=
 golang.org/x/net v0.28.0/go.mod h1:yqtgsTWOOnlGLG9GFRrK3++bGOUEkNBoHZc8MEDWPNg=
-golang.org/x/oauth2 v0.21.0 h1:tsimM75w1tF/uws5rbeHzIWxEqElMehnc+iW793zsZs=
-golang.org/x/oauth2 v0.21.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.22.0 h1:BzDx2FehcG7jJwgWLELCdmLuxk2i+x9UDpSiss2u0ZA=
+golang.org/x/oauth2 v0.22.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/helper/cardinality.go
+++ b/pkg/helper/cardinality.go
@@ -8,7 +8,7 @@ import (
 )
 
 func CheckCardinality(labels ...string) (*CardinalityReport, error) {
-	frontendCfg, err := config.LoadStaticFrontendConfig()
+	frontendCfg, err := config.GetStaticFrontendConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helper/helpers.go
+++ b/pkg/helper/helpers.go
@@ -93,13 +93,13 @@ func UnstructuredDuration(in *metav1.Duration) string {
 	return in.ToUnstructured().(string)
 }
 
-func FindFilter(labels []string, isNumber bool) bool {
+func FindFields(labels []string, isNumber bool) bool {
 	type filter struct {
 		exists bool
 		isNum  bool
 	}
 
-	cfg, err := config.LoadStaticFrontendConfig()
+	cfg, err := config.GetStaticFrontendConfig()
 	if err != nil {
 		return false
 	}

--- a/vendor/github.com/netobserv/flowlogs-pipeline/pkg/api/encode_prom.go
+++ b/vendor/github.com/netobserv/flowlogs-pipeline/pkg/api/encode_prom.go
@@ -52,6 +52,7 @@ type MetricsItem struct {
 	Filters    []MetricsFilter           `yaml:"filters" json:"filters" doc:"a list of criteria to filter entries by"`
 	ValueKey   string                    `yaml:"valueKey" json:"valueKey" doc:"entry key from which to resolve metric value"`
 	Labels     []string                  `yaml:"labels" json:"labels" doc:"labels to be associated with the metric"`
+	Remap      map[string]string         `yaml:"remap" json:"remap" doc:"optional remapping of labels"`
 	Buckets    []float64                 `yaml:"buckets" json:"buckets" doc:"histogram buckets"`
 	ValueScale float64                   `yaml:"valueScale,omitempty" json:"valueScale,omitempty" doc:"scale factor of the value (MetricVal := FlowVal / Scale)"`
 }

--- a/vendor/github.com/prometheus/common/config/http_config.go
+++ b/vendor/github.com/prometheus/common/config/http_config.go
@@ -411,6 +411,10 @@ func (c *HTTPClientConfig) Validate() error {
 			return fmt.Errorf("at most one of oauth2 client_secret, client_secret_file & client_secret_ref must be configured")
 		}
 	}
+	// Change empty URL to nil to avoid connection errors
+	if c.ProxyURL.URL != nil && *c.ProxyURL.URL == (url.URL{}) {
+		c.ProxyURL.URL = nil
+	}
 	if err := c.ProxyConfig.Validate(); err != nil {
 		return err
 	}

--- a/vendor/github.com/prometheus/common/config/http_config.go
+++ b/vendor/github.com/prometheus/common/config/http_config.go
@@ -411,10 +411,6 @@ func (c *HTTPClientConfig) Validate() error {
 			return fmt.Errorf("at most one of oauth2 client_secret, client_secret_file & client_secret_ref must be configured")
 		}
 	}
-	// Change empty URL to nil to avoid connection errors
-	if c.ProxyURL.URL != nil && *c.ProxyURL.URL == (url.URL{}) {
-		c.ProxyURL.URL = nil
-	}
 	if err := c.ProxyConfig.Validate(); err != nil {
 		return err
 	}

--- a/vendor/golang.org/x/oauth2/LICENSE
+++ b/vendor/golang.org/x/oauth2/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -10,7 +10,7 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-   * Neither the name of Google Inc. nor the names of its
+   * Neither the name of Google LLC nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -111,8 +111,8 @@ github.com/munnerz/goautoneg
 # github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 ## explicit
 github.com/mwitkow/go-conntrack
-# github.com/netobserv/flowlogs-pipeline v1.6.2-community.0.20240902140418-72029f57586d
-## explicit; go 1.21.0
+# github.com/netobserv/flowlogs-pipeline v1.6.1-crc0.0.20240910083052-f8f7471f1ea6
+## explicit; go 1.22.3
 github.com/netobserv/flowlogs-pipeline/pkg/api
 github.com/netobserv/flowlogs-pipeline/pkg/config
 github.com/netobserv/flowlogs-pipeline/pkg/utils
@@ -237,7 +237,7 @@ golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 golang.org/x/net/internal/timeseries
 golang.org/x/net/trace
-# golang.org/x/oauth2 v0.21.0
+# golang.org/x/oauth2 v0.22.0
 ## explicit; go 1.18
 golang.org/x/oauth2
 golang.org/x/oauth2/clientcredentials
@@ -887,5 +887,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# github.com/prometheus/common v0.48.0 => github.com/netobserv/prometheus-common v0.48.0-netobserv
-# github.com/netobserv/flowlogs-pipeline => ../flowlogs-pipeline

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -887,3 +887,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
+# github.com/prometheus/common v0.48.0 => github.com/netobserv/prometheus-common v0.48.0-netobserv
+# github.com/netobserv/flowlogs-pipeline => ../flowlogs-pipeline


### PR DESCRIPTION
## Description

- Add "remap" to FlowMetrics CRD
- Add examples with DNS requests/responses
- Some variables renamed for more clarity

## Dependencies

FLP: https://github.com/netobserv/flowlogs-pipeline/pull/698

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
