### PR TITLE
Add missing peer map to bpfman volume

### DIFF
--- a/controllers/ebpf/agent_controller.go
+++ b/controllers/ebpf/agent_controller.go
@@ -370,7 +370,7 @@ func (c *AgentController) desired(ctx context.Context, coll *flowslatest.FlowCol
 					Driver: "csi.bpfman.io",
 					VolumeAttributes: map[string]string{
 						"csi.bpfman.io/program": "netobserv",
-						"csi.bpfman.io/maps":    "aggregated_flows,additional_flow_metrics,direct_flows,dns_flows,filter_map,global_counters,packet_record",
+						"csi.bpfman.io/maps":    "aggregated_flows,additional_flow_metrics,direct_flows,dns_flows,filter_map,peer_filter_map,global_counters,packet_record",
 					},
 				},
 			},


### PR DESCRIPTION
## Description

add missing peer filter map to ebpf volume
```
oc get pods -n netobserv-privileged
NAME                         READY   STATUS             RESTARTS      AGE
netobserv-ebpf-agent-dcxwf   0/1     CrashLoopBackOff   1 (8s ago)    44s
netobserv-ebpf-agent-dssls   0/1     CrashLoopBackOff   1 (11s ago)   44s
netobserv-ebpf-agent-jpx58   0/1     CrashLoopBackOff   1 (13s ago)   44s
netobserv-ebpf-agent-pjslk   0/1     CrashLoopBackOff   1 (6s ago)    44s
netobserv-ebpf-agent-q7fzz   0/1     Error              2 (22s ago)   44s
netobserv-ebpf-agent-z7w6m   0/1     Error              2 (28s ago)   44s
oc logs -n netobserv-privileged netobserv-ebpf-agent-dcxwf
time="2025-01-28T15:02:39Z" level=info msg="starting NetObserv eBPF Agent [build version: main-528ec8c, build date: 2025-01-28 12:06]"
time="2025-01-28T15:02:39Z" level=info msg="initializing Flows agent" component=agent.Flows
time="2025-01-28T15:02:39Z" level=info msg="BPFManager mode: loading aggregated flows pinned maps" component=ebpf.FlowFetcher
time="2025-01-28T15:02:39Z" level=info msg="BPFManager mode: loading additional flow metrics pinned maps" component=ebpf.FlowFetcher
time="2025-01-28T15:02:39Z" level=info msg="BPFManager mode: loading direct flows pinned maps" component=ebpf.FlowFetcher
time="2025-01-28T15:02:39Z" level=info msg="BPFManager mode: loading DNS flows pinned maps" component=ebpf.FlowFetcher
time="2025-01-28T15:02:39Z" level=info msg="BPFManager mode: loading filter pinned maps" component=ebpf.FlowFetcher
time="2025-01-28T15:02:39Z" level=info msg="BPFManager mode: loading Peerfilter pinned maps" component=ebpf.FlowFetcher
time="2025-01-28T15:02:39Z" level=fatal msg="can't instantiate NetObserv eBPF Agent" error="failed to load /run/netobserv/maps/peer_filter_map: no such file or directory"
```
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
