### PR TITLE
make sure zone_id is visible when pkt xlation feature is enabled

### DIFF
--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -575,6 +575,7 @@ columns:
     filter: xlat_zone_id
     default: true
     width: 5
+    feature: packetTranslation
   - id: XlatIcmpId
     group: Xlat
     name: Xlat icmp code
@@ -605,7 +606,7 @@ columns:
     group: Xlat
     name: Xlat Src Kubernetes Object
     calculated: kubeObject(XlatSrcK8S_Type,XlatSrcK8S_Namespace,XlatSrcK8S_Name,1) or concat(XlatSrcAddr,':',XlatSrcPort)
-    default: false
+    default: true
     width: 15
     feature: packetTranslation
   - id: XlatDstAddr
@@ -630,7 +631,7 @@ columns:
     group: Xlat
     name: Xlat Dst Kubernetes Object
     calculated: kubeObject(XlatDstK8S_Type,XlatDstK8S_Namespace,XlatDstK8S_Name,1) or concat(XlatDstAddr,':',XlatDstPort)
-    default: false
+    default: true
     width: 15
     feature: packetTranslation
   - id: XlatK8S_Object


### PR DESCRIPTION
## Description

make sure zoneid column only shows when pktxlat feature is on
also include src and dst object as default column when feature is enabled
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
