### PR TITLE
NETOBSERV-2078: Fix Openshift version check to work on ROSA

### DIFF
--- a/apis/flowcollector/v1beta2/flowcollector_validation_webhook.go
+++ b/apis/flowcollector/v1beta2/flowcollector_validation_webhook.go
@@ -90,7 +90,7 @@ func (r *FlowCollector) validateAgent(_ context.Context, fc *FlowCollectorSpec) 
 		slices.Contains(fc.Agent.EBPF.Features, EbpfManager) {
 		// Make sure required version of ocp is installed
 		if CurrentClusterInfo != nil && CurrentClusterInfo.IsOpenShift() {
-			b, err := CurrentClusterInfo.OpenShiftVersionIsAtLeast("4.18.0")
+			b, err := CurrentClusterInfo.OpenShiftVersionIsAtLeast("4.18.0-0")
 			if err != nil {
 				warnings = append(warnings, fmt.Sprintf("Could not detect OpenShift cluster version: %s", err.Error()))
 			} else if !b {
@@ -105,7 +105,7 @@ func (r *FlowCollector) validateAgent(_ context.Context, fc *FlowCollectorSpec) 
 	}
 	if slices.Contains(fc.Agent.EBPF.Features, PacketDrop) {
 		if CurrentClusterInfo != nil && CurrentClusterInfo.IsOpenShift() {
-			b, err := CurrentClusterInfo.OpenShiftVersionIsAtLeast("4.14.0")
+			b, err := CurrentClusterInfo.OpenShiftVersionIsAtLeast("4.14.0-0")
 			if err != nil {
 				warnings = append(warnings, fmt.Sprintf("Could not detect OpenShift cluster version: %s", err.Error()))
 			} else if !b {

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -1040,6 +1040,18 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - clusteroperators
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
           - clusterversions
           - networks
           verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -111,6 +111,18 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - clusteroperators
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - clusterversions
   - networks
   verbs:

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -38,6 +38,7 @@ import (
 //+kubebuilder:rbac:urls="/metrics",verbs=get
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions/status,verbs=update;patch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get;create;delete;update;patch;list;watch
 
 type Registerer func(context.Context, *Manager) error
 

--- a/pkg/test/envtest.go
+++ b/pkg/test/envtest.go
@@ -132,6 +132,10 @@ func PrepareEnvTest(controllers []manager.Registerer, namespaces []string, baseP
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	err = k8sClient.Create(ctx, &configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{Name: "network"},
+	})
+	Expect(err).NotTo(HaveOccurred())
 	k8sManager, err := manager.NewManager(
 		context.Background(),
 		cfg,


### PR DESCRIPTION
## Description

Fix OCP version check to work on ROSA
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
