### PR TITLE
NETOBSERV-1766 Increase loki.WriteBatchSize to 10MB default

### DIFF
--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -853,7 +853,7 @@ type FlowCollectorLoki struct {
 	WriteBatchWait *metav1.Duration `json:"writeBatchWait,omitempty"` // Warning: keep as pointer, else default is ignored
 
 	//+kubebuilder:validation:Minimum=1
-	//+kubebuilder:default:=102400
+	//+kubebuilder:default:=10485760
 	// `writeBatchSize` is the maximum batch size (in bytes) of Loki logs to accumulate before sending.
 	WriteBatchSize int64 `json:"writeBatchSize,omitempty"`
 

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -6619,7 +6619,7 @@ spec:
                       A timeout of zero means no timeout.
                     type: string
                   writeBatchSize:
-                    default: 102400
+                    default: 10485760
                     description: '`writeBatchSize` is the maximum batch size (in bytes)
                       of Loki logs to accumulate before sending.'
                     format: int64

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -6074,7 +6074,7 @@ spec:
                         A timeout of zero means no timeout.
                       type: string
                     writeBatchSize:
-                      default: 102400
+                      default: 10485760
                       description: '`writeBatchSize` is the maximum batch size (in bytes) of Loki logs to accumulate before sending.'
                       format: int64
                       minimum: 1

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -12755,7 +12755,7 @@ A timeout of zero means no timeout.<br/>
           `writeBatchSize` is the maximum batch size (in bytes) of Loki logs to accumulate before sending.<br/>
           <br/>
             <i>Format</i>: int64<br/>
-            <i>Default</i>: 102400<br/>
+            <i>Default</i>: 10485760<br/>
             <i>Minimum</i>: 1<br/>
         </td>
         <td>false</td>


### PR DESCRIPTION
## Description

Increase loki.WriteBatchSize to 10MB default

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [X] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
