### PR TITLE
update webhook check for 4.18 features and pktDrop

### DIFF
--- a/apis/flowcollector/v1beta2/flowcollector_validation_webhook_test.go
+++ b/apis/flowcollector/v1beta2/flowcollector_validation_webhook_test.go
@@ -112,6 +112,25 @@ func TestValidateAgent(t *testing.T) {
 			expectedWarnings: admission.Warnings{"The PacketDrop feature requires eBPF Agent to run in privileged mode"},
 		},
 		{
+			name:       "PacketDrop on ocp 4.12 triggers warning",
+			ocpVersion: "4.12.5",
+			fc: &FlowCollector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: FlowCollectorSpec{
+					Agent: FlowCollectorAgent{
+						Type: AgentEBPF,
+						EBPF: FlowCollectorEBPF{
+							Features:   []AgentFeature{PacketDrop},
+							Privileged: true,
+						},
+					},
+				},
+			},
+			expectedWarnings: admission.Warnings{"The PacketDrop feature requires OpenShift 4.14 or above (version detected: 4.12.5)"},
+		},
+		{
 			name:       "NetworkEvents on ocp 4.16 triggers warning",
 			ocpVersion: "4.16.5",
 			fc: &FlowCollector{
@@ -128,7 +147,7 @@ func TestValidateAgent(t *testing.T) {
 					},
 				},
 			},
-			expectedWarnings: admission.Warnings{"The NetworkEvents feature requires OpenShift 4.18 or above (version detected: 4.16.5)"},
+			expectedWarnings: admission.Warnings{"The NetworkEvents/UDNMapping/EbpfManager features require OpenShift 4.18 or above (version detected: 4.16.5)"},
 		},
 		{
 			name:       "NetworkEvents without privilege triggers warning",
@@ -146,7 +165,7 @@ func TestValidateAgent(t *testing.T) {
 					},
 				},
 			},
-			expectedWarnings: admission.Warnings{"The NetworkEvents feature requires eBPF Agent to run in privileged mode"},
+			expectedWarnings: admission.Warnings{"The NetworkEvents/UDNMapping/EbpfManager features require eBPF Agent to run in privileged mode"},
 		},
 		{
 			name: "FlowFilter different ports configs are mutually exclusive",


### PR DESCRIPTION
## Description

update validationn check for 4.18 features NetworkEvent, UDNMapping and EbpfManager
and add OCP version check for pktDrop feature
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
