### PR TITLE
NETOBSERV-1856: new role for metrics reading permissions

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -1061,6 +1061,12 @@ spec:
           - create
           - get
         - apiGroups:
+          - metrics.k8s.io
+          resources:
+          - pods
+          verbs:
+          - create
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - prometheusrules

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -140,6 +140,12 @@ rules:
   - create
   - get
 - apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - create
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - prometheusrules

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -44,9 +44,10 @@ const (
 	ConsoleNamespace         = "openshift-console"
 
 	// Roles
-	CRWriter  = "netobserv-writer"
-	CRBWriter = "netobserv-writer-flp"
-	CRReader  = "netobserv-reader"
+	LokiCRWriter  = "netobserv-writer"
+	LokiCRBWriter = "netobserv-writer-flp"
+	LokiCRReader  = "netobserv-reader"
+	PromCRReader  = "netobserv-metrics-reader"
 
 	EnvTestConsole = "TEST_CONSOLE"
 )

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -43,10 +43,10 @@ const (
 	UWMonitoringNamespace    = "openshift-user-workload-monitoring"
 	ConsoleNamespace         = "openshift-console"
 
-	// Loki roles
-	LokiCRWriter  = "netobserv-writer"
-	LokiCRBWriter = "netobserv-writer-flp"
-	LokiCRReader  = "netobserv-reader"
+	// Roles
+	CRWriter  = "netobserv-writer"
+	CRBWriter = "netobserv-writer-flp"
+	CRReader  = "netobserv-reader"
 
 	EnvTestConsole = "TEST_CONSOLE"
 )

--- a/controllers/flp/flp_controller.go
+++ b/controllers/flp/flp_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/netobserv/network-observability-operator/pkg/loki"
 	"github.com/netobserv/network-observability-operator/pkg/manager"
 	"github.com/netobserv/network-observability-operator/pkg/manager/status"
+	"github.com/netobserv/network-observability-operator/pkg/resources"
 	"github.com/netobserv/network-observability-operator/pkg/watchers"
 	configv1 "github.com/openshift/api/config/v1"
 	"gopkg.in/yaml.v2"
@@ -252,21 +253,24 @@ func reconcileMonitoringCerts(ctx context.Context, info *reconcilers.Common, tls
 	return nil
 }
 
