### PR TITLE
NETOBSERV-1890: expand TCP flags as string in FLP

### DIFF
--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -814,21 +814,9 @@ filters:
   - id: tcp_flags
     name: TCP flags
     component: autocomplete
-    hint: Specify a TCP flags value as integer number.
+    hint: Specify a TCP flags value.
     examples: |-
-      Logical OR combination of unique TCP flags comprised in the flow, as per RFC-9293, with additional custom flags
-      users can specify either numeric value or string representation of the flags as follows :
-      - FIN or 1,
-      - SYN or 2,
-      - RST or 4,
-      - PSH or 8,
-      - ACK or 16,
-      - URG or 32,
-      - ECE or 64,
-      - CWR or 128,
-      - SYN_ACK or 256,
-      - FIN_ACK or 512,
-      - RST_ACK or 1024,
+      Logical OR combination of unique TCP flags comprised in the flow, as per RFC-9293, with additional custom flags (SYN_ACK, FIN_ACK and RST_ACK).
   - id: node_direction
     name: Node Direction
     component: autocomplete
@@ -1142,7 +1130,7 @@ fields:
     type: string
     description: Network interfaces
   - name: Flags
-    type: number
+    type: string
     description: |
       Logical OR combination of unique TCP flags comprised in the flow, as per RFC-9293, with additional custom flags to represent the following per-packet combinations: +
       - SYN+ACK (0x100) +

