### PR TITLE
NETOBSERV-2075: [minor] Add agent severity to error metric

### DIFF
--- a/pkg/dashboards/health.go
+++ b/pkg/dashboards/health.go
@@ -17,7 +17,7 @@ func CreateHealthDashboard(netobsNs, nsFlowsMetric string) (string, error) {
 		NewPanel("Sampling", metricslatest.ChartTypeSingleStat, "", 3, NewTarget(
 			"avg(netobserv_agent_sampling_rate)", "")),
 		NewPanel("Errors last minute", metricslatest.ChartTypeSingleStat, "", 3, NewTarget(
-			`(sum(increase(netobserv_agent_errors_total[1m])) OR on() vector(0))
+			`(sum(increase(netobserv_agent_errors_total{severity!="low"}[1m])) OR on() vector(0))
 			+ (sum(increase(netobserv_ingest_errors[1m])) OR on() vector(0))
 			+ (sum(increase(netobserv_encode_prom_errors[1m])) OR on() vector(0))
 			+ (sum(increase(netobserv_loki_batch_retries_total[1m])) OR on() vector(0))
@@ -90,7 +90,7 @@ func CreateHealthDashboard(netobsNs, nsFlowsMetric string) (string, error) {
 			NewTarget(`sum(netobserv_agent_buffer_size) by (name)`, "{{name}}"),
 		),
 		NewPanel("Errors per minute", metricslatest.ChartTypeStackArea, "", 4,
-			NewTarget(`sum(increase(netobserv_agent_errors_total[1m])) by (component, error)`, "{{component}} {{error}}"),
+			NewTarget(`sum(increase(netobserv_agent_errors_total[1m])) by (component, error, severity)`, "{{component}} {{error}} (sev: {{severity}})"),
 		),
 		NewPanel("Filtered flows rate", metricslatest.ChartTypeStackArea, "", 4,
 			NewTarget("sum(rate(netobserv_agent_filtered_flows_total[1m])) by (source, reason)", "{{source}} {{reason}}"),


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
https://github.com/netobserv/netobserv-ebpf-agent/pull/509

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
