### PR TITLE
NETOBSERV-1893: fix netobserv-mertics-reader role creation [1.7 backport]

### DIFF
--- a/controllers/flp/flp_controller.go
+++ b/controllers/flp/flp_controller.go
@@ -269,8 +269,8 @@ func reconcileDataAccessRoles(ctx context.Context, r *reconcilers.Common, b *bui
 			}
 		}
 	}
-	// Install netobserv-metrics-reader role; copy to avoid any undesired mutation
-	cr := resources.PromReaderCR
+	// Install netobserv-metrics-reader role
+	cr := resources.PromReaderCR()
 	return r.ReconcileClusterRole(ctx, &cr)
 }
 

--- a/controllers/flp/flp_controller.go
+++ b/controllers/flp/flp_controller.go
@@ -269,8 +269,9 @@ func reconcileDataAccessRoles(ctx context.Context, r *reconcilers.Common, b *bui
 			}
 		}
 	}
-	// Install netobserv-metrics-reader role
-	return r.ReconcileClusterRole(ctx, &resources.PromReaderCR)
+	// Install netobserv-metrics-reader role; copy to avoid any undesired mutation
+	cr := resources.PromReaderCR
+	return r.ReconcileClusterRole(ctx, &cr)
 }
 
 func (r *Reconciler) getOpenShiftSubnets(ctx context.Context) ([]flowslatest.SubnetLabel, error) {

--- a/pkg/loki/roles.go
+++ b/pkg/loki/roles.go
@@ -10,7 +10,7 @@ import (
 
 func ClusterRoles(appName, saName, namespace string) ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) {
 	crb := writerBinding(appName, saName, namespace)
-	return []rbacv1.ClusterRole{resources.LokiWriterCR, resources.LokiReaderCR}, []rbacv1.ClusterRoleBinding{*crb}
+	return []rbacv1.ClusterRole{resources.LokiWriterCR(), resources.LokiReaderCR()}, []rbacv1.ClusterRoleBinding{*crb}
 }
 
 func writerBinding(appName, saName, namespace string) *rbacv1.ClusterRoleBinding {

--- a/pkg/resources/static_resources.go
+++ b/pkg/resources/static_resources.go
@@ -7,37 +7,43 @@ import (
 	"github.com/netobserv/network-observability-operator/controllers/constants"
 )
 
-var LokiWriterCR = rbacv1.ClusterRole{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: constants.LokiCRWriter,
-	},
-	Rules: []rbacv1.PolicyRule{{
-		APIGroups:     []string{"loki.grafana.com"},
-		Resources:     []string{"network"},
-		ResourceNames: []string{"logs"},
-		Verbs:         []string{"create"},
-	}},
+func LokiWriterCR() rbacv1.ClusterRole {
+	return rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.LokiCRWriter,
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups:     []string{"loki.grafana.com"},
+			Resources:     []string{"network"},
+			ResourceNames: []string{"logs"},
+			Verbs:         []string{"create"},
+		}},
+	}
 }
 
-var LokiReaderCR = rbacv1.ClusterRole{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: constants.LokiCRReader,
-	},
-	Rules: []rbacv1.PolicyRule{{
-		APIGroups:     []string{"loki.grafana.com"},
-		Resources:     []string{"network"},
-		ResourceNames: []string{"logs"},
-		Verbs:         []string{"get"},
-	}},
+func LokiReaderCR() rbacv1.ClusterRole {
+	return rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.LokiCRReader,
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups:     []string{"loki.grafana.com"},
+			Resources:     []string{"network"},
+			ResourceNames: []string{"logs"},
+			Verbs:         []string{"get"},
+		}},
+	}
 }
 
-var PromReaderCR = rbacv1.ClusterRole{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: constants.PromCRReader,
-	},
-	Rules: []rbacv1.PolicyRule{{
-		APIGroups: []string{"metrics.k8s.io"},
-		Resources: []string{"pods"},
-		Verbs:     []string{"create"},
-	}},
+func PromReaderCR() rbacv1.ClusterRole {
+	return rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.PromCRReader,
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"metrics.k8s.io"},
+			Resources: []string{"pods"},
+			Verbs:     []string{"create"},
+		}},
+	}
 }


### PR DESCRIPTION
Prevent undesired mutation of the role by copying it before use.

backport of https://github.com/netobserv/network-observability-operator/pull/799


## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
