### PR TITLE
NETOBSERV-1788 add owner type to labels

### DIFF
--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -51,7 +51,7 @@ const (
 	EnvTestConsole = "TEST_CONSOLE"
 )
 
-var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstK8S_Type", "K8S_FlowLayer", "FlowDirection"}
+var LokiIndexFields = []string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "SrcOwnerType", "SrcK8S_Type", "DstK8S_Namespace", "DstK8S_OwnerName", "DstOwnerType", "DstK8S_Type", "K8S_FlowLayer", "FlowDirection"}
 var LokiConnectionIndexFields = []string{"_RecordType"}
 var LokiZoneIndexFields = []string{"SrcK8S_Zone", "DstK8S_Zone"}
 var FlowCollectorName = types.NamespacedName{Name: "cluster"}

--- a/controllers/flp/flp_test.go
+++ b/controllers/flp/flp_test.go
@@ -650,9 +650,11 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiManual(t *testing.T) {
 	assert.EqualValues([]string{
 		"SrcK8S_Namespace",
 		"SrcK8S_OwnerName",
+		"SrcOwnerType",
 		"SrcK8S_Type",
 		"DstK8S_Namespace",
 		"DstK8S_OwnerName",
+		"DstOwnerType",
 		"DstK8S_Type",
 		"K8S_FlowLayer",
 		"FlowDirection",
@@ -706,9 +708,11 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiStack(t *testing.T) {
 	assert.EqualValues([]string{
 		"SrcK8S_Namespace",
 		"SrcK8S_OwnerName",
+		"SrcOwnerType",
 		"SrcK8S_Type",
 		"DstK8S_Namespace",
 		"DstK8S_OwnerName",
+		"DstOwnerType",
 		"DstK8S_Type",
 		"K8S_FlowLayer",
 		"FlowDirection",


### PR DESCRIPTION
## Description

Add owner type labels for https://github.com/netobserv/network-observability-console-plugin/pull/580

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
