### PR TITLE
NETOBSERV-1885: improve resource filter descriptions

### DIFF
--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -658,26 +658,24 @@ filters:
     name: Resource
     component: autocomplete
     category: source
-    placeholder: 'E.g: Pod.default.my-pod'
+    placeholder: 'E.g: Deployment.example.my-dep or Pod.default.my-pod'
     hint: Specify an existing resource from its kind, namespace and name.
     examples: |-
       Specify a kind, namespace and name from existing:
               - Select kind first from suggestions
-              - Then Select namespace from suggestions
+              - Then select namespace from suggestions
               - Finally select name from suggestions
-              You can also directly specify a kind, namespace and name like pod.openshift.apiserver
   - id: dst_resource
     name: Resource
     component: autocomplete
     category: destination
-    placeholder: 'E.g: Pod.default.my-pod'
+    placeholder: 'E.g: Deployment.example.my-dep or Pod.default.my-pod'
     hint: Specify an existing resource from its kind, namespace and name.
     examples: |-
       Specify a kind, namespace and name from existing:
               - Select kind first from suggestions
-              - Then Select namespace from suggestions
+              - Then select namespace from suggestions
               - Finally select name from suggestions
-              You can also directly specify a kind, namespace and name like pod.openshift.apiserver
   - id: src_address
     name: IP
     component: text


### PR DESCRIPTION
## Description

Improve misleading descriptions

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
