### PR TITLE
Updating konflux task due to breaking change and deprecated tasks

### DIFF
--- a/.tekton/pipeline-fbc-ref.yaml
+++ b/.tekton/pipeline-fbc-ref.yaml
@@ -334,20 +334,20 @@ spec:
       - name: kind
         value: task
       resolver: bundles
-  - name: inspect-image
+  - name: validate-fbc
     params:
     - name: IMAGE_URL
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: IMAGE_DIGEST
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
-    - build-container
+    - build-image-index
     taskRef:
       params:
       - name: name
-        value: inspect-image
+        value: validate-fbc
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-inspect-image:0.2@sha256:8ec039eeaa71e73465ad3a361a81aca1a95d361762e899fde780249948ed8145
+        value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1
       - name: kind
         value: task
       resolver: bundles
@@ -356,56 +356,6 @@ spec:
       operator: in
       values:
       - "false"
-    workspaces:
-    - name: source
-      workspace: workspace
-  - name: fbc-validate
-    params:
-    - name: IMAGE_URL
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    - name: IMAGE_DIGEST
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    - name: BASE_IMAGE
-      value: $(tasks.inspect-image.results.BASE_IMAGE)
-    runAfter:
-    - inspect-image
-    taskRef:
-      params:
-      - name: name
-        value: fbc-validation
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-fbc-validation:0.2@sha256:1f5e199042025b4a7c0f9e49e09c5b62d2e20c5e1b1457dde9ae2ded77774be4
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
-    workspaces:
-    - name: workspace
-      workspace: workspace
-  - name: fbc-related-image-check
-    runAfter:
-    - fbc-validate
-    taskRef:
-      params:
-      - name: name
-        value: fbc-related-image-check
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-fbc-related-image-check:0.2@sha256:f97137a14410d49610fa6961d040c7d55fe1e58d8aaa7c935130e3c5608f2275
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
-    workspaces:
-    - name: workspace
-      workspace: workspace
   workspaces:
   - name: workspace
   - name: git-auth


### PR DESCRIPTION
## Description

Updating konflux task due to breaking change and deprecated tasks
- removing fbc-related-image-check
- renaming task-fbc-validation
- removing inspect-image

See https://github.com/netobserv/network-observability-operator/pull/787

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
