### PR TITLE
NETOBSERV-1933: do not set default additional namespaces for netpol

### DIFF
--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -100,7 +100,6 @@ type NetworkPolicy struct {
 	// `additionalNamespaces` contains additional namespaces allowed to connect to the NetObserv namespace.
 	// It gives some flexibility in the network policy configuration, however should you need a more specific
 	// configuration, you can disable it and install your own instead.
-	//+kubebuilder:default:={"openshift-console", "openshift-monitoring"}
 	//+optional
 	AdditionalNamespaces []string `json:"additionalNamespaces"`
 }

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -6690,9 +6690,6 @@ spec:
                   for NetObserv components isolation.'
                 properties:
                   additionalNamespaces:
-                    default:
-                    - openshift-console
-                    - openshift-monitoring
                     description: |-
                       `additionalNamespaces` contains additional namespaces allowed to connect to the NetObserv namespace.
                       It gives some flexibility in the network policy configuration, however should you need a more specific

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -6148,9 +6148,6 @@ spec:
                   description: '`networkPolicy` defines ingress network policy settings for NetObserv components isolation.'
                   properties:
                     additionalNamespaces:
-                      default:
-                        - openshift-console
-                        - openshift-monitoring
                       description: |-
                         `additionalNamespaces` contains additional namespaces allowed to connect to the NetObserv namespace.
                         It gives some flexibility in the network policy configuration, however should you need a more specific

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -13828,8 +13828,6 @@ If the namespace is different, the config map or the secret is copied so that it
           `additionalNamespaces` contains additional namespaces allowed to connect to the NetObserv namespace.
 It gives some flexibility in the network policy configuration, however should you need a more specific
 configuration, you can disable it and install your own instead.<br/>
-          <br/>
-            <i>Default</i>: [openshift-console openshift-monitoring]<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
## Description

Default namespaces are handled in code, do not add extra namespaces by default or they will be listed twice in the network policy


<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
