### PR TITLE
NETOBSERV-1926 manage console-plugin-pf4-support-image

### DIFF
--- a/.mk/development.mk
+++ b/.mk/development.mk
@@ -165,8 +165,10 @@ endif
 set-plugin-image:
 ifeq ("", "$(CSV)")
 	kubectl set env -n $(NAMESPACE) deployment netobserv-controller-manager -c "manager" RELATED_IMAGE_CONSOLE_PLUGIN=quay.io/$(USER)/network-observability-console-plugin:$(VERSION)
+	kubectl set env -n $(NAMESPACE) deployment netobserv-controller-manager -c "manager" RELATED_IMAGE_CONSOLE_PLUGIN_PF4_SUPPORT=quay.io/$(USER)/network-observability-console-plugin:$(VERSION)
 else
 	./hack/swap-image-csv.sh $(CSV) $(OPERATOR_NS) console-plugin RELATED_IMAGE_CONSOLE_PLUGIN quay.io/$(USER)/network-observability-console-plugin:$(VERSION)
+	./hack/swap-image-csv.sh $(CSV) $(OPERATOR_NS) console-plugin RELATED_IMAGE_CONSOLE_PLUGIN_PF4_SUPPORT quay.io/$(USER)/network-observability-console-plugin:$(VERSION)
 endif
 	@echo -e "\n==> Redeploying..."
 	kubectl rollout status -n $(OPERATOR_NS) --timeout=60s deployment netobserv-controller-manager

--- a/.mk/local.mk
+++ b/.mk/local.mk
@@ -44,7 +44,8 @@ local-deploy-operator:
 	go run ./main.go \
 		-ebpf-agent-image=quay.io/netobserv/netobserv-ebpf-agent:main \
 		-flowlogs-pipeline-image=quay.io/netobserv/flowlogs-pipeline:main \
-		-console-plugin-image=quay.io/netobserv/network-observability-console-plugin:main &
+		-console-plugin-image=quay.io/netobserv/network-observability-console-plugin:main \
+		-console-plugin-pf4-support-image=quay.io/netobserv/network-observability-console-plugin:main &
 	@echo "====> Waiting for flowlogs-pipeline pod to be ready"
 	while : ; do kubectl get ds flowlogs-pipeline && break; sleep 1; done
 	kubectl wait --timeout=180s --for=condition=ready pod -l app=flowlogs-pipeline

--- a/.mk/ocp.mk
+++ b/.mk/ocp.mk
@@ -35,7 +35,8 @@ ocp-deploy-operator: ## run flp from the operator
 	go run ./main.go \
 		-ebpf-agent-image=quay.io/netobserv/netobserv-ebpf-agent:main \
 		-flowlogs-pipeline-image=quay.io/netobserv/flowlogs-pipeline:main \
-		-console-plugin-image=quay.io/netobserv/network-observability-console-plugin:main
+		-console-plugin-image=quay.io/netobserv/network-observability-console-plugin:main \
+		-console-plugin-pf4-support-image=quay.io/netobserv/network-observability-console-plugin:main
 
 .PHONY: undeploy-operator
 undeploy-operator: ## stop the operator locally

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -190,6 +190,8 @@ following the environment variables with your custom operand image with `kubectl
 * `RELATED_IMAGE_EBPF_AGENT`
 * `RELATED_IMAGE_FLOWLOGS_PIPELINE`
 * `RELATED_IMAGE_CONSOLE_PLUGIN`
+* `RELATED_IMAGE_CONSOLE_PLUGIN_PF4_SUPPORT` for OCP versions < 4.15.0
+
 
 Examples:
 
@@ -197,6 +199,7 @@ Examples:
 oc -n netobserv set env deployment/netobserv-controller-manager -c "manager" RELATED_IMAGE_EBPF_AGENT="quay.io/netobserv/netobserv-ebpf-agent:main"
 oc -n netobserv set env deployment/netobserv-controller-manager -c "manager" RELATED_IMAGE_FLOWLOGS_PIPELINE="quay.io/netobserv/flowlogs-pipeline:main"
 oc -n netobserv set env deployment/netobserv-controller-manager -c "manager" RELATED_IMAGE_CONSOLE_PLUGIN="quay.io/netobserv/network-observability-console-plugin:main"
+oc -n netobserv set env deployment/netobserv-controller-manager -c "manager" RELATED_IMAGE_CONSOLE_PLUGIN_PF4_SUPPORT="quay.io/netobserv/network-observability-console-plugin:main"
 ```
 
 Alternatively you can use helper make targets for the same purpose:
