### PR TITLE
NETOBSERV-1779 allow port filtering if protocol not set

### DIFF
--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -499,38 +499,6 @@ func (c *AgentController) configureFlowFilter(filter *flowslatest.EBPFFlowFilter
 			Value: filter.Protocol,
 		})
 		switch filter.Protocol {
-		case "TCP", "UDP", "SCTP":
-			if filter.SourcePorts.Type == intstr.String {
-				config = append(config, corev1.EnvVar{Name: envFilterSourcePortRange,
-					Value: filter.SourcePorts.String(),
-				})
-			}
-			if filter.SourcePorts.Type == intstr.Int {
-				config = append(config, corev1.EnvVar{Name: envFilterSourcePort,
-					Value: strconv.Itoa(filter.SourcePorts.IntValue()),
-				})
-			}
-			if filter.DestPorts.Type == intstr.String {
-				config = append(config, corev1.EnvVar{Name: envFilterDestPortRange,
-					Value: filter.DestPorts.String(),
-				})
-			}
-			if filter.DestPorts.Type == intstr.Int {
-				config = append(config, corev1.EnvVar{Name: envFilterDestPort,
-					Value: strconv.Itoa(filter.DestPorts.IntValue()),
-				})
-			}
-			if filter.Ports.Type == intstr.String {
-				config = append(config, corev1.EnvVar{Name: envFilterPortRange,
-					Value: filter.Ports.String(),
-				})
-			}
-			if filter.Ports.Type == intstr.Int {
-				config = append(config, corev1.EnvVar{Name: envFilterPort,
-					Value: strconv.Itoa(filter.Ports.IntValue()),
-				})
-			}
-
 		case "ICMP", "ICMPv6":
 			if filter.ICMPType != nil && *filter.ICMPType != 0 {
 				config = append(config, corev1.EnvVar{Name: envFilterICMPType,
@@ -543,12 +511,40 @@ func (c *AgentController) configureFlowFilter(filter *flowslatest.EBPFFlowFilter
 			}
 		}
 	}
-
+	if filter.SourcePorts.Type == intstr.String {
+		config = append(config, corev1.EnvVar{Name: envFilterSourcePortRange,
+			Value: filter.SourcePorts.String(),
+		})
+	}
+	if filter.SourcePorts.Type == intstr.Int {
+		config = append(config, corev1.EnvVar{Name: envFilterSourcePort,
+			Value: strconv.Itoa(filter.SourcePorts.IntValue()),
+		})
+	}
+	if filter.DestPorts.Type == intstr.String {
+		config = append(config, corev1.EnvVar{Name: envFilterDestPortRange,
+			Value: filter.DestPorts.String(),
+		})
+	}
+	if filter.DestPorts.Type == intstr.Int {
+		config = append(config, corev1.EnvVar{Name: envFilterDestPort,
+			Value: strconv.Itoa(filter.DestPorts.IntValue()),
+		})
+	}
+	if filter.Ports.Type == intstr.String {
+		config = append(config, corev1.EnvVar{Name: envFilterPortRange,
+			Value: filter.Ports.String(),
+		})
+	}
+	if filter.Ports.Type == intstr.Int {
+		config = append(config, corev1.EnvVar{Name: envFilterPort,
+			Value: strconv.Itoa(filter.Ports.IntValue()),
+		})
+	}
 	if filter.PeerIP != "" {
 		config = append(config, corev1.EnvVar{Name: envFilterPeerIPAddress,
 			Value: filter.PeerIP})
 	}
-
 	if filter.TCPFlags != "" {
 		config = append(config, corev1.EnvVar{Name: envFilterTCPFlags,
 			Value: filter.TCPFlags,

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -498,18 +498,15 @@ func (c *AgentController) configureFlowFilter(filter *flowslatest.EBPFFlowFilter
 		config = append(config, corev1.EnvVar{Name: envFilterProtocol,
 			Value: filter.Protocol,
 		})
-		switch filter.Protocol {
-		case "ICMP", "ICMPv6":
-			if filter.ICMPType != nil && *filter.ICMPType != 0 {
-				config = append(config, corev1.EnvVar{Name: envFilterICMPType,
-					Value: strconv.Itoa(*filter.ICMPType),
-				})
-			}
-			if filter.ICMPCode != nil && *filter.ICMPCode != 0 {
-				config = append(config, corev1.EnvVar{Name: envFilterICMPCode,
-					Value: strconv.Itoa(*filter.ICMPCode)})
-			}
-		}
+	}
+	if filter.ICMPType != nil && *filter.ICMPType != 0 {
+		config = append(config, corev1.EnvVar{Name: envFilterICMPType,
+			Value: strconv.Itoa(*filter.ICMPType),
+		})
+	}
+	if filter.ICMPCode != nil && *filter.ICMPCode != 0 {
+		config = append(config, corev1.EnvVar{Name: envFilterICMPCode,
+			Value: strconv.Itoa(*filter.ICMPCode)})
 	}
 	if filter.SourcePorts.Type == intstr.String {
 		config = append(config, corev1.EnvVar{Name: envFilterSourcePortRange,


### PR DESCRIPTION
## Description

Allow port filtering if protocol not set

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
