### PR TITLE
Allow flow filtering for L4 protocols using two ports [BP to 1.6.2]

### DIFF
--- a/apis/flowcollector/v1beta1/flowcollector_types.go
+++ b/apis/flowcollector/v1beta1/flowcollector_types.go
@@ -211,20 +211,23 @@ type EBPFFlowFilter struct {
 	Direction string `json:"direction,omitempty"`
 
 	// SourcePorts defines the source ports to filter flows by.
-	// To filter a single port, set a single port as an integer value. For example sourcePorts: 80.
-	// To filter a range of ports, use a "start-end" range, string format. For example sourcePorts: "80-100".
+	// To filter a single port, set a single port as an integer value. For example, sourcePorts: 80.
+	// To filter a range of ports, use a "start-end" range, string format. For example, sourcePorts: "80-100".
+	// To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
 	// +optional
 	SourcePorts intstr.IntOrString `json:"sourcePorts,omitempty"`
 
 	// DestPorts defines the destination ports to filter flows by.
-	// To filter a single port, set a single port as an integer value. For example destPorts: 80.
-	// To filter a range of ports, use a "start-end" range, string format. For example destPorts: "80-100".
+	// To filter a single port, set a single port as an integer value. For example, destPorts: 80.
+	// To filter a range of ports, use a "start-end" range, string format. For example, destPorts: "80-100".
+	// To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
 	// +optional
 	DestPorts intstr.IntOrString `json:"destPorts,omitempty"`
 
 	// Ports defines the ports to filter flows by. it can be user for either source or destination ports.
-	// To filter a single port, set a single port as an integer value. For example ports: 80.
-	// To filter a range of ports, use a "start-end" range, string format. For example ports: "80-10
+	// To filter a single port, set a single port as an integer value. For example, ports: 80.
+	// To filter a range of ports, use a "start-end" range, string format. For example, ports: "80-10
+	// To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
 	Ports intstr.IntOrString `json:"ports,omitempty"`
 
 	// PeerIP defines the IP address to filter flows by.

--- a/apis/flowcollector/v1beta1/flowcollector_types.go
+++ b/apis/flowcollector/v1beta1/flowcollector_types.go
@@ -226,7 +226,7 @@ type EBPFFlowFilter struct {
 
 	// Ports defines the ports to filter flows by. it can be user for either source or destination ports.
 	// To filter a single port, set a single port as an integer value. For example, ports: 80.
-	// To filter a range of ports, use a "start-end" range, string format. For example, ports: "80-10
+	// To filter a range of ports, use a "start-end" range, string format. For example, ports: "80-100".
 	// To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
 	Ports intstr.IntOrString `json:"ports,omitempty"`
 

--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -216,20 +216,23 @@ type EBPFFlowFilter struct {
 	Direction string `json:"direction,omitempty"`
 
 	// `sourcePorts` defines the source ports to filter flows by.
-	// To filter a single port, set a single port as an integer value. For example: `sourcePorts: 80`.
-	// To filter a range of ports, use a "start-end" range in string format. For example: `sourcePorts: "80-100"`.
+	// To filter a single port, set a single port as an integer value. For example, `sourcePorts: 80`.
+	// To filter a range of ports, use a "start-end" range in string format. For example, `sourcePorts: "80-100"`.
+	// To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
 	// +optional
 	SourcePorts intstr.IntOrString `json:"sourcePorts,omitempty"`
 
 	// `destPorts` defines the destination ports to filter flows by.
-	// To filter a single port, set a single port as an integer value. For example: `destPorts: 80`.
-	// To filter a range of ports, use a "start-end" range in string format. For example: `destPorts: "80-100"`.
+	// To filter a single port, set a single port as an integer value. For example, `destPorts: 80`.
+	// To filter a range of ports, use a "start-end" range in string format. For example, `destPorts: "80-100"`.
+	// To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
 	// +optional
 	DestPorts intstr.IntOrString `json:"destPorts,omitempty"`
 
 	// `ports` defines the ports to filter flows by. It is used both for source and destination ports.
-	// To filter a single port, set a single port as an integer value. For example: `ports: 80`.
-	// To filter a range of ports, use a "start-end" range in string format. For example: `ports: "80-100"`.
+	// To filter a single port, set a single port as an integer value. For example, `ports: 80`.
+	// To filter a range of ports, use a "start-end" range in string format. For example, `ports: "80-100"`.
+	// To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
 	Ports intstr.IntOrString `json:"ports,omitempty"`
 
 	// `peerIP` defines the IP address to filter flows by.

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -167,8 +167,9 @@ spec:
                             - type: string
                             description: |-
                               DestPorts defines the destination ports to filter flows by.
-                              To filter a single port, set a single port as an integer value. For example destPorts: 80.
-                              To filter a range of ports, use a "start-end" range, string format. For example destPorts: "80-100".
+                              To filter a single port, set a single port as an integer value. For example, destPorts: 80.
+                              To filter a range of ports, use a "start-end" range, string format. For example, destPorts: "80-100".
+                              To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                             x-kubernetes-int-or-string: true
                           direction:
                             description: Direction defines the direction to filter
@@ -200,8 +201,9 @@ spec:
                             - type: string
                             description: |-
                               Ports defines the ports to filter flows by. it can be user for either source or destination ports.
-                              To filter a single port, set a single port as an integer value. For example ports: 80.
-                              To filter a range of ports, use a "start-end" range, string format. For example ports: "80-10
+                              To filter a single port, set a single port as an integer value. For example, ports: 80.
+                              To filter a range of ports, use a "start-end" range, string format. For example, ports: "80-10
+                              To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                             x-kubernetes-int-or-string: true
                           protocol:
                             description: Protocol defines the protocol to filter flows
@@ -219,8 +221,9 @@ spec:
                             - type: string
                             description: |-
                               SourcePorts defines the source ports to filter flows by.
-                              To filter a single port, set a single port as an integer value. For example sourcePorts: 80.
-                              To filter a range of ports, use a "start-end" range, string format. For example sourcePorts: "80-100".
+                              To filter a single port, set a single port as an integer value. For example, sourcePorts: 80.
+                              To filter a range of ports, use a "start-end" range, string format. For example, sourcePorts: "80-100".
+                              To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                             x-kubernetes-int-or-string: true
                         type: object
                       imagePullPolicy:
@@ -3729,8 +3732,9 @@ spec:
                             - type: string
                             description: |-
                               `destPorts` defines the destination ports to filter flows by.
-                              To filter a single port, set a single port as an integer value. For example: `destPorts: 80`.
-                              To filter a range of ports, use a "start-end" range in string format. For example: `destPorts: "80-100"`.
+                              To filter a single port, set a single port as an integer value. For example, `destPorts: 80`.
+                              To filter a range of ports, use a "start-end" range in string format. For example, `destPorts: "80-100"`.
+                              To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                             x-kubernetes-int-or-string: true
                           direction:
                             description: '`direction` defines the direction to filter
@@ -3763,8 +3767,9 @@ spec:
                             - type: string
                             description: |-
                               `ports` defines the ports to filter flows by. It is used both for source and destination ports.
-                              To filter a single port, set a single port as an integer value. For example: `ports: 80`.
-                              To filter a range of ports, use a "start-end" range in string format. For example: `ports: "80-100"`.
+                              To filter a single port, set a single port as an integer value. For example, `ports: 80`.
+                              To filter a range of ports, use a "start-end" range in string format. For example, `ports: "80-100"`.
+                              To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                             x-kubernetes-int-or-string: true
                           protocol:
                             description: '`protocol` defines the protocol to filter
@@ -3782,8 +3787,9 @@ spec:
                             - type: string
                             description: |-
                               `sourcePorts` defines the source ports to filter flows by.
-                              To filter a single port, set a single port as an integer value. For example: `sourcePorts: 80`.
-                              To filter a range of ports, use a "start-end" range in string format. For example: `sourcePorts: "80-100"`.
+                              To filter a single port, set a single port as an integer value. For example, `sourcePorts: 80`.
+                              To filter a range of ports, use a "start-end" range in string format. For example, `sourcePorts: "80-100"`.
+                              To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                             x-kubernetes-int-or-string: true
                         type: object
                       imagePullPolicy:

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -202,7 +202,7 @@ spec:
                             description: |-
                               Ports defines the ports to filter flows by. it can be user for either source or destination ports.
                               To filter a single port, set a single port as an integer value. For example, ports: 80.
-                              To filter a range of ports, use a "start-end" range, string format. For example, ports: "80-10
+                              To filter a range of ports, use a "start-end" range, string format. For example, ports: "80-100".
                               To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                             x-kubernetes-int-or-string: true
                           protocol:

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -181,7 +181,7 @@ spec:
                               description: |-
                                 Ports defines the ports to filter flows by. it can be user for either source or destination ports.
                                 To filter a single port, set a single port as an integer value. For example, ports: 80.
-                                To filter a range of ports, use a "start-end" range, string format. For example, ports: "80-10
+                                To filter a range of ports, use a "start-end" range, string format. For example, ports: "80-100".
                                 To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                               x-kubernetes-int-or-string: true
                             protocol:

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -150,8 +150,9 @@ spec:
                                 - type: string
                               description: |-
                                 DestPorts defines the destination ports to filter flows by.
-                                To filter a single port, set a single port as an integer value. For example destPorts: 80.
-                                To filter a range of ports, use a "start-end" range, string format. For example destPorts: "80-100".
+                                To filter a single port, set a single port as an integer value. For example, destPorts: 80.
+                                To filter a range of ports, use a "start-end" range, string format. For example, destPorts: "80-100".
+                                To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                               x-kubernetes-int-or-string: true
                             direction:
                               description: Direction defines the direction to filter flows by.
@@ -179,8 +180,9 @@ spec:
                                 - type: string
                               description: |-
                                 Ports defines the ports to filter flows by. it can be user for either source or destination ports.
-                                To filter a single port, set a single port as an integer value. For example ports: 80.
-                                To filter a range of ports, use a "start-end" range, string format. For example ports: "80-10
+                                To filter a single port, set a single port as an integer value. For example, ports: 80.
+                                To filter a range of ports, use a "start-end" range, string format. For example, ports: "80-10
+                                To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                               x-kubernetes-int-or-string: true
                             protocol:
                               description: Protocol defines the protocol to filter flows by.
@@ -197,8 +199,9 @@ spec:
                                 - type: string
                               description: |-
                                 SourcePorts defines the source ports to filter flows by.
-                                To filter a single port, set a single port as an integer value. For example sourcePorts: 80.
-                                To filter a range of ports, use a "start-end" range, string format. For example sourcePorts: "80-100".
+                                To filter a single port, set a single port as an integer value. For example, sourcePorts: 80.
+                                To filter a range of ports, use a "start-end" range, string format. For example, sourcePorts: "80-100".
+                                To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                               x-kubernetes-int-or-string: true
                           type: object
                         imagePullPolicy:
@@ -3434,8 +3437,9 @@ spec:
                                 - type: string
                               description: |-
                                 `destPorts` defines the destination ports to filter flows by.
-                                To filter a single port, set a single port as an integer value. For example: `destPorts: 80`.
-                                To filter a range of ports, use a "start-end" range in string format. For example: `destPorts: "80-100"`.
+                                To filter a single port, set a single port as an integer value. For example, `destPorts: 80`.
+                                To filter a range of ports, use a "start-end" range in string format. For example, `destPorts: "80-100"`.
+                                To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                               x-kubernetes-int-or-string: true
                             direction:
                               description: '`direction` defines the direction to filter flows by.'
@@ -3463,8 +3467,9 @@ spec:
                                 - type: string
                               description: |-
                                 `ports` defines the ports to filter flows by. It is used both for source and destination ports.
-                                To filter a single port, set a single port as an integer value. For example: `ports: 80`.
-                                To filter a range of ports, use a "start-end" range in string format. For example: `ports: "80-100"`.
+                                To filter a single port, set a single port as an integer value. For example, `ports: 80`.
+                                To filter a range of ports, use a "start-end" range in string format. For example, `ports: "80-100"`.
+                                To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                               x-kubernetes-int-or-string: true
                             protocol:
                               description: '`protocol` defines the protocol to filter flows by.'
@@ -3481,8 +3486,9 @@ spec:
                                 - type: string
                               description: |-
                                 `sourcePorts` defines the source ports to filter flows by.
-                                To filter a single port, set a single port as an integer value. For example: `sourcePorts: 80`.
-                                To filter a range of ports, use a "start-end" range in string format. For example: `sourcePorts: "80-100"`.
+                                To filter a single port, set a single port as an integer value. For example, `sourcePorts: 80`.
+                                To filter a range of ports, use a "start-end" range in string format. For example, `sourcePorts: "80-100"`.
+                                To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.
                               x-kubernetes-int-or-string: true
                           type: object
                         imagePullPolicy:

--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -72,6 +72,9 @@ const (
 	envFilterSourcePortRange      = "FILTER_SOURCE_PORT_RANGE"
 	envFilterDestPortRange        = "FILTER_DESTINATION_PORT_RANGE"
 	envFilterPortRange            = "FILTER_PORT_RANGE"
+	envFilterSourcePorts          = "FILTER_SOURCE_PORTS"
+	envFilterDestPorts            = "FILTER_DESTINATION_PORTS"
+	envFilterPorts                = "FILTER_PORTS"
 	envFilterICMPType             = "FILTER_ICMP_TYPE"
 	envFilterICMPCode             = "FILTER_ICMP_CODE"
 	envFilterPeerIPAddress        = "FILTER_PEER_IP"
@@ -425,6 +428,7 @@ func (c *AgentController) envConfig(ctx context.Context, coll *flowslatest.FlowC
 	return config, nil
 }
 
+// nolint:cyclop
 func (c *AgentController) configureFlowFilter(filter *flowslatest.EBPFFlowFilter, config []corev1.EnvVar) []corev1.EnvVar {
 	if filter.CIDR != "" {
 		config = append(config, corev1.EnvVar{Name: envFilterIPCIDR,
@@ -448,9 +452,16 @@ func (c *AgentController) configureFlowFilter(filter *flowslatest.EBPFFlowFilter
 		switch filter.Protocol {
 		case "TCP", "UDP", "SCTP":
 			if filter.SourcePorts.Type == intstr.String {
-				config = append(config, corev1.EnvVar{Name: envFilterSourcePortRange,
-					Value: filter.SourcePorts.String(),
-				})
+				if strings.Contains(filter.SourcePorts.String(), "-") {
+					config = append(config, corev1.EnvVar{Name: envFilterSourcePortRange,
+						Value: filter.SourcePorts.String(),
+					})
+				}
+				if strings.Contains(filter.SourcePorts.String(), ",") {
+					config = append(config, corev1.EnvVar{Name: envFilterSourcePorts,
+						Value: filter.SourcePorts.String(),
+					})
+				}
 			}
 			if filter.SourcePorts.Type == intstr.Int {
 				config = append(config, corev1.EnvVar{Name: envFilterSourcePort,
@@ -458,19 +469,34 @@ func (c *AgentController) configureFlowFilter(filter *flowslatest.EBPFFlowFilter
 				})
 			}
 			if filter.DestPorts.Type == intstr.String {
-				config = append(config, corev1.EnvVar{Name: envFilterDestPortRange,
-					Value: filter.DestPorts.String(),
-				})
+				if strings.Contains(filter.DestPorts.String(), "-") {
+					config = append(config, corev1.EnvVar{Name: envFilterDestPortRange,
+						Value: filter.DestPorts.String(),
+					})
+				}
+				if strings.Contains(filter.DestPorts.String(), ",") {
+					config = append(config, corev1.EnvVar{Name: envFilterDestPorts,
+						Value: filter.DestPorts.String(),
+					})
+				}
 			}
 			if filter.DestPorts.Type == intstr.Int {
 				config = append(config, corev1.EnvVar{Name: envFilterDestPort,
 					Value: strconv.Itoa(filter.DestPorts.IntValue()),
 				})
+
 			}
 			if filter.Ports.Type == intstr.String {
-				config = append(config, corev1.EnvVar{Name: envFilterPortRange,
-					Value: filter.Ports.String(),
-				})
+				if strings.Contains(filter.Ports.String(), "-") {
+					config = append(config, corev1.EnvVar{Name: envFilterPortRange,
+						Value: filter.Ports.String(),
+					})
+				}
+				if strings.Contains(filter.Ports.String(), ",") {
+					config = append(config, corev1.EnvVar{Name: envFilterPorts,
+						Value: filter.Ports.String(),
+					})
+				}
 			}
 			if filter.Ports.Type == intstr.Int {
 				config = append(config, corev1.EnvVar{Name: envFilterPort,

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -451,8 +451,9 @@ Example: 10.10.10.0/24 or 100:100:100:100::/64<br/>
         <td>int or string</td>
         <td>
           DestPorts defines the destination ports to filter flows by.
-To filter a single port, set a single port as an integer value. For example destPorts: 80.
-To filter a range of ports, use a "start-end" range, string format. For example destPorts: "80-100".<br/>
+To filter a single port, set a single port as an integer value. For example, destPorts: 80.
+To filter a range of ports, use a "start-end" range, string format. For example, destPorts: "80-100".
+To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -498,8 +499,9 @@ Example: 10.10.10.10<br/>
         <td>int or string</td>
         <td>
           Ports defines the ports to filter flows by. it can be user for either source or destination ports.
-To filter a single port, set a single port as an integer value. For example ports: 80.
-To filter a range of ports, use a "start-end" range, string format. For example ports: "80-10<br/>
+To filter a single port, set a single port as an integer value. For example, ports: 80.
+To filter a range of ports, use a "start-end" range, string format. For example, ports: "80-10
+To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -516,8 +518,9 @@ To filter a range of ports, use a "start-end" range, string format. For example 
         <td>int or string</td>
         <td>
           SourcePorts defines the source ports to filter flows by.
-To filter a single port, set a single port as an integer value. For example sourcePorts: 80.
-To filter a range of ports, use a "start-end" range, string format. For example sourcePorts: "80-100".<br/>
+To filter a single port, set a single port as an integer value. For example, sourcePorts: 80.
+To filter a range of ports, use a "start-end" range, string format. For example, sourcePorts: "80-100".
+To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7844,8 +7847,9 @@ Examples: `10.10.10.0/24` or `100:100:100:100::/64`<br/>
         <td>int or string</td>
         <td>
           `destPorts` defines the destination ports to filter flows by.
-To filter a single port, set a single port as an integer value. For example: `destPorts: 80`.
-To filter a range of ports, use a "start-end" range in string format. For example: `destPorts: "80-100"`.<br/>
+To filter a single port, set a single port as an integer value. For example, `destPorts: 80`.
+To filter a range of ports, use a "start-end" range in string format. For example, `destPorts: "80-100"`.
+To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7891,8 +7895,9 @@ Example: `10.10.10.10`.<br/>
         <td>int or string</td>
         <td>
           `ports` defines the ports to filter flows by. It is used both for source and destination ports.
-To filter a single port, set a single port as an integer value. For example: `ports: 80`.
-To filter a range of ports, use a "start-end" range in string format. For example: `ports: "80-100"`.<br/>
+To filter a single port, set a single port as an integer value. For example, `ports: 80`.
+To filter a range of ports, use a "start-end" range in string format. For example, `ports: "80-100"`.
+To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -7909,8 +7914,9 @@ To filter a range of ports, use a "start-end" range in string format. For exampl
         <td>int or string</td>
         <td>
           `sourcePorts` defines the source ports to filter flows by.
-To filter a single port, set a single port as an integer value. For example: `sourcePorts: 80`.
-To filter a range of ports, use a "start-end" range in string format. For example: `sourcePorts: "80-100"`.<br/>
+To filter a single port, set a single port as an integer value. For example, `sourcePorts: 80`.
+To filter a range of ports, use a "start-end" range in string format. For example, `sourcePorts: "80-100"`.
+To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -500,7 +500,7 @@ Example: 10.10.10.10<br/>
         <td>
           Ports defines the ports to filter flows by. it can be user for either source or destination ports.
 To filter a single port, set a single port as an integer value. For example, ports: 80.
-To filter a range of ports, use a "start-end" range, string format. For example, ports: "80-10
+To filter a range of ports, use a "start-end" range, string format. For example, ports: "80-100".
 To filter two ports, use a "port1,port2" in string format. For example, `ports: "80,100"`.<br/>
         </td>
         <td>false</td>


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
(cherry picked from commit 38031f1830161b98affc29534fb95b5b6286ef3e)

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
