### PR TITLE
NETOBSERV-1848 Enable egress metric to show more traffic

### DIFF
--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -554,7 +554,8 @@ type FLPMetrics struct {
 	// `namespace_egress_packets_total` shows up as `netobserv_namespace_egress_packets_total` in Prometheus.
 	// Note that the more metrics you add, the bigger is the impact on Prometheus workload resources.
 	// Metrics enabled by default are:
-	// `namespace_flows_total`, `node_ingress_bytes_total`, `workload_ingress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled),
+	// `namespace_flows_total`, `node_ingress_bytes_total`, `node_egress_bytes_total`, `workload_ingress_bytes_total`,
+	// `workload_egress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled),
 	// `namespace_rtt_seconds` (when `FlowRTT` feature is enabled), `namespace_dns_latency_seconds` (when `DNSTracking` feature is enabled).
 	// More information, with full list of available metrics: https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md
 	// +optional

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -8165,7 +8165,8 @@ spec:
                           `namespace_egress_packets_total` shows up as `netobserv_namespace_egress_packets_total` in Prometheus.
                           Note that the more metrics you add, the bigger is the impact on Prometheus workload resources.
                           Metrics enabled by default are:
-                          `namespace_flows_total`, `node_ingress_bytes_total`, `workload_ingress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled),
+                          `namespace_flows_total`, `node_ingress_bytes_total`, `node_egress_bytes_total`, `workload_ingress_bytes_total`,
+                          `workload_egress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled),
                           `namespace_rtt_seconds` (when `FlowRTT` feature is enabled), `namespace_dns_latency_seconds` (when `DNSTracking` feature is enabled).
                           More information, with full list of available metrics: https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md
                         items:

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -7550,7 +7550,8 @@ spec:
                             `namespace_egress_packets_total` shows up as `netobserv_namespace_egress_packets_total` in Prometheus.
                             Note that the more metrics you add, the bigger is the impact on Prometheus workload resources.
                             Metrics enabled by default are:
-                            `namespace_flows_total`, `node_ingress_bytes_total`, `workload_ingress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled),
+                            `namespace_flows_total`, `node_ingress_bytes_total`, `node_egress_bytes_total`, `workload_ingress_bytes_total`,
+                            `workload_egress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled),
                             `namespace_rtt_seconds` (when `FlowRTT` feature is enabled), `namespace_dns_latency_seconds` (when `DNSTracking` feature is enabled).
                             More information, with full list of available metrics: https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md
                           items:

--- a/controllers/flp/flp_controller_flowmetrics_test.go
+++ b/controllers/flp/flp_controller_flowmetrics_test.go
@@ -111,7 +111,7 @@ func ControllerFlowMetricsSpecs() {
 
 			metrics, err := getConfiguredMetrics(&dcm)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(metrics).To(HaveLen(3)) // only default metrics
+			Expect(metrics).To(HaveLen(5)) // only default metrics
 		})
 	})
 

--- a/controllers/flp/flp_test.go
+++ b/controllers/flp/flp_test.go
@@ -888,7 +888,9 @@ func TestMergeMetricsConfiguration_Default(t *testing.T) {
 	names := getSortedMetricsNames(cfs.Parameters[5].Encode.Prom.Metrics)
 	assert.Equal([]string{
 		"namespace_flows_total",
+		"node_egress_bytes_total",
 		"node_ingress_bytes_total",
+		"workload_egress_bytes_total",
 		"workload_ingress_bytes_total",
 	}, names)
 	assert.Equal("netobserv_", cfs.Parameters[5].Encode.Prom.Prefix)
@@ -913,7 +915,9 @@ func TestMergeMetricsConfiguration_DefaultWithFeatures(t *testing.T) {
 		"namespace_drop_packets_total",
 		"namespace_flows_total",
 		"namespace_rtt_seconds",
+		"node_egress_bytes_total",
 		"node_ingress_bytes_total",
+		"workload_egress_bytes_total",
 		"workload_ingress_bytes_total",
 	}, names)
 	assert.Equal("netobserv_", cfs.Parameters[5].Encode.Prom.Prefix)

