### PR TITLE
NETOBSERV-1811 set namespace ownership

### DIFF
--- a/controllers/monitoring/monitoring_controller.go
+++ b/controllers/monitoring/monitoring_controller.go
@@ -102,7 +102,7 @@ func (r *Reconciler) reconcile(ctx context.Context, clh *helper.Client, desired 
 		if err != nil {
 			return err
 		}
-	} else if !helper.IsSubSet(nsExist.ObjectMeta.Labels, desiredNs.ObjectMeta.Labels) {
+	} else if !helper.SkipOwnership(nsExist) && !helper.IsSubSet(nsExist.ObjectMeta.Labels, desiredNs.ObjectMeta.Labels) {
 		err = r.Update(ctx, desiredNs)
 		if err != nil {
 			return err

--- a/pkg/helper/client_helper.go
+++ b/pkg/helper/client_helper.go
@@ -47,6 +47,7 @@ func (c *Client) CreateOwned(ctx context.Context, obj client.Object) error {
 		log.Error(err, "Failed to set controller reference")
 		return err
 	}
+	AddOwnedLabel(obj)
 	kind := reflect.TypeOf(obj).String()
 	log.Info("CREATING a new "+kind, "Namespace", obj.GetNamespace(), "Name", obj.GetName())
 	err = c.Create(ctx, obj)
@@ -86,7 +87,7 @@ func (c *Client) UpdateOwned(ctx context.Context, old, obj client.Object) error 
 	return nil
 }
 
-// UpdateIfOwned is an helper function that updates an object if currently owned by the operator
+// UpdateIfOwned is an helper function that updates an object if currently owned and managed by the operator
 func (c *Client) UpdateIfOwned(ctx context.Context, old, obj client.Object) error {
 	log := log.FromContext(ctx)
 


### PR DESCRIPTION
## Description

Set namespace ownership using a new `netobserv-managed: true` label so users can bypass reconcile loop if they want to customize labels by setting it to false.

The `ownerReference` is not set to namespace object to avoid unexpected deletions.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
