### PR TITLE
NETOBSERV-1955: fix wrong metrics for conversation tracking

### DIFF
--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -651,8 +651,8 @@ type FlowCollectorFLP struct {
 
 	// `logTypes` defines the desired record types to generate. Possible values are:<br>
 	// - `Flows` to export regular network flows. This is the default.<br>
-	// - `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates.<br>
-	// - `EndedConversations` to generate only ended conversations events.<br>
+	// - `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates. Note that in this mode, Prometheus metrics are not accurate on long-standing conversations.<br>
+	// - `EndedConversations` to generate only ended conversations events. Note that in this mode, Prometheus metrics are not accurate on long-standing conversations.<br>
 	// - `All` to generate both network flows and all conversations events. It is not recommended due to the impact on resources footprint.<br>
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum:="Flows";"Conversations";"EndedConversations";"All"

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -8632,8 +8632,8 @@ spec:
                     description: |-
                       `logTypes` defines the desired record types to generate. Possible values are:<br>
                       - `Flows` to export regular network flows. This is the default.<br>
-                      - `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates.<br>
-                      - `EndedConversations` to generate only ended conversations events.<br>
+                      - `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates. Note that in this mode, Prometheus metrics are not accurate on long-standing conversations.<br>
+                      - `EndedConversations` to generate only ended conversations events. Note that in this mode, Prometheus metrics are not accurate on long-standing conversations.<br>
                       - `All` to generate both network flows and all conversations events. It is not recommended due to the impact on resources footprint.<br>
                     enum:
                     - Flows

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -7954,8 +7954,8 @@ spec:
                       description: |-
                         `logTypes` defines the desired record types to generate. Possible values are:<br>
                         - `Flows` to export regular network flows. This is the default.<br>
-                        - `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates.<br>
-                        - `EndedConversations` to generate only ended conversations events.<br>
+                        - `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates. Note that in this mode, Prometheus metrics are not accurate on long-standing conversations.<br>
+                        - `EndedConversations` to generate only ended conversations events. Note that in this mode, Prometheus metrics are not accurate on long-standing conversations.<br>
                         - `All` to generate both network flows and all conversations events. It is not recommended due to the impact on resources footprint.<br>
                       enum:
                         - Flows

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -14468,8 +14468,8 @@ This setting is ignored when Kafka is disabled.<br/>
         <td>
           `logTypes` defines the desired record types to generate. Possible values are:<br>
 - `Flows` to export regular network flows. This is the default.<br>
-- `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates.<br>
-- `EndedConversations` to generate only ended conversations events.<br>
+- `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates. Note that in this mode, Prometheus metrics are not accurate on long-standing conversations.<br>
+- `EndedConversations` to generate only ended conversations events. Note that in this mode, Prometheus metrics are not accurate on long-standing conversations.<br>
 - `All` to generate both network flows and all conversations events. It is not recommended due to the impact on resources footprint.<br><br/>
           <br/>
             <i>Enum</i>: Flows, Conversations, EndedConversations, All<br/>

--- a/helm/templates/flows.netobserv.io_flowcollectors.yaml
+++ b/helm/templates/flows.netobserv.io_flowcollectors.yaml
@@ -7968,8 +7968,8 @@ spec:
                       description: |-
                         `logTypes` defines the desired record types to generate. Possible values are:<br>
                         - `Flows` to export regular network flows. This is the default.<br>
-                        - `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates.<br>
-                        - `EndedConversations` to generate only ended conversations events.<br>
+                        - `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates. Note that in this mode, Prometheus metrics are not accurate on long-standing conversations.<br>
+                        - `EndedConversations` to generate only ended conversations events. Note that in this mode, Prometheus metrics are not accurate on long-standing conversations.<br>
                         - `All` to generate both network flows and all conversations events. It is not recommended due to the impact on resources footprint.<br>
                       enum:
                         - Flows


### PR DESCRIPTION
## Description

This is fixing wrong metrics that are due to accumulating bytes/packets counters from heartbits, which are not relevant for accumulation.

However, conversation tracking is still bad at providing accurate metrics for long-standing connections, as the ConnectionEnded event may be very long to come. So this is going to remain as a known limitation of Conversation Tracking.

I don't think there's any urgency to backport this on 1.8

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