@@ -215,7 +218,7 @@ E.g:
 CSV=network-observability-operator.v1.2.0 USER=myself VERSION=test make set-agent-image set-flp-image set-plugin-image
 ```
 
-You can also do this by editing the CSV via the console by changing the image defined under `RELATED_IMAGE_EBPF_AGENT`, `RELATED_IMAGE_FLOWLOGS_PIPELINE`, and/or `RELATED_IMAGE_CONSOLE_PLUGIN`. If you are using this method, ensure that you are in the `openshift-netobserv-operator` namespace before updating the image value. If you are in a different namespace, then it reverts it back.
+You can also do this by editing the CSV via the console by changing the image defined under `RELATED_IMAGE_EBPF_AGENT`, `RELATED_IMAGE_FLOWLOGS_PIPELINE`, `RELATED_IMAGE_CONSOLE_PLUGIN` and/or `RELATED_IMAGE_CONSOLE_PLUGIN_PF4_SUPPORT`. If you are using this method, ensure that you are in the `openshift-netobserv-operator` namespace before updating the image value. If you are in a different namespace, then it reverts it back.
 
 ![Alt text](./docs/assets/console-csv.png)
 

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -1193,6 +1193,7 @@ spec:
                 - --ebpf-agent-image=$(RELATED_IMAGE_EBPF_AGENT)
                 - --flowlogs-pipeline-image=$(RELATED_IMAGE_FLOWLOGS_PIPELINE)
                 - --console-plugin-image=$(RELATED_IMAGE_CONSOLE_PLUGIN)
+                - --console-plugin-pf4-support-image=$(RELATED_IMAGE_CONSOLE_PLUGIN_PF4_SUPPORT)
                 - --downstream-deployment=$(DOWNSTREAM_DEPLOYMENT)
                 - --profiling-bind-address=$(PROFILING_BIND_ADDRESS)
                 command:
@@ -1203,6 +1204,8 @@ spec:
                 - name: RELATED_IMAGE_FLOWLOGS_PIPELINE
                   value: quay.io/netobserv/flowlogs-pipeline:v1.6.1-community
                 - name: RELATED_IMAGE_CONSOLE_PLUGIN
+                  value: quay.io/netobserv/network-observability-console-plugin:v1.6.1-community
+                - name: RELATED_IMAGE_CONSOLE_PLUGIN_PF4_SUPPORT
                   value: quay.io/netobserv/network-observability-console-plugin:v1.6.1-community
                 - name: DOWNSTREAM_DEPLOYMENT
                   value: "false"
@@ -1373,6 +1376,8 @@ spec:
     name: flowlogs-pipeline
   - image: quay.io/netobserv/network-observability-console-plugin:v1.6.1-community
     name: console-plugin
+  - image: quay.io/netobserv/network-observability-console-plugin:v1.6.1-community
+    name: console-plugin-pf4-support-image
   replaces: netobserv-operator.v1.6.0-community
   version: 1.6.1-community
   webhookdefinitions:

--- a/catalog/index.yaml
+++ b/catalog/index.yaml
@@ -990,6 +990,8 @@ relatedImages:
   name: ebpf-agent
 - image: quay.io/netobserv/network-observability-console-plugin:v1.6.1-community
   name: console-plugin
+- image: quay.io/netobserv/network-observability-console-plugin:v1.6.1-community
+  name: console-plugin-pf4-support-image
 - image: quay.io/netobserv/network-observability-operator:1.6.1-community
   name: ""
 - image: quay.io/ocazade0/network-observability-operator-bundle:v1.6.1-community

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -17,6 +17,7 @@ spec:
         - "--ebpf-agent-image=$(RELATED_IMAGE_EBPF_AGENT)"
         - "--flowlogs-pipeline-image=$(RELATED_IMAGE_FLOWLOGS_PIPELINE)"
         - "--console-plugin-image=$(RELATED_IMAGE_CONSOLE_PLUGIN)"
+        - "--console-plugin-pf4-support-image=$(RELATED_IMAGE_CONSOLE_PLUGIN_PF4_SUPPORT)"
       - name: kube-rbac-proxy
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,7 @@ spec:
         - --ebpf-agent-image=$(RELATED_IMAGE_EBPF_AGENT)
         - --flowlogs-pipeline-image=$(RELATED_IMAGE_FLOWLOGS_PIPELINE)
         - --console-plugin-image=$(RELATED_IMAGE_CONSOLE_PLUGIN)
+        - --console-plugin-pf4-support-image=$(RELATED_IMAGE_CONSOLE_PLUGIN_PF4_SUPPORT)
         - --downstream-deployment=$(DOWNSTREAM_DEPLOYMENT)
         - --profiling-bind-address=$(PROFILING_BIND_ADDRESS)
         env:
@@ -35,6 +36,8 @@ spec:
           - name: RELATED_IMAGE_FLOWLOGS_PIPELINE
             value: quay.io/netobserv/flowlogs-pipeline:v1.6.1-community
           - name: RELATED_IMAGE_CONSOLE_PLUGIN
+            value: quay.io/netobserv/network-observability-console-plugin:v1.6.1-community
+          - name: RELATED_IMAGE_CONSOLE_PLUGIN_PF4_SUPPORT
             value: quay.io/netobserv/network-observability-console-plugin:v1.6.1-community
           - name: DOWNSTREAM_DEPLOYMENT
             value: "false"

--- a/hack/container_digest.sh
+++ b/hack/container_digest.sh
@@ -2,3 +2,4 @@ export OPERATOR_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/ocp-network-observ
 export EBPF_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/ocp-network-observab-tenant/netobserv-operator/netobserv-ebpf-agent@sha256:eb43914d8285d0fcf9eaa52c08eb86f8a4b9f1afb6eadb32f7abe246d951431d'
 export FLP_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/ocp-network-observab-tenant/netobserv-operator/flowlogs-pipeline@sha256:31adbe5a41c518b1864eb917a51b7edc6afda8582f96b1499770a3969557b3ed'
 export CONSOLE_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/ocp-network-observab-tenant/netobserv-operator/network-observability-console-plugin@sha256:d31de305a2d73b5fd2b1f26b88bc8644345c07abb6dad19d2c4b427b2f8e3e5f'
+export CONSOLE_PF4_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/ocp-network-observab-tenant/netobserv-operator/network-observability-console-plugin@sha256:d31de305a2d73b5fd2b1f26b88bc8644345c07abb6dad19d2c4b427b2f8e3e5f'

--- a/hack/patch_csv.py
+++ b/hack/patch_csv.py
@@ -30,6 +30,7 @@ operator_image = os.getenv('OPERATOR_IMAGE_PULLSPEC')
 ebpf_image = os.getenv('EBPF_IMAGE_PULLSPEC')
 flp_image = os.getenv('FLP_IMAGE_PULLSPEC')
 console_image = os.getenv('CONSOLE_IMAGE_PULLSPEC')
+console_pf4_image = os.getenv('CONSOLE_PF4_IMAGE_PULLSPEC')
 
 csv['metadata']['annotations']['operators.openshift.io/valid-subscription'] = '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
 csv['metadata']['annotations']['operatorframework.io/cluster-monitoring'] = 'true'
@@ -63,6 +64,8 @@ for env in csv['spec']['install']['spec']['deployments'][0]['spec']['template'][
       env['value'] = flp_image
    if env['name'] == 'RELATED_IMAGE_CONSOLE_PLUGIN':
       env['value'] = console_image
+   if env['name'] == 'RELATED_IMAGE_CONSOLE_PLUGIN_PF4_SUPPORT':
+      env['value'] = console_pf4_image
 
 csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['containers'][0]['image'] = operator_image
 

--- a/main.go
+++ b/main.go
@@ -104,6 +104,7 @@ func main() {
 	flag.StringVar(&config.EBPFAgentImage, "ebpf-agent-image", "quay.io/netobserv/netobserv-ebpf-agent:main", "The image of the eBPF agent")
 	flag.StringVar(&config.FlowlogsPipelineImage, "flowlogs-pipeline-image", "quay.io/netobserv/flowlogs-pipeline:main", "The image of Flowlogs Pipeline")
 	flag.StringVar(&config.ConsolePluginImage, "console-plugin-image", "quay.io/netobserv/network-observability-console-plugin:main", "The image of the Console Plugin")
+	flag.StringVar(&config.ConsolePluginPF4SupportImage, "console-plugin-pf4-support-image", "quay.io/netobserv/network-observability-console-plugin:main", "The image of the Console Plugin for Patternfly 4 support (OCP < 4.15.0)")
 	flag.BoolVar(&config.DownstreamDeployment, "downstream-deployment", false, "Either this deployment is a downstream deployment ot not")
 	flag.BoolVar(&enableHTTP2, "enable-http2", enableHTTP2, "If HTTP/2 should be enabled for the metrics and webhook servers.")
 	flag.BoolVar(&versionFlag, "v", false, "print version")

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -18,3 +18,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/netobserv/network-observability-console-plugin:main
+  - name: network-observability-console-plugin-patternfly4-support
+    from:
+      kind: DockerImage
+      name: quay.io/netobserv/network-observability-console-plugin:main

--- a/pkg/manager/config.go
+++ b/pkg/manager/config.go
@@ -12,6 +12,8 @@ type Config struct {
 	FlowlogsPipelineImage string
 	// ConsolePluginImage is the image of the Console Plugin that is managed by the operator
 	ConsolePluginImage string
+	// ConsolePluginImage is the image of the Console Plugin for Patternfly 4 support (OCP < 4.15.0) that is managed by the operator
+	ConsolePluginPF4SupportImage string
 	// Release kind is either upstream or downstream
 	DownstreamDeployment bool
 }
@@ -25,6 +27,9 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.ConsolePluginImage == "" {
 		return errors.New("console plugin image argument can't be empty")
+	}
+	if cfg.ConsolePluginPF4SupportImage == "" {
+		return errors.New("console plugin PF4 support image argument can't be empty")
 	}
 	return nil
 }

--- a/pkg/test/envtest.go
+++ b/pkg/test/envtest.go
@@ -136,10 +136,11 @@ func PrepareEnvTest(controllers []manager.Registerer, namespaces []string, baseP
 		context.Background(),
 		cfg,
 		&manager.Config{
-			EBPFAgentImage:        "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-ebpf-agent@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
-			FlowlogsPipelineImage: "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-flowlogs-pipeline@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
-			ConsolePluginImage:    "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-console-plugin@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
-			DownstreamDeployment:  false,
+			EBPFAgentImage:               "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-ebpf-agent@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
+			FlowlogsPipelineImage:        "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-flowlogs-pipeline@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
+			ConsolePluginImage:           "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-console-plugin@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
+			ConsolePluginPF4SupportImage: "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-console-plugin@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
+			DownstreamDeployment:         false,
 		},
 		&ctrl.Options{
 			Scheme: scheme.Scheme,


### PR DESCRIPTION
## Description

Allow `RELATED_IMAGE_CONSOLE_PLUGIN_PF4_SUPPORT` image in CSV for older OCP versions that doesn't support Patternfly 5

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
