### PR TITLE
NETOBSERV-1934: allow connection from apiserver

### DIFF
--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -9,6 +9,7 @@ import (
 const (
 	DefaultOperatorNamespace = "netobserv"
 	OperatorName             = "netobserv-operator"
+	WebhookPort              = 9443
 	FLPName                  = "flowlogs-pipeline"
 	FLPPortName              = "flp" // must be <15 chars
 	FLPMetricsPort           = 9401

--- a/controllers/networkpolicy/np_objects.go
+++ b/controllers/networkpolicy/np_objects.go
@@ -81,6 +81,20 @@ func buildMainNetworkPolicy(desired *flowslatest.FlowCollector, mgr *manager.Man
 				},
 			})
 		}
+		// Allow apiserver/host
+		np.Spec.Ingress = append(np.Spec.Ingress, networkingv1.NetworkPolicyIngressRule{
+			From: []networkingv1.NetworkPolicyPeer{
+				{
+					NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"policy-group.network.openshift.io/host-network": "",
+					}},
+				},
+			},
+			Ports: []networkingv1.NetworkPolicyPort{{
+				Protocol: ptr.To(corev1.ProtocolTCP),
+				Port:     ptr.To(intstr.FromInt32(constants.WebhookPort)),
+			}},
+		})
 	}
 
 	for _, aNs := range desired.Spec.NetworkPolicy.AdditionalNamespaces {

--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func main() {
 			TLSOpts:     []func(*tls.Config){disableHTTP2},
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port:    9443,
+			Port:    constants.WebhookPort,
 			TLSOpts: []func(*tls.Config){disableHTTP2},
 		}),
 		PprofBindAddress:       pprofAddr,


### PR DESCRIPTION
## Description

It's actually using host/mp0 interface, so needs a "policy-group.network.openshift.io/host-network" label rule


<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