-func reconcileLokiRoles(ctx context.Context, r *reconcilers.Common, b *builder) error {
-	roles := loki.ClusterRoles(b.desired.Loki.Mode)
-	if len(roles) > 0 {
-		for i := range roles {
-			if err := r.ReconcileClusterRole(ctx, &roles[i]); err != nil {
-				return err
+func reconcileDataAccessRoles(ctx context.Context, r *reconcilers.Common, b *builder) error {
+	if helper.UseLoki(b.desired) && b.desired.Loki.Mode == flowslatest.LokiModeLokiStack {
+		roles, bindings := loki.ClusterRoles(b.name(), b.name(), b.info.Namespace)
+		if len(roles) > 0 {
+			for i := range roles {
+				if err := r.ReconcileClusterRole(ctx, &roles[i]); err != nil {
+					return err
+				}
+			}
+			for i := range bindings {
+				if err := r.ReconcileClusterRoleBinding(ctx, &bindings[i]); err != nil {
+					return err
+				}
 			}
 		}
-		if helper.UseLoki(b.desired) {
-			// Binding
-			crb := loki.ClusterRoleBinding(b.name(), b.name(), b.info.Namespace)
-			if err := r.ReconcileClusterRoleBinding(ctx, crb); err != nil {
-				return err
-			}
-		}
+	} else {
+		// No Loki: just install roles for allowing users to bind metrics readers
+		return r.ReconcileClusterRole(ctx, &resources.NetObservReaderCR)
 	}
 	return nil
 }

--- a/controllers/flp/flp_controller.go
+++ b/controllers/flp/flp_controller.go
@@ -253,14 +253,14 @@ func reconcileMonitoringCerts(ctx context.Context, info *reconcilers.Common, tls
 }
 
 func reconcileLokiRoles(ctx context.Context, r *reconcilers.Common, b *builder) error {
-	if helper.UseLoki(b.desired) {
-		roles := loki.ClusterRoles(b.desired.Loki.Mode)
-		if len(roles) > 0 {
-			for i := range roles {
-				if err := r.ReconcileClusterRole(ctx, &roles[i]); err != nil {
-					return err
-				}
+	roles := loki.ClusterRoles(b.desired.Loki.Mode)
+	if len(roles) > 0 {
+		for i := range roles {
+			if err := r.ReconcileClusterRole(ctx, &roles[i]); err != nil {
+				return err
 			}
+		}
+		if helper.UseLoki(b.desired) {
 			// Binding
 			crb := loki.ClusterRoleBinding(b.name(), b.name(), b.info.Namespace)
 			if err := r.ReconcileClusterRoleBinding(ctx, crb); err != nil {

--- a/controllers/flp/flp_controller.go
+++ b/controllers/flp/flp_controller.go
@@ -268,11 +268,9 @@ func reconcileDataAccessRoles(ctx context.Context, r *reconcilers.Common, b *bui
 				}
 			}
 		}
-	} else {
-		// No Loki: just install roles for allowing users to bind metrics readers
-		return r.ReconcileClusterRole(ctx, &resources.NetObservReaderCR)
 	}
-	return nil
+	// Install netobserv-metrics-reader role
+	return r.ReconcileClusterRole(ctx, &resources.PromReaderCR)
 }
 
 func (r *Reconciler) getOpenShiftSubnets(ctx context.Context) ([]flowslatest.SubnetLabel, error) {

--- a/controllers/flp/flp_controller_test.go
+++ b/controllers/flp/flp_controller_test.go
@@ -681,17 +681,17 @@ func ControllerSpecs() {
 			By("Expecting Writer ClusterRole")
 			Eventually(func() interface{} {
 				var cr rbacv1.ClusterRole
-				return k8sClient.Get(ctx, types.NamespacedName{Name: constants.LokiCRWriter}, &cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: constants.CRWriter}, &cr)
 			}, timeout, interval).Should(Succeed())
 			By("Expecting Reader ClusterRole")
 			Eventually(func() interface{} {
 				var cr rbacv1.ClusterRole
-				return k8sClient.Get(ctx, types.NamespacedName{Name: constants.LokiCRReader}, &cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: constants.CRReader}, &cr)
 			}, timeout, interval).Should(Succeed())
 			By("Expecting FLP Writer ClusterRoleBinding")
 			Eventually(func() interface{} {
 				var crb rbacv1.ClusterRoleBinding
-				return k8sClient.Get(ctx, types.NamespacedName{Name: constants.LokiCRBWriter}, &crb)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: constants.CRBWriter}, &crb)
 			}, timeout, interval).Should(Succeed())
 		})
 

--- a/controllers/flp/flp_controller_test.go
+++ b/controllers/flp/flp_controller_test.go
@@ -681,17 +681,17 @@ func ControllerSpecs() {
 			By("Expecting Writer ClusterRole")
 			Eventually(func() interface{} {
 				var cr rbacv1.ClusterRole
-				return k8sClient.Get(ctx, types.NamespacedName{Name: constants.CRWriter}, &cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: constants.LokiCRWriter}, &cr)
 			}, timeout, interval).Should(Succeed())
 			By("Expecting Reader ClusterRole")
 			Eventually(func() interface{} {
 				var cr rbacv1.ClusterRole
-				return k8sClient.Get(ctx, types.NamespacedName{Name: constants.CRReader}, &cr)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: constants.LokiCRReader}, &cr)
 			}, timeout, interval).Should(Succeed())
 			By("Expecting FLP Writer ClusterRoleBinding")
 			Eventually(func() interface{} {
 				var crb rbacv1.ClusterRoleBinding
-				return k8sClient.Get(ctx, types.NamespacedName{Name: constants.CRBWriter}, &crb)
+				return k8sClient.Get(ctx, types.NamespacedName{Name: constants.LokiCRBWriter}, &crb)
 			}, timeout, interval).Should(Succeed())
 		})
 

--- a/controllers/flp/flp_monolith_reconciler.go
+++ b/controllers/flp/flp_monolith_reconciler.go
@@ -210,5 +210,5 @@ func (r *monolithReconciler) reconcilePermissions(ctx context.Context, builder *
 		}
 	}
 
-	return reconcileLokiRoles(ctx, r.Common, &builder.generic)
+	return reconcileDataAccessRoles(ctx, r.Common, &builder.generic)
 }

