### PR TITLE
NETOBSERV-1792 Add bundle nudging configuration to konflux

### DIFF
--- a/.tekton/network-observability-operator-bundle-pull-request.yaml
+++ b/.tekton/network-observability-operator-bundle-pull-request.yaml
@@ -7,8 +7,12 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/***".pathChanged() ||
+      "bundle.Dockerfile".pathChanged() ||
+      "bundle/***".pathChanged() ||
+      "hack/update-build.sh".pathChanged() ||
+      "hack/patch_csv.py".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: netobserv-operator

--- a/.tekton/network-observability-operator-bundle-push.yaml
+++ b/.tekton/network-observability-operator-bundle-push.yaml
@@ -6,8 +6,12 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"  &&
+      (".tekton/***".pathChanged() ||
+      "bundle.Dockerfile".pathChanged() ||
+      "bundle/***".pathChanged() ||
+      "hack/update-build.sh".pathChanged() ||
+      "hack/patch_csv.py".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: netobserv-operator

--- a/.tekton/network-observability-operator-fbc-pull-request.yaml
+++ b/.tekton/network-observability-operator-fbc-pull-request.yaml
@@ -7,8 +7,12 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/***".pathChanged() ||
+      "catalog.Dockerfile".pathChanged() ||
+      "catalog/***".pathChanged() ||
+      "hack/update-build.sh".pathChanged() ||
+      "hack/patch_csv.py".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: netobserv-operator

--- a/.tekton/network-observability-operator-fbc-push.yaml
+++ b/.tekton/network-observability-operator-fbc-push.yaml
@@ -6,8 +6,12 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/***".pathChanged() ||
+      "catalog.Dockerfile".pathChanged() ||
+      "catalog/***".pathChanged() ||
+      "hack/update-build.sh".pathChanged() ||
+      "hack/patch_csv.py".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: netobserv-operator

--- a/.tekton/network-observability-operator-pull-request.yaml
+++ b/.tekton/network-observability-operator-pull-request.yaml
@@ -7,8 +7,21 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/***".pathChanged() ||
+      "apis/***".pathChanged() ||
+      "controllers/***".pathChanged() ||
+      "Dockerfile".pathChanged() ||
+      "docs/***".pathChanged() ||
+      "go.mod".pathChanged() ||
+      "go.sum".pathChanged() ||
+      "hack/update-build.sh".pathChanged() ||
+      "LICENSE".pathChanged() ||
+      "main.go".pathChanged() ||
+      "Makefile".pathChanged() ||
+      "manifests/***".pathChanged() ||
+      "pkg/***".pathChanged() ||
+      "vendor/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: netobserv-operator

--- a/.tekton/network-observability-operator-push.yaml
+++ b/.tekton/network-observability-operator-push.yaml
@@ -5,9 +5,23 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/netobserv/network-observability-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.openshift.io/build-nudge-files: "hack/container_digest.sh"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"  &&
+      (".tekton/***".pathChanged() ||
+      "apis/***".pathChanged() ||
+      "controllers/***".pathChanged() ||
+      "Dockerfile".pathChanged() ||
+      "docs/***".pathChanged() ||
+      "go.mod".pathChanged() ||
+      "go.sum".pathChanged() ||
+      "hack/update-build.sh".pathChanged() ||
+      "LICENSE".pathChanged() ||
+      "main.go".pathChanged() ||
+      "Makefile".pathChanged() ||
+      "manifests/***".pathChanged() ||
+      "pkg/***".pathChanged() ||
+      "vendor/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: netobserv-operator

--- a/hack/container_digest.sh
+++ b/hack/container_digest.sh
@@ -1,0 +1,4 @@
+export OPERATOR_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/ocp-network-observab-tenant/netobserv-operator/network-observability-operator@sha256:896ff6c6afcdd6d9cb80945868a39242f9441cf2ea5d424fc0e058800628b860'
+export EBPF_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/ocp-network-observab-tenant/netobserv-operator/netobserv-ebpf-agent@sha256:36a741fe7cf5d19db0622b1d7f846617612602e85a97021e9a76595d5e4ffdc1'
+export FLP_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/ocp-network-observab-tenant/netobserv-operator/flowlogs-pipeline@sha256:4049ec904072ac7d8c20e98a14ab2d3e89dc3b4b5abc5f5dffd1c0b85267b443'
+export CONSOLE_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/ocp-network-observab-tenant/netobserv-operator/network-observability-console-plugin@sha256:5f2352a2d0fba28f4a00578892bc7993e6a363959f1e4956d7ab74ab0fccb829'

--- a/hack/patch_csv.py
+++ b/hack/patch_csv.py
@@ -26,10 +26,10 @@ replaces = os.getenv('REPLACES')
 desc_file_name = os.getenv('IN_CSV_DESC')
 csv = load_manifest(os.getenv('TARGET_CSV_FILE'))
 created_at = datetime_time.strftime('%Y-%m-%dT%H:%M:%S')
-operator_image = 'registry.redhat.io/network-observability/network-observability-rhel9-operator:v{}'.format(version)
-ebpf_image = 'registry.redhat.io/network-observability/network-observability-ebpf-agent-rhel9:v{}'.format(version)
-flp_image ='registry.redhat.io/network-observability/network-observability-flowlogs-pipeline-rhel9:v{}'.format(version)
-console_image = 'registry.redhat.io/network-observability/network-observability-console-plugin-rhel9:v{}'.format(version)
+operator_image = os.getenv('OPERATOR_IMAGE_PULLSPEC')
+ebpf_image = os.getenv('EBPF_IMAGE_PULLSPEC')
+flp_image = os.getenv('FLP_IMAGE_PULLSPEC')
+console_image = os.getenv('CONSOLE_IMAGE_PULLSPEC')
 
 csv['metadata']['annotations']['operators.openshift.io/valid-subscription'] = '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
 csv['metadata']['annotations']['operatorframework.io/cluster-monitoring'] = 'true'

--- a/hack/update-build.sh
+++ b/hack/update-build.sh
@@ -20,6 +20,8 @@ csv_name="netobserv-operator.clusterserviceversion.yaml"
 csv_file="${manifests_dir}/${csv_name}"
 index_file="./catalog/index.yaml"
 
+source ./hack/container_digest.sh
+
 cat <<EOF >>"${CONTAINER_FILE}"
 LABEL com.redhat.component="network-observability-operator-container"
 LABEL name="network-observability-operator"


### PR DESCRIPTION
## Description

Bundle nudging allow to create dependencies between konflux components.

Once a new operator image is built, konflux will automatically create a PR to update the operator digest located in hack/container_digest.sh

Because of this we have to be more precise to the list of files triggering konflux build. We want to avoid any loop with a build triggering a PR which trigger again the same build.

This is a first PR to test if it works with the operator -> bundle dependency, other dependency will be done once this one is tested.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
