### PR TITLE
NETOBSERV-2048: Add webhook check to prevent CIDR duplication when configure multi rules filtering

### DIFF
--- a/apis/flowcollector/v1beta2/flowcollector_validation_webhook.go
+++ b/apis/flowcollector/v1beta2/flowcollector_validation_webhook.go
@@ -107,8 +107,15 @@ func (r *FlowCollector) validateAgent(_ context.Context, fc *FlowCollector) (adm
 	}
 	var errs []error
 	if fc.Spec.Agent.EBPF.FlowFilter != nil && fc.Spec.Agent.EBPF.FlowFilter.Enable != nil && *fc.Spec.Agent.EBPF.FlowFilter.Enable {
+		m := make(map[string]bool)
 		for i := range fc.Spec.Agent.EBPF.FlowFilter.FlowFilterRules {
-			errs = append(errs, validateFilter(&fc.Spec.Agent.EBPF.FlowFilter.FlowFilterRules[i])...)
+			rule := fc.Spec.Agent.EBPF.FlowFilter.FlowFilterRules[i]
+			if found := m[rule.CIDR]; found {
+				errs = append(errs, fmt.Errorf("flow filter rule CIDR %s already exists", rule.CIDR))
+				break
+			}
+			m[rule.CIDR] = true
+			errs = append(errs, validateFilter(&rule)...)
 		}
 		errs = append(errs, validateFilter(fc.Spec.Agent.EBPF.FlowFilter)...)
 	}

--- a/apis/flowcollector/v1beta2/flowcollector_validation_webhook_test.go
+++ b/apis/flowcollector/v1beta2/flowcollector_validation_webhook_test.go
@@ -49,6 +49,7 @@ func TestValidateAgent(t *testing.T) {
 										Action:    "Accept",
 										CIDR:      "0.0.0.0/0",
 										Direction: "Egress",
+										Protocol:  "TCP",
 									},
 								},
 							},
@@ -56,6 +57,42 @@ func TestValidateAgent(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "Invalid filter with duplicate CIDR",
+			fc: &FlowCollector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: FlowCollectorSpec{
+					Agent: FlowCollectorAgent{
+						Type: AgentEBPF,
+						EBPF: FlowCollectorEBPF{
+							Features:   []AgentFeature{DNSTracking, FlowRTT, PacketDrop},
+							Privileged: true,
+							Sampling:   ptr.To(int32(100)),
+							FlowFilter: &EBPFFlowFilter{
+								Enable: ptr.To(true),
+								FlowFilterRules: []EBPFFlowFilterRule{
+									{
+										Action:    "Accept",
+										CIDR:      "0.0.0.0/0",
+										Direction: "Egress",
+										Protocol:  "TCP",
+									},
+									{
+										Action:    "Accept",
+										CIDR:      "0.0.0.0/0",
+										Direction: "Egress",
+										Protocol:  "UDP",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: "flow filter rule CIDR 0.0.0.0/0 already exists",
 		},
 		{
 			name: "PacketDrop without privilege triggers warning",


### PR DESCRIPTION

## Description

prevent users from using duplicate CIDR when configure multi filter rules
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
