### PR TITLE
NETOBSERV-1803: Allow flow filtering for L4 protocols using two ports

### DIFF
--- a/apis/flowcollector/v1beta1/flowcollector_types.go
+++ b/apis/flowcollector/v1beta1/flowcollector_types.go
@@ -218,20 +218,23 @@ type EBPFFlowFilter struct {
 	TCPFlags string `json:"tcpFlags,omitempty"`
 
 	// SourcePorts defines the source ports to filter flows by.
-	// To filter a single port, set a single port as an integer value. For example sourcePorts: 80.
-	// To filter a range of ports, use a "start-end" range, string format. For example sourcePorts: "80-100".
+	// To filter a single port, set a single port as an integer value. For example, sourcePorts: 80.
+	// To filter a range of ports, use a "start-end" range in string format. For example, sourcePorts: "80-100".
+	// To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
 	// +optional
 	SourcePorts intstr.IntOrString `json:"sourcePorts,omitempty"`
 
 	// DestPorts defines the destination ports to filter flows by.
-	// To filter a single port, set a single port as an integer value. For example destPorts: 80.
-	// To filter a range of ports, use a "start-end" range, string format. For example destPorts: "80-100".
+	// To filter a single port, set a single port as an integer value. For example, destPorts: 80.
+	// To filter a range of ports, use a "start-end" range in string format. For example, destPorts: "80-100".
+	// To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
 	// +optional
 	DestPorts intstr.IntOrString `json:"destPorts,omitempty"`
 
 	// Ports defines the ports to filter flows by. it can be user for either source or destination ports.
-	// To filter a single port, set a single port as an integer value. For example ports: 80.
-	// To filter a range of ports, use a "start-end" range, string format. For example ports: "80-10
+	// To filter a single port, set a single port as an integer value. For example, ports: 80.
+	// To filter a range of ports, use a "start-end" range in string format. For example, ports: "80-100".
+	// To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
 	Ports intstr.IntOrString `json:"ports,omitempty"`
 
 	// PeerIP defines the IP address to filter flows by.

--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -242,20 +242,23 @@ type EBPFFlowFilter struct {
 	TCPFlags string `json:"tcpFlags,omitempty"`
 
 	// `sourcePorts` defines the source ports to filter flows by.
-	// To filter a single port, set a single port as an integer value. For example: `sourcePorts: 80`.
-	// To filter a range of ports, use a "start-end" range in string format. For example: `sourcePorts: "80-100"`.
+	// To filter a single port, set a single port as an integer value. For example, `sourcePorts: 80`.
+	// To filter a range of ports, use a "start-end" range in string format. For example, `sourcePorts: "80-100"`.
+	// To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
 	// +optional
 	SourcePorts intstr.IntOrString `json:"sourcePorts,omitempty"`
 
 	// `destPorts` defines the destination ports to filter flows by.
-	// To filter a single port, set a single port as an integer value. For example: `destPorts: 80`.
-	// To filter a range of ports, use a "start-end" range in string format. For example: `destPorts: "80-100"`.
+	// To filter a single port, set a single port as an integer value. For example, `destPorts: 80`.
+	// To filter a range of ports, use a "start-end" range in string format. For example, `destPorts: "80-100"`.
+	// To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
 	// +optional
 	DestPorts intstr.IntOrString `json:"destPorts,omitempty"`
 
 	// `ports` defines the ports to filter flows by. It is used both for source and destination ports.
-	// To filter a single port, set a single port as an integer value. For example: `ports: 80`.
-	// To filter a range of ports, use a "start-end" range in string format. For example: `ports: "80-100"`.
+	// To filter a single port, set a single port as an integer value. For example, `ports: 80`.
+	// To filter a range of ports, use a "start-end" range in string format. For example, `ports: "80-100"`.
+	// To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
 	Ports intstr.IntOrString `json:"ports,omitempty"`
 
 	// `peerIP` defines the IP address to filter flows by.

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -171,8 +171,9 @@ spec:
                             - type: string
                             description: |-
                               DestPorts defines the destination ports to filter flows by.
-                              To filter a single port, set a single port as an integer value. For example destPorts: 80.
-                              To filter a range of ports, use a "start-end" range, string format. For example destPorts: "80-100".
+                              To filter a single port, set a single port as an integer value. For example, destPorts: 80.
+                              To filter a range of ports, use a "start-end" range in string format. For example, destPorts: "80-100".
+                              To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                             x-kubernetes-int-or-string: true
                           direction:
                             description: Direction defines the direction to filter
@@ -204,8 +205,9 @@ spec:
                             - type: string
                             description: |-
                               Ports defines the ports to filter flows by. it can be user for either source or destination ports.
-                              To filter a single port, set a single port as an integer value. For example ports: 80.
-                              To filter a range of ports, use a "start-end" range, string format. For example ports: "80-10
+                              To filter a single port, set a single port as an integer value. For example, ports: 80.
+                              To filter a range of ports, use a "start-end" range in string format. For example, ports: "80-100".
+                              To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                             x-kubernetes-int-or-string: true
                           protocol:
                             description: Protocol defines the protocol to filter flows
@@ -223,8 +225,9 @@ spec:
                             - type: string
                             description: |-
                               SourcePorts defines the source ports to filter flows by.
-                              To filter a single port, set a single port as an integer value. For example sourcePorts: 80.
-                              To filter a range of ports, use a "start-end" range, string format. For example sourcePorts: "80-100".
+                              To filter a single port, set a single port as an integer value. For example, sourcePorts: 80.
+                              To filter a range of ports, use a "start-end" range in string format. For example, sourcePorts: "80-100".
+                              To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                             x-kubernetes-int-or-string: true
                           tcpFlags:
                             description: '`tcpFlags` defines the TCP flags to filter
@@ -3752,8 +3755,9 @@ spec:
                             - type: string
                             description: |-
                               `destPorts` defines the destination ports to filter flows by.
-                              To filter a single port, set a single port as an integer value. For example: `destPorts: 80`.
-                              To filter a range of ports, use a "start-end" range in string format. For example: `destPorts: "80-100"`.
+                              To filter a single port, set a single port as an integer value. For example, `destPorts: 80`.
+                              To filter a range of ports, use a "start-end" range in string format. For example, `destPorts: "80-100"`.
+                              To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                             x-kubernetes-int-or-string: true
                           direction:
                             description: '`direction` defines the direction to filter
@@ -3786,8 +3790,9 @@ spec:
                             - type: string
                             description: |-
                               `ports` defines the ports to filter flows by. It is used both for source and destination ports.
-                              To filter a single port, set a single port as an integer value. For example: `ports: 80`.
-                              To filter a range of ports, use a "start-end" range in string format. For example: `ports: "80-100"`.
+                              To filter a single port, set a single port as an integer value. For example, `ports: 80`.
+                              To filter a range of ports, use a "start-end" range in string format. For example, `ports: "80-100"`.
+                              To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                             x-kubernetes-int-or-string: true
                           protocol:
                             description: '`protocol` defines the protocol to filter
@@ -3805,8 +3810,9 @@ spec:
                             - type: string
                             description: |-
                               `sourcePorts` defines the source ports to filter flows by.
-                              To filter a single port, set a single port as an integer value. For example: `sourcePorts: 80`.
-                              To filter a range of ports, use a "start-end" range in string format. For example: `sourcePorts: "80-100"`.
+                              To filter a single port, set a single port as an integer value. For example, `sourcePorts: 80`.
+                              To filter a range of ports, use a "start-end" range in string format. For example, `sourcePorts: "80-100"`.
+                              To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                             x-kubernetes-int-or-string: true
                           tcpFlags:
                             description: '`tcpFlags` defines the TCP flags to filter

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -154,8 +154,9 @@ spec:
                                 - type: string
                               description: |-
                                 DestPorts defines the destination ports to filter flows by.
-                                To filter a single port, set a single port as an integer value. For example destPorts: 80.
-                                To filter a range of ports, use a "start-end" range, string format. For example destPorts: "80-100".
+                                To filter a single port, set a single port as an integer value. For example, destPorts: 80.
+                                To filter a range of ports, use a "start-end" range in string format. For example, destPorts: "80-100".
+                                To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                               x-kubernetes-int-or-string: true
                             direction:
                               description: Direction defines the direction to filter flows by.
@@ -183,8 +184,9 @@ spec:
                                 - type: string
                               description: |-
                                 Ports defines the ports to filter flows by. it can be user for either source or destination ports.
-                                To filter a single port, set a single port as an integer value. For example ports: 80.
-                                To filter a range of ports, use a "start-end" range, string format. For example ports: "80-10
+                                To filter a single port, set a single port as an integer value. For example, ports: 80.
+                                To filter a range of ports, use a "start-end" range in string format. For example, ports: "80-100".
+                                To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                               x-kubernetes-int-or-string: true
                             protocol:
                               description: Protocol defines the protocol to filter flows by.
@@ -201,8 +203,9 @@ spec:
                                 - type: string
                               description: |-
                                 SourcePorts defines the source ports to filter flows by.
-                                To filter a single port, set a single port as an integer value. For example sourcePorts: 80.
-                                To filter a range of ports, use a "start-end" range, string format. For example sourcePorts: "80-100".
+                                To filter a single port, set a single port as an integer value. For example, sourcePorts: 80.
+                                To filter a range of ports, use a "start-end" range in string format. For example, sourcePorts: "80-100".
+                                To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                               x-kubernetes-int-or-string: true
                             tcpFlags:
                               description: '`tcpFlags` defines the TCP flags to filter flows by.'
@@ -3456,8 +3459,9 @@ spec:
                                 - type: string
                               description: |-
                                 `destPorts` defines the destination ports to filter flows by.
-                                To filter a single port, set a single port as an integer value. For example: `destPorts: 80`.
-                                To filter a range of ports, use a "start-end" range in string format. For example: `destPorts: "80-100"`.
+                                To filter a single port, set a single port as an integer value. For example, `destPorts: 80`.
+                                To filter a range of ports, use a "start-end" range in string format. For example, `destPorts: "80-100"`.
+                                To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                               x-kubernetes-int-or-string: true
                             direction:
                               description: '`direction` defines the direction to filter flows by.'
@@ -3485,8 +3489,9 @@ spec:
                                 - type: string
                               description: |-
                                 `ports` defines the ports to filter flows by. It is used both for source and destination ports.
-                                To filter a single port, set a single port as an integer value. For example: `ports: 80`.
-                                To filter a range of ports, use a "start-end" range in string format. For example: `ports: "80-100"`.
+                                To filter a single port, set a single port as an integer value. For example, `ports: 80`.
+                                To filter a range of ports, use a "start-end" range in string format. For example, `ports: "80-100"`.
+                                To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                               x-kubernetes-int-or-string: true
                             protocol:
                               description: '`protocol` defines the protocol to filter flows by.'
@@ -3503,8 +3508,9 @@ spec:
                                 - type: string
                               description: |-
                                 `sourcePorts` defines the source ports to filter flows by.
-                                To filter a single port, set a single port as an integer value. For example: `sourcePorts: 80`.
-                                To filter a range of ports, use a "start-end" range in string format. For example: `sourcePorts: "80-100"`.
+                                To filter a single port, set a single port as an integer value. For example, `sourcePorts: 80`.
+                                To filter a range of ports, use a "start-end" range in string format. For example, `sourcePorts: "80-100"`.
+                                To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                               x-kubernetes-int-or-string: true
                             tcpFlags:
                               description: '`tcpFlags` defines the TCP flags to filter flows by.'

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -74,6 +74,9 @@ const (
 	envFilterSourcePortRange      = "FILTER_SOURCE_PORT_RANGE"
 	envFilterDestPortRange        = "FILTER_DESTINATION_PORT_RANGE"
 	envFilterPortRange            = "FILTER_PORT_RANGE"
+	envFilterSourcePorts          = "FILTER_SOURCE_PORTS"
+	envFilterDestPorts            = "FILTER_DESTINATION_PORTS"
+	envFilterPorts                = "FILTER_PORTS"
 	envFilterICMPType             = "FILTER_ICMP_TYPE"
 	envFilterICMPCode             = "FILTER_ICMP_CODE"
 	envFilterPeerIPAddress        = "FILTER_PEER_IP"
@@ -478,6 +481,7 @@ func (c *AgentController) envConfig(ctx context.Context, coll *flowslatest.FlowC
 	return config, nil
 }
 
+// nolint:cyclop
 func (c *AgentController) configureFlowFilter(filter *flowslatest.EBPFFlowFilter, config []corev1.EnvVar) []corev1.EnvVar {
 	if filter.CIDR != "" {
 		config = append(config, corev1.EnvVar{Name: envFilterIPCIDR,
@@ -509,9 +513,16 @@ func (c *AgentController) configureFlowFilter(filter *flowslatest.EBPFFlowFilter
 			Value: strconv.Itoa(*filter.ICMPCode)})
 	}
 	if filter.SourcePorts.Type == intstr.String {
-		config = append(config, corev1.EnvVar{Name: envFilterSourcePortRange,
-			Value: filter.SourcePorts.String(),
-		})
+		if strings.Contains(filter.SourcePorts.String(), "-") {
+			config = append(config, corev1.EnvVar{Name: envFilterSourcePortRange,
+				Value: filter.SourcePorts.String(),
+			})
+		}
+		if strings.Contains(filter.SourcePorts.String(), ",") {
+			config = append(config, corev1.EnvVar{Name: envFilterSourcePorts,
+				Value: filter.SourcePorts.String(),
+			})
+		}
 	}
 	if filter.SourcePorts.Type == intstr.Int {
 		config = append(config, corev1.EnvVar{Name: envFilterSourcePort,
@@ -519,9 +530,16 @@ func (c *AgentController) configureFlowFilter(filter *flowslatest.EBPFFlowFilter
 		})
 	}
 	if filter.DestPorts.Type == intstr.String {
-		config = append(config, corev1.EnvVar{Name: envFilterDestPortRange,
-			Value: filter.DestPorts.String(),
-		})
+		if strings.Contains(filter.DestPorts.String(), "-") {
+			config = append(config, corev1.EnvVar{Name: envFilterDestPortRange,
+				Value: filter.DestPorts.String(),
+			})
+		}
+		if strings.Contains(filter.DestPorts.String(), ",") {
+			config = append(config, corev1.EnvVar{Name: envFilterDestPorts,
+				Value: filter.DestPorts.String(),
+			})
+		}
 	}
 	if filter.DestPorts.Type == intstr.Int {
 		config = append(config, corev1.EnvVar{Name: envFilterDestPort,
@@ -529,9 +547,16 @@ func (c *AgentController) configureFlowFilter(filter *flowslatest.EBPFFlowFilter
 		})
 	}
 	if filter.Ports.Type == intstr.String {
-		config = append(config, corev1.EnvVar{Name: envFilterPortRange,
-			Value: filter.Ports.String(),
-		})
+		if strings.Contains(filter.Ports.String(), "-") {
+			config = append(config, corev1.EnvVar{Name: envFilterPortRange,
+				Value: filter.Ports.String(),
+			})
+		}
+		if strings.Contains(filter.Ports.String(), ",") {
+			config = append(config, corev1.EnvVar{Name: envFilterPorts,
+				Value: filter.Ports.String(),
+			})
+		}
 	}
 	if filter.Ports.Type == intstr.Int {
 		config = append(config, corev1.EnvVar{Name: envFilterPort,

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -453,8 +453,9 @@ Example: 10.10.10.0/24 or 100:100:100:100::/64<br/>
         <td>int or string</td>
         <td>
           DestPorts defines the destination ports to filter flows by.
-To filter a single port, set a single port as an integer value. For example destPorts: 80.
-To filter a range of ports, use a "start-end" range, string format. For example destPorts: "80-100".<br/>
+To filter a single port, set a single port as an integer value. For example, destPorts: 80.
+To filter a range of ports, use a "start-end" range in string format. For example, destPorts: "80-100".
+To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -500,8 +501,9 @@ Example: 10.10.10.10<br/>
         <td>int or string</td>
         <td>
           Ports defines the ports to filter flows by. it can be user for either source or destination ports.
-To filter a single port, set a single port as an integer value. For example ports: 80.
-To filter a range of ports, use a "start-end" range, string format. For example ports: "80-10<br/>
+To filter a single port, set a single port as an integer value. For example, ports: 80.
+To filter a range of ports, use a "start-end" range in string format. For example, ports: "80-100".
+To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -518,8 +520,9 @@ To filter a range of ports, use a "start-end" range, string format. For example 
         <td>int or string</td>
         <td>
           SourcePorts defines the source ports to filter flows by.
-To filter a single port, set a single port as an integer value. For example sourcePorts: 80.
-To filter a range of ports, use a "start-end" range, string format. For example sourcePorts: "80-100".<br/>
+To filter a single port, set a single port as an integer value. For example, sourcePorts: 80.
+To filter a range of ports, use a "start-end" range in string format. For example, sourcePorts: "80-100".
+To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7864,8 +7867,9 @@ Examples: `10.10.10.0/24` or `100:100:100:100::/64`<br/>
         <td>int or string</td>
         <td>
           `destPorts` defines the destination ports to filter flows by.
-To filter a single port, set a single port as an integer value. For example: `destPorts: 80`.
-To filter a range of ports, use a "start-end" range in string format. For example: `destPorts: "80-100"`.<br/>
+To filter a single port, set a single port as an integer value. For example, `destPorts: 80`.
+To filter a range of ports, use a "start-end" range in string format. For example, `destPorts: "80-100"`.
+To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7911,8 +7915,9 @@ Example: `10.10.10.10`.<br/>
         <td>int or string</td>
         <td>
           `ports` defines the ports to filter flows by. It is used both for source and destination ports.
-To filter a single port, set a single port as an integer value. For example: `ports: 80`.
-To filter a range of ports, use a "start-end" range in string format. For example: `ports: "80-100"`.<br/>
+To filter a single port, set a single port as an integer value. For example, `ports: 80`.
+To filter a range of ports, use a "start-end" range in string format. For example, `ports: "80-100"`.
+To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7929,8 +7934,9 @@ To filter a range of ports, use a "start-end" range in string format. For exampl
         <td>int or string</td>
         <td>
           `sourcePorts` defines the source ports to filter flows by.
-To filter a single port, set a single port as an integer value. For example: `sourcePorts: 80`.
-To filter a range of ports, use a "start-end" range in string format. For example: `sourcePorts: "80-100"`.<br/>
+To filter a single port, set a single port as an integer value. For example, `sourcePorts: 80`.
+To filter a range of ports, use a "start-end" range in string format. For example, `sourcePorts: "80-100"`.
+To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
## Description

Allow filtering TCP/UDP/SCTP using two ports syntax like "90,100" to filter either on port 90 or 100
## Dependencies

https://github.com/netobserv/netobserv-ebpf-agent/pull/389

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
