### PR TITLE
NETOBSERV-1633: Enable prefetch dependencies in konlfux build pipelines

### DIFF
--- a/.tekton/network-observability-operator-bundle-pull-request.yaml
+++ b/.tekton/network-observability-operator-bundle-pull-request.yaml
@@ -103,7 +103,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default:  "{\"type\":\"gomod\", \"path\":\".\"}"
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/network-observability-operator-bundle-push.yaml
+++ b/.tekton/network-observability-operator-bundle-push.yaml
@@ -101,7 +101,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: "{\"type\":\"gomod\", \"path\":\".\"}"
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/network-observability-operator-fbc-pull-request.yaml
+++ b/.tekton/network-observability-operator-fbc-pull-request.yaml
@@ -104,7 +104,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: "{\"type\":\"gomod\", \"path\":\".\"}"
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/network-observability-operator-fbc-push.yaml
+++ b/.tekton/network-observability-operator-fbc-push.yaml
@@ -101,7 +101,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: "{\"type\":\"gomod\", \"path\":\".\"}"
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/network-observability-operator-pull-request.yaml
+++ b/.tekton/network-observability-operator-pull-request.yaml
@@ -111,7 +111,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: "{\"type\":\"gomod\", \"path\":\".\"}"
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/network-observability-operator-push.yaml
+++ b/.tekton/network-observability-operator-push.yaml
@@ -109,7 +109,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: "{\"type\":\"gomod\", \"path\":\".\"}"
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string


### PR DESCRIPTION
## Description

Enable prefetch dependencies in konlfux build pipelines, this is not needed to build but required by release pipeline.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