--- a/controllers/flp/flp_pipeline_builder.go
+++ b/controllers/flp/flp_pipeline_builder.go
@@ -93,6 +93,13 @@ func (b *PipelineBuilder) AddProcessorStages() error {
 			Type: api.NetworkReinterpretDirection,
 		},
 		{
+			Type: api.NetworkDecodeTCPFlags,
+			DecodeTCPFlags: &api.NetworkGenericRule{
+				Input:  "Flags",
+				Output: "Flags",
+			},
+		},
+		{
 			Type: api.NetworkAddKubernetesInfra,
 			KubernetesInfra: &api.K8sInfraRule{
 				NamespaceNameFields: []api.K8sReference{

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/coreos/go-semver v0.3.1
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0
-	github.com/netobserv/flowlogs-pipeline v1.7.0-community.0.20241126083919-0fa789ce0e58
+	github.com/netobserv/flowlogs-pipeline v1.7.0-community.0.20241126155124-18e017f67001
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.35.1
 	github.com/openshift/api v0.0.0-20240722135205-ae4f370f361f

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/netobserv/flowlogs-pipeline v1.7.0-community.0.20241126083919-0fa789ce0e58 h1:wfk7Sl0rMoDqfUgvfwlStCGXtIgrtwo4h2LDEGGjgrs=
-github.com/netobserv/flowlogs-pipeline v1.7.0-community.0.20241126083919-0fa789ce0e58/go.mod h1:wnCpWttAFkLSSxOcfCkd9zA5pwV/1OcxS5tAfAxNWEc=
+github.com/netobserv/flowlogs-pipeline v1.7.0-community.0.20241126155124-18e017f67001 h1:Hb5RxMfFafng2+QbnkiEWTS4TUUz7zcpUS8RiauzWXw=
+github.com/netobserv/flowlogs-pipeline v1.7.0-community.0.20241126155124-18e017f67001/go.mod h1:wnCpWttAFkLSSxOcfCkd9zA5pwV/1OcxS5tAfAxNWEc=
 github.com/netobserv/prometheus-common v0.55.0-netobserv h1:Fapr74g0S3gRh/kTTyv9Ytm4DJJfFuUTEToiU/np9eg=
 github.com/netobserv/prometheus-common v0.55.0-netobserv/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
 github.com/onsi/ginkgo/v2 v2.20.2 h1:7NVCeyIWROIAheY21RLS+3j2bb52W0W82tkberYytp4=

--- a/pkg/helper/cardinality/cardinality.json
+++ b/pkg/helper/cardinality/cardinality.json
@@ -35,7 +35,7 @@
   "FlowDirection": "fine",
   "IfDirections": "fine",
   "Interfaces": "careful",
-  "Flags": "fine",
+  "Flags": "careful",
   "Bytes": "avoid",
   "Packets": "avoid",
   "PktDropBytes": "avoid",

--- a/vendor/github.com/netobserv/flowlogs-pipeline/pkg/api/transform_network.go
+++ b/vendor/github.com/netobserv/flowlogs-pipeline/pkg/api/transform_network.go
@@ -59,6 +59,7 @@ const (
 	NetworkAddKubernetesInfra   TransformNetworkOperationEnum = "add_kubernetes_infra"  // add output kubernetes isInfra field from input
 	NetworkReinterpretDirection TransformNetworkOperationEnum = "reinterpret_direction" // reinterpret flow direction at the node level (instead of net interface), to ease the deduplication process
 	NetworkAddSubnetLabel       TransformNetworkOperationEnum = "add_subnet_label"      // categorize IPs based on known subnets configuration
+	NetworkDecodeTCPFlags       TransformNetworkOperationEnum = "decode_tcp_flags"      // decode bitwise TCP flags into a string
 )
 
 type NetworkTransformRule struct {
@@ -69,6 +70,7 @@ type NetworkTransformRule struct {
 	AddLocation     *NetworkGenericRule           `yaml:"add_location,omitempty" json:"add_location,omitempty" doc:"Add location rule configuration"`
 	AddSubnetLabel  *NetworkAddSubnetLabelRule    `yaml:"add_subnet_label,omitempty" json:"add_subnet_label,omitempty" doc:"Add subnet label rule configuration"`
 	AddService      *NetworkAddServiceRule        `yaml:"add_service,omitempty" json:"add_service,omitempty" doc:"Add service rule configuration"`
+	DecodeTCPFlags  *NetworkGenericRule           `yaml:"decode_tcp_flags,omitempty" json:"decode_tcp_flags,omitempty" doc:"Decode bitwise TCP flags into a string"`
 }
 
 type K8sInfraRule struct {

--- a/vendor/github.com/netobserv/flowlogs-pipeline/pkg/utils/tcp_flags.go
+++ b/vendor/github.com/netobserv/flowlogs-pipeline/pkg/utils/tcp_flags.go
@@ -1,0 +1,30 @@
+package utils
+
+type tcpFlag struct {
+	value uint16
+	name  string
+}
+
+var tcpFlags = []tcpFlag{
+	{value: 1, name: "FIN"},
+	{value: 2, name: "SYN"},
+	{value: 4, name: "RST"},
+	{value: 8, name: "PSH"},
+	{value: 16, name: "ACK"},
+	{value: 32, name: "URG"},
+	{value: 64, name: "ECE"},
+	{value: 128, name: "CWR"},
+	{value: 256, name: "SYN_ACK"},
+	{value: 512, name: "FIN_ACK"},
+	{value: 1024, name: "RST_ACK"},
+}
+
+func DecodeTCPFlags(bitfield uint16) []string {
+	var values []string
+	for _, flag := range tcpFlags {
+		if bitfield&flag.value != 0 {
+			values = append(values, flag.name)
+		}
+	}
+	return values
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -123,7 +123,7 @@ github.com/munnerz/goautoneg
 # github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 ## explicit
 github.com/mwitkow/go-conntrack
-# github.com/netobserv/flowlogs-pipeline v1.7.0-community.0.20241126083919-0fa789ce0e58
+# github.com/netobserv/flowlogs-pipeline v1.7.0-community.0.20241126155124-18e017f67001
 ## explicit; go 1.22.3
 github.com/netobserv/flowlogs-pipeline/pkg/api
 github.com/netobserv/flowlogs-pipeline/pkg/config


### PR DESCRIPTION
## Description

Set tcp flags as a string field
Also change its cardinality to "careful", as it's any combination of values, it can be high potentially

## Dependencies

- FLP: https://github.com/netobserv/flowlogs-pipeline/pull/747
- Console plugin: https://github.com/netobserv/network-observability-console-plugin/pull/632

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
