### PR TITLE
NETOBSERV-1904 add configs for UDNs

### DIFF
--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -438,6 +438,13 @@ columns:
     field: Interfaces
     default: false
     width: 15
+  - id: UDN
+    name: User Defined Network
+    tooltip: The user defined network identifier.
+    field: UdnId
+    filter: udn
+    default: false
+    width: 15
   - id: Bytes
     name: Bytes
     tooltip: The total aggregated number of bytes.
@@ -849,6 +856,10 @@ filters:
     component: autocomplete
     placeholder: 'E.g: Ingress, Egress'
     hint: Specify the direction of the Flow observed at the network interface observation point.
+  - id: udn
+    name: User Defined Network
+    component: autocomplete
+    hint: Specify a user defined network name.
   - id: id
     name: Conversation Id
     component: text
@@ -913,6 +924,14 @@ scopes:
     feature: multiCluster
     filter: cluster_name
     stepInto: zone
+  - id: udn
+    name: UDN
+    shortName: UDN
+    description: User Defined Network
+    labels:
+      - UdnId
+    filter: udn
+    stepInto: host
   - id: zone
     name: Zone
     shortName: AZ
@@ -935,9 +954,12 @@ scopes:
       - SrcK8S_HostName
       - DstK8S_HostName
     groups:
-      - clusters
+      - udns
       - zones
+      - clusters
       - clusters+zones
+      - clusters+udns
+      - udns+zones
     filters:
       - src_host_name
       - dst_host_name
@@ -956,6 +978,9 @@ scopes:
       - zones
       - zones+hosts
       - hosts
+      - udns
+      - udns+zones
+      - udns+hosts
     filters:
       - src_namespace
       - dst_namespace
@@ -982,6 +1007,10 @@ scopes:
       - hosts
       - hosts+namespaces
       - namespaces
+      - udns
+      - udns+zones
+      - udns+hosts
+      - udns+namespaces
     filters:
       - src_owner_name
       - dst_owner_name
@@ -1021,6 +1050,11 @@ scopes:
       - namespaces
       - namespaces+owners
       - owners
+      - udns
+      - udns+zones
+      - udns+hosts
+      - udns+namespaces
+      - udns+owners
     filters:
       - src_resource
       - dst_resource
@@ -1195,6 +1229,10 @@ fields:
   - name: K8S_ClusterName
     type: string
     description: Cluster name or identifier
+  - name: UdnId
+    type: string
+    description: User Defined Network
+    lokiLabel: true
   - name: _RecordType
     type: string
     description: "Type of record: 'flowLog' for regular flow logs, or 'newConnection', 'heartbeat', 'endConnection' for conversation tracking"

--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -931,7 +931,7 @@ scopes:
     labels:
       - UdnId
     filter: udn
-    stepInto: host
+    stepInto: namespace
   - id: zone
     name: Zone
     shortName: AZ

--- a/controllers/flp/flp_test.go
+++ b/controllers/flp/flp_test.go
@@ -657,6 +657,7 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiManual(t *testing.T) {
 		"DstK8S_Type",
 		"K8S_FlowLayer",
 		"FlowDirection",
+		"UdnId",
 		"_RecordType",
 	}, lokiCfg.Labels)
 	assert.Equal(`{app="netobserv-flowcollector"}`, fmt.Sprintf("%v", lokiCfg.StaticLabels))
@@ -713,6 +714,7 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiStack(t *testing.T) {
 		"DstK8S_Type",
 		"K8S_FlowLayer",
 		"FlowDirection",
+		"UdnId",
 		"_RecordType",
 	}, lokiCfg.Labels)
 	assert.Equal(`{app="netobserv-flowcollector"}`, fmt.Sprintf("%v", lokiCfg.StaticLabels))

--- a/pkg/helper/loki/labels_test.go
+++ b/pkg/helper/loki/labels_test.go
@@ -20,6 +20,7 @@ func TestDefaultLokiLabels(t *testing.T) {
 		"DstK8S_Type",
 		"K8S_FlowLayer",
 		"FlowDirection",
+		"UdnId",
 	})
 }
 
@@ -40,6 +41,7 @@ func TestAllLokiLabels(t *testing.T) {
 		"DstK8S_Type",
 		"K8S_FlowLayer",
 		"FlowDirection",
+		"UdnId",
 		"_RecordType",
 		"K8S_ClusterName",
 		"SrcK8S_Zone",

--- a/pkg/helper/loki/loki-labels.json
+++ b/pkg/helper/loki/loki-labels.json
@@ -7,7 +7,8 @@
     "DstK8S_OwnerName",
     "DstK8S_Type",
     "K8S_FlowLayer",
-    "FlowDirection"
+    "FlowDirection",
+    "UdnId"
   ],
   "conntrack": [
     "_RecordType"


### PR DESCRIPTION
## Description

Update the config for UDNs to: 
- manage columns
-  filters
-  fields
-  scopes and groups 

## Dependencies

https://github.com/netobserv/network-observability-console-plugin/pull/656 for some display polishing

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
