### PR TITLE
NETOBSERV-1777: Allow DNS tracking to use configurable port for tracking [BP]

### DIFF
--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -94,10 +94,12 @@ const (
 )
 
 const (
-	EnvDedupeJustMark     = "DEDUPER_JUST_MARK"
-	EnvDedupeMerge        = "DEDUPER_MERGE"
-	DedupeJustMarkDefault = "false"
-	DedupeMergeDefault    = "true"
+	EnvDedupeJustMark      = "DEDUPER_JUST_MARK"
+	EnvDedupeMerge         = "DEDUPER_MERGE"
+	envDNSTrackingPort     = "DNS_TRACKING_PORT"
+	DedupeJustMarkDefault  = "false"
+	DedupeMergeDefault     = "true"
+	defaultDNSTrackingPort = "53"
 )
 
 // AgentController reconciles the status of the eBPF agent Daemonset, as well as the
@@ -615,6 +617,7 @@ func (c *AgentController) setEnvConfig(coll *flowslatest.FlowCollector) []corev1
 	dedup := dedupeDefault
 	dedupJustMark := DedupeJustMarkDefault
 	dedupMerge := DedupeMergeDefault
+	dnsTrackingPort := defaultDNSTrackingPort
 	// we need to sort env map to keep idempotency,
 	// as equal maps could be iterated in different order
 	advancedConfig := helper.GetAdvancedAgentConfig(coll.Spec.Agent.EBPF.Advanced)
@@ -626,6 +629,8 @@ func (c *AgentController) setEnvConfig(coll *flowslatest.FlowCollector) []corev1
 			dedupJustMark = v
 		} else if k == EnvDedupeMerge {
 			dedupMerge = v
+		} else if k == envDNSTrackingPort {
+			dnsTrackingPort = v
 		} else {
 			config = append(config, corev1.EnvVar{Name: k, Value: v})
 		}
@@ -633,6 +638,7 @@ func (c *AgentController) setEnvConfig(coll *flowslatest.FlowCollector) []corev1
 
 	config = append(config, corev1.EnvVar{Name: envDedupe, Value: dedup})
 	config = append(config, corev1.EnvVar{Name: EnvDedupeJustMark, Value: dedupJustMark})
+	config = append(config, corev1.EnvVar{Name: envDNSTrackingPort, Value: dnsTrackingPort})
 	config = append(config, corev1.EnvVar{
 		Name: envAgentIP,
 		ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
(cherry picked from commit 192b5b9ba2fc8df099f4cafeae839661d6904580)

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
