### PR TITLE
OLM forms, fix display name generation for mac

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -768,15 +768,15 @@ spec:
         path: loki.manual.querierUrl
       - displayName: Status url
         path: loki.manual.statusUrl
-      - displayName: TenantID
+      - displayName: Tenant id
         path: loki.manual.tenantID
       - displayName: Ingester url
         path: loki.microservices.ingesterUrl
       - displayName: Querier url
         path: loki.microservices.querierUrl
-      - displayName: TenantID
+      - displayName: Tenant id
         path: loki.microservices.tenantID
-      - displayName: TenantID
+      - displayName: Tenant id
         path: loki.monolithic.tenantID
       - displayName: Url
         path: loki.monolithic.url

--- a/hack/crd2csvSpecDesc.sh
+++ b/hack/crd2csvSpecDesc.sh
@@ -29,7 +29,9 @@ process_property() {
     false
     return
   fi
-  local displayName=$(echo $logicPath | sed 's/.*\.//' | sed 's/\([A-Z]\)\([a-z]\)/ \L\1\2/g' | sed 's/.*/\u&/' )
+  local displayName=$(echo $logicPath | sed 's/.*\.//' | sed 's/\([a-z]\)\([A-Z]\)/\1 \2/g' )
+  displayName=${displayName,,} # lower case
+  displayName=${displayName^} # first letter capital
 #  local description=$(cat $crd | yq "$yamlPath.description" | sed 's/`/"/g' | sed 's/<br>//g')
   if [[ $(cat $csv | yq "$csvRoot[] | select(.path==\"$logicPath\")") != "" ]]; then
     if [[ $(cat $csv | yq "$csvRoot[] | select(.path==\"$logicPath\") | has(\"displayName\")") == false ]]; then


### PR DESCRIPTION
We need to check if it fixes csv gen on mac.
Initial issue was mentioned here: https://github.com/netobserv/network-observability-operator/pull/912#discussion_r1868183836