--- a/controllers/flp/metrics_api_test.go
+++ b/controllers/flp/metrics_api_test.go
@@ -81,7 +81,9 @@ func TestFlowMetricToFLP(t *testing.T) {
 		"m_1",
 		"m_2",
 		"namespace_flows_total",
+		"node_egress_bytes_total",
 		"node_ingress_bytes_total",
+		"workload_egress_bytes_total",
 		"workload_ingress_bytes_total",
 	}, names)
 

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -16816,7 +16816,8 @@ The names correspond to the names in Prometheus without the prefix. For example,
 `namespace_egress_packets_total` shows up as `netobserv_namespace_egress_packets_total` in Prometheus.
 Note that the more metrics you add, the bigger is the impact on Prometheus workload resources.
 Metrics enabled by default are:
-`namespace_flows_total`, `node_ingress_bytes_total`, `workload_ingress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled),
+`namespace_flows_total`, `node_ingress_bytes_total`, `node_egress_bytes_total`, `workload_ingress_bytes_total`,
+`workload_egress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled),
 `namespace_rtt_seconds` (when `FlowRTT` feature is enabled), `namespace_dns_latency_seconds` (when `DNSTracking` feature is enabled).
 More information, with full list of available metrics: https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md<br/>
         </td>

--- a/pkg/dashboards/dashboard_test.go
+++ b/pkg/dashboards/dashboard_test.go
@@ -114,22 +114,30 @@ func TestCreateFlowMetricsDashboard_DefaultList(t *testing.T) {
 	assert.NoError(err)
 
 	assert.Equal("NetObserv / Main", d.Title)
-	assert.Equal([]string{"", "Traffic rates", "TCP latencies", "Byte and packet drops", "DNS"}, d.Titles())
+	assert.Equal([]string{"Overview", "Traffic rates", "TCP latencies", "Byte and packet drops", "DNS"}, d.Titles())
 
 	topRow := d.FindRow("")
 	assert.Equal([]string{
+		"Total egress traffic",
 		"Total ingress traffic",
 		"TCP latency, p99",
 		"Drops",
 		"DNS latency, p99",
 		"DNS error rate",
+		"Infra egress traffic",
+		"Apps egress traffic",
 		"Infra ingress traffic",
 		"Apps ingress traffic",
 	}, topRow.Titles())
 
 	trafficRow := d.FindRow("Traffic rates")
 	assert.Equal([]string{
+		"Top egress traffic per node (Bps)",
 		"Top ingress traffic per node (Bps)",
+		"Top egress traffic per infra namespace (Bps)",
+		"Top egress traffic per app namespace (Bps)",
+		"Top egress traffic per infra workload (Bps)",
+		"Top egress traffic per app workload (Bps)",
 		"Top ingress traffic per infra namespace (Bps)",
 		"Top ingress traffic per app namespace (Bps)",
 		"Top ingress traffic per infra workload (Bps)",

--- a/pkg/metrics/predefined_metrics.go
+++ b/pkg/metrics/predefined_metrics.go
@@ -36,7 +36,9 @@ var (
 	// Note that we set default in-code rather than in CRD, in order to keep track of value being unset or set intentionnally in FlowCollector
 	DefaultIncludeList = []string{
 		"node_ingress_bytes_total",
+		"node_egress_bytes_total",
 		"workload_ingress_bytes_total",
+		"workload_egress_bytes_total",
 		"namespace_flows_total",
 		"namespace_drop_packets_total",
 		"namespace_rtt_seconds",
@@ -45,8 +47,11 @@ var (
 	// More metrics enabled when Loki is disabled, to avoid loss of information
 	DefaultIncludeListLokiDisabled = []string{
 		"node_ingress_bytes_total",
+		"node_egress_bytes_total",
 		"workload_ingress_bytes_total",
+		"workload_egress_bytes_total",
 		"workload_ingress_packets_total",
+		"workload_egress_packets_total",
 		"workload_flows_total",
 		"workload_drop_bytes_total",
 		"workload_drop_packets_total",


### PR DESCRIPTION
## Description

Add egress metrics to prom defaults

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