--- a/controllers/flp/flp_test.go
+++ b/controllers/flp/flp_test.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var resources = corev1.ResourceRequirements{
+var rs = corev1.ResourceRequirements{
 	Limits: map[corev1.ResourceName]resource.Quantity{
 		corev1.ResourceCPU:    resource.MustParse("1"),
 		corev1.ResourceMemory: resource.MustParse("512Mi"),
@@ -63,7 +63,7 @@ func getConfig() flowslatest.FlowCollectorSpec {
 		Processor: flowslatest.FlowCollectorFLP{
 			ImagePullPolicy: string(pullPolicy),
 			LogLevel:        "trace",
-			Resources:       resources,
+			Resources:       rs,
 			Metrics: flowslatest.FLPMetrics{
 				Server: flowslatest.MetricsServerConfig{
 					Port: ptr.To(int32(9090)),

--- a/controllers/flp/flp_transfo_reconciler.go
+++ b/controllers/flp/flp_transfo_reconciler.go
@@ -228,5 +228,5 @@ func (r *transformerReconciler) reconcilePermissions(ctx context.Context, builde
 		return err
 	}
 
-	return reconcileLokiRoles(ctx, r.Common, &builder.generic)
+	return reconcileDataAccessRoles(ctx, r.Common, &builder.generic)
 }

--- a/pkg/loki/roles.go
+++ b/pkg/loki/roles.go
@@ -10,13 +10,13 @@ import (
 
 func ClusterRoles(appName, saName, namespace string) ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) {
 	crb := writerBinding(appName, saName, namespace)
-	return []rbacv1.ClusterRole{resources.NetObservWriterCR, resources.NetObservReaderCR}, []rbacv1.ClusterRoleBinding{*crb}
+	return []rbacv1.ClusterRole{resources.LokiWriterCR, resources.LokiReaderCR}, []rbacv1.ClusterRoleBinding{*crb}
 }
 
 func writerBinding(appName, saName, namespace string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: constants.CRBWriter,
+			Name: constants.LokiCRBWriter,
 			Labels: map[string]string{
 				"app": appName,
 			},
@@ -24,7 +24,7 @@ func writerBinding(appName, saName, namespace string) *rbacv1.ClusterRoleBinding
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     constants.CRWriter,
+			Name:     constants.LokiCRWriter,
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind:      "ServiceAccount",

--- a/pkg/loki/roles.go
+++ b/pkg/loki/roles.go
@@ -6,42 +6,20 @@ import (
 
 	flowslatest "github.com/netobserv/network-observability-operator/apis/flowcollector/v1beta2"
 	"github.com/netobserv/network-observability-operator/controllers/constants"
+	"github.com/netobserv/network-observability-operator/pkg/resources"
 )
 
 func ClusterRoles(mode flowslatest.LokiMode) []rbacv1.ClusterRole {
 	if mode == flowslatest.LokiModeLokiStack {
-		return []rbacv1.ClusterRole{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: constants.LokiCRWriter,
-				},
-				Rules: []rbacv1.PolicyRule{{
-					APIGroups:     []string{"loki.grafana.com"},
-					Resources:     []string{"network"},
-					ResourceNames: []string{"logs"},
-					Verbs:         []string{"create"},
-				}},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: constants.LokiCRReader,
-				},
-				Rules: []rbacv1.PolicyRule{{
-					APIGroups:     []string{"loki.grafana.com"},
-					Resources:     []string{"network"},
-					ResourceNames: []string{"logs"},
-					Verbs:         []string{"get"},
-				}},
-			},
-		}
+		return []rbacv1.ClusterRole{resources.NetObservWriterCR, resources.NetObservReaderCR}
 	}
-	return []rbacv1.ClusterRole{}
+	return []rbacv1.ClusterRole{resources.NetObservReaderCR}
 }
 
 func ClusterRoleBinding(appName, saName, namespace string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: constants.LokiCRBWriter,
+			Name: constants.CRBWriter,
 			Labels: map[string]string{
 				"app": appName,
 			},
@@ -49,7 +27,7 @@ func ClusterRoleBinding(appName, saName, namespace string) *rbacv1.ClusterRoleBi
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     constants.LokiCRWriter,
+			Name:     constants.CRWriter,
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind:      "ServiceAccount",

--- a/pkg/loki/roles.go
+++ b/pkg/loki/roles.go
@@ -4,19 +4,16 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	flowslatest "github.com/netobserv/network-observability-operator/apis/flowcollector/v1beta2"
 	"github.com/netobserv/network-observability-operator/controllers/constants"
 	"github.com/netobserv/network-observability-operator/pkg/resources"
 )
 
-func ClusterRoles(mode flowslatest.LokiMode) []rbacv1.ClusterRole {
-	if mode == flowslatest.LokiModeLokiStack {
-		return []rbacv1.ClusterRole{resources.NetObservWriterCR, resources.NetObservReaderCR}
-	}
-	return []rbacv1.ClusterRole{resources.NetObservReaderCR}
+func ClusterRoles(appName, saName, namespace string) ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) {
+	crb := writerBinding(appName, saName, namespace)
+	return []rbacv1.ClusterRole{resources.NetObservWriterCR, resources.NetObservReaderCR}, []rbacv1.ClusterRoleBinding{*crb}
 }
 
-func ClusterRoleBinding(appName, saName, namespace string) *rbacv1.ClusterRoleBinding {
+func writerBinding(appName, saName, namespace string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.CRBWriter,

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -30,6 +30,7 @@ import (
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;create;delete;update;patch;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions;networks,verbs=get;list;watch
 //+kubebuilder:rbac:groups=loki.grafana.com,resources=network,resourceNames=logs,verbs=get;create
+//+kubebuilder:rbac:groups=metrics.k8s.io,resources=pods,verbs=create
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:urls="/metrics",verbs=get
 

--- a/pkg/resources/static_resources.go
+++ b/pkg/resources/static_resources.go
@@ -7,9 +7,9 @@ import (
 	"github.com/netobserv/network-observability-operator/controllers/constants"
 )
 
-var NetObservWriterCR = rbacv1.ClusterRole{
+var LokiWriterCR = rbacv1.ClusterRole{
 	ObjectMeta: metav1.ObjectMeta{
-		Name: constants.CRWriter,
+		Name: constants.LokiCRWriter,
 	},
 	Rules: []rbacv1.PolicyRule{{
 		APIGroups:     []string{"loki.grafana.com"},
@@ -19,18 +19,25 @@ var NetObservWriterCR = rbacv1.ClusterRole{
 	}},
 }
 
-var NetObservReaderCR = rbacv1.ClusterRole{
+var LokiReaderCR = rbacv1.ClusterRole{
 	ObjectMeta: metav1.ObjectMeta{
-		Name: constants.CRReader,
+		Name: constants.LokiCRReader,
+	},
+	Rules: []rbacv1.PolicyRule{{
+		APIGroups:     []string{"loki.grafana.com"},
+		Resources:     []string{"network"},
+		ResourceNames: []string{"logs"},
+		Verbs:         []string{"get"},
+	}},
+}
+
+var PromReaderCR = rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: constants.PromCRReader,
 	},
 	Rules: []rbacv1.PolicyRule{{
 		APIGroups: []string{"metrics.k8s.io"},
 		Resources: []string{"pods"},
 		Verbs:     []string{"create"},
-	}, {
-		APIGroups:     []string{"loki.grafana.com"},
-		Resources:     []string{"network"},
-		ResourceNames: []string{"logs"},
-		Verbs:         []string{"get"},
 	}},
 }

--- a/pkg/resources/static_resources.go
+++ b/pkg/resources/static_resources.go
@@ -1,0 +1,36 @@
+package resources
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/netobserv/network-observability-operator/controllers/constants"
+)
+
+var NetObservWriterCR = rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: constants.CRWriter,
+	},
+	Rules: []rbacv1.PolicyRule{{
+		APIGroups:     []string{"loki.grafana.com"},
+		Resources:     []string{"network"},
+		ResourceNames: []string{"logs"},
+		Verbs:         []string{"create"},
+	}},
+}
+
+var NetObservReaderCR = rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: constants.CRReader,
+	},
+	Rules: []rbacv1.PolicyRule{{
+		APIGroups: []string{"metrics.k8s.io"},
+		Resources: []string{"pods"},
+		Verbs:     []string{"create"},
+	}, {
+		APIGroups:     []string{"loki.grafana.com"},
+		Resources:     []string{"network"},
+		ResourceNames: []string{"logs"},
+		Verbs:         []string{"get"},
+	}},
+}


### PR DESCRIPTION
## Description

A new role is created for reading metrics. This role is separate from netobserv-reader role, because it is meant to be namespace-scoped and not cluster-wide (whereas for Loki multi-tenancy, netobserv-reader has to be bound cluster-wide).

To use this role, just write: 

```bash
oc adm policy add-role-to-user netobserv-metrics-reader test -n my-namespace
```

This will grant user "test" access to the netflow metrics in the "my-namespace" namespace, which can be used both in the developer view and in the adminitrator view.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
