### PR TITLE
NETOBSERV-1580: update frontend config for CLI

### DIFF
--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -440,6 +440,7 @@ columns:
   - id: Bytes
     name: Bytes
     tooltip: The total aggregated number of bytes.
+    field: Bytes
     fields:
       - Bytes
       - PktDropBytes
@@ -448,6 +449,7 @@ columns:
   - id: Packets
     name: Packets
     tooltip: The total aggregated number of packets.
+    field: Packets
     fields:
       - Packets
       - PktDropPackets
@@ -473,6 +475,41 @@ columns:
     calculated: substract(column.CollectionTime,TimeFlowEndMs)
     default: false
     width: 5
+  - id: PktDropBytes
+    name: Dropped Bytes
+    tooltip: The total aggregated number of bytes dropped.
+    field: PktDropBytes
+    default: false
+    width: 5
+    feature: pktDrop
+  - id: PktDropPackets
+    name: Dropped Packets
+    tooltip: The total aggregated number of packets dropped.
+    field: PktDropPackets
+    default: false
+    width: 5
+    feature: pktDrop
+  - id: PktDropLatestState
+    name: Drop State
+    tooltip: TCP state on last dropped packet.
+    field: PktDropLatestState
+    default: false
+    width: 10
+    feature: pktDrop
+  - id: PktDropLatestDropCause
+    name: Drop Cause
+    tooltip: TCP state on last dropped packet.
+    field: PktDropLatestDropCause
+    default: false
+    width: 10
+    feature: pktDrop
+  - id: PktDropLatestFlags
+    name: Drop Flags
+    tooltip: TCP flags on last dropped packet.
+    field: PktDropLatestFlags
+    default: false
+    width: 10
+    feature: pktDrop
   - id: DNSId
     group: DNS
     name: DNS Id


### PR DESCRIPTION
## Description

Simple config update to make CLI compatible
- added missing fields references when multiple fields were involved (console plugin takes the array in priority)
- added missing drop related fields (these will not be shown by default but selectable in the plugin)

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [X] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
