### PR TITLE
NETOBSERV-1786: Automatically update bundle reference in the catalog

### DIFF
--- a/.tekton/network-observability-operator-bundle-pull-request.yaml
+++ b/.tekton/network-observability-operator-bundle-pull-request.yaml
@@ -12,6 +12,7 @@ metadata:
       "bundle.Dockerfile".pathChanged() ||
       "bundle/***".pathChanged() ||
       "hack/update-build.sh".pathChanged() ||
+      "hack/container_digest.sh".pathChanged() ||
       "hack/patch_csv.py".pathChanged())
   creationTimestamp: null
   labels:

--- a/.tekton/network-observability-operator-bundle-push.yaml
+++ b/.tekton/network-observability-operator-bundle-push.yaml
@@ -5,12 +5,14 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/netobserv/network-observability-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.openshift.io/build-nudge-files: "hack/bundle_digest.sh"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"  &&
       (".tekton/***".pathChanged() ||
       "bundle.Dockerfile".pathChanged() ||
       "bundle/***".pathChanged() ||
       "hack/update-build.sh".pathChanged() ||
+      "hack/container_digest.sh".pathChanged() ||
       "hack/patch_csv.py".pathChanged())
   creationTimestamp: null
   labels:

--- a/.tekton/network-observability-operator-fbc-pull-request.yaml
+++ b/.tekton/network-observability-operator-fbc-pull-request.yaml
@@ -12,6 +12,8 @@ metadata:
       "catalog.Dockerfile".pathChanged() ||
       "catalog/***".pathChanged() ||
       "hack/update-build.sh".pathChanged() ||
+      "hack/bundle_digest.sh".pathChanged() ||
+      "hack/patch_catalog.py".pathChanged() ||
       "hack/patch_csv.py".pathChanged())
   creationTimestamp: null
   labels:

--- a/.tekton/network-observability-operator-fbc-push.yaml
+++ b/.tekton/network-observability-operator-fbc-push.yaml
@@ -11,6 +11,8 @@ metadata:
       "catalog.Dockerfile".pathChanged() ||
       "catalog/***".pathChanged() ||
       "hack/update-build.sh".pathChanged() ||
+      "hack/bundle_digest.sh".pathChanged() ||
+      "hack/patch_catalog.py".pathChanged() ||
       "hack/patch_csv.py".pathChanged())
   creationTimestamp: null
   labels:

--- a/catalog/index.yaml
+++ b/catalog/index.yaml
@@ -6,7 +6,7 @@ icon:
 name: netobserv-operator
 schema: olm.package
 ---
-image: quay.io/ocazade0/network-observability-operator-bundle:v1.6.1-community
+image: quay.io/netobserv/network-observability-operator-bundle:v1.6.1-community
 name: netobserv-operator.v1.6.1-community
 package: netobserv-operator
 properties:

--- a/hack/bundle_digest.sh
+++ b/hack/bundle_digest.sh
@@ -1,0 +1,1 @@
+export BUNDLE_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/ocp-network-observab-tenant/netobserv-operator/network-observability-operator-bundle@sha256:14e6d2e175b37bb7a163f8e7b45d88ede622777a34237810c2c57406451d69f1'

--- a/hack/patch_catalog.py
+++ b/hack/patch_catalog.py
@@ -6,7 +6,9 @@ yaml = YAML()
 yaml.explicit_start = True
 
 version = os.getenv('VERSION')
-bundle_image = 'registry.redhat.io/network-observability/network-observability-operator-bundle:v{}'.format(version)
+bundle_image = os.getenv('BUNDLE_IMAGE_PULLSPEC')
+package_name = "netobserv-operator"
+package_full_name = '{}.v{}'.format(package_name, version)
 
 def load_index(pathn):
    if not pathn.endswith(".yaml"):
@@ -28,4 +30,14 @@ index = load_index(os.getenv('TARGET_INDEX_FILE'))
 
 index[1]["image"] = bundle_image
 
+# Changing package name
+index[1]["name"] = package_full_name
+index[2]["entries"][0]["name"] = package_full_name
+for prop in index[1]["properties"]:
+   if prop["type"] == "olm.package":
+      prop["value"]["version"] = version
+
+# Setting channel to stable
+index[0]["defaultChannel"] = "stable"
+index[2]["name"] = "stable"
 dump_index(os.getenv('TARGET_INDEX_FILE'), index)

--- a/hack/update-build.sh
+++ b/hack/update-build.sh
@@ -21,6 +21,7 @@ csv_file="${manifests_dir}/${csv_name}"
 index_file="./catalog/index.yaml"
 
 source ./hack/container_digest.sh
+source ./hack/bundle_digest.sh
 
 cat <<EOF >>"${CONTAINER_FILE}"
 LABEL com.redhat.component="network-observability-operator-container"
@@ -76,3 +77,6 @@ REPLACES="${REPLACE_VERSION}" VERSION="${TARGET_VERSION}" TARGET_INDEX_FILE="${i
 
 sed -i 's/operators.operatorframework.io.bundle.channels.v1: latest,community/operators.operatorframework.io.bundle.channels.v1: stable/g' ./bundle/metadata/annotations.yaml
 sed -i 's/operators.operatorframework.io.bundle.channel.default.v1: community/operators.operatorframework.io.bundle.channel.default.v1: stable/g' ./bundle/metadata/annotations.yaml
+
+#Using downstream base image
+sed -i 's/\(FROM.*\)docker.io\/library\/golang:1.22\(.*\)/\1brew.registry.redhat.io\/rh-osbs\/openshift-golang-builder:v1.22.5-202407301806.g4c8b32d.el9\2/g' ./Dockerfile


### PR DESCRIPTION
## Description

Automatically update bundle reference in the catalog using nudge feature from konflux

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
