### PR TITLE
NETOBSERV-1418: make namespace immutable

### DIFF
--- a/apis/flowcollector/v1beta1/flowcollector_types.go
+++ b/apis/flowcollector/v1beta1/flowcollector_types.go
@@ -49,6 +49,7 @@ type FlowCollectorSpec struct {
 
 	// Namespace where NetObserv pods are deployed.
 	// +kubebuilder:default:=netobserv
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Namespace is immutable. If you need to change it, delete and recreate the resource."
 	Namespace string `json:"namespace,omitempty"`
 
 	// Agent configuration for flows extraction.

--- a/apis/flowcollector/v1beta2/flowcollector_types.go
+++ b/apis/flowcollector/v1beta2/flowcollector_types.go
@@ -49,6 +49,7 @@ type FlowCollectorSpec struct {
 
 	// Namespace where NetObserv pods are deployed.
 	// +kubebuilder:default:=netobserv
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Namespace is immutable. If you need to change it, delete and recreate the resource."
 	Namespace string `json:"namespace,omitempty"`
 
 	// Agent configuration for flows extraction.

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -1835,6 +1835,10 @@ spec:
                 default: netobserv
                 description: Namespace where NetObserv pods are deployed.
                 type: string
+                x-kubernetes-validations:
+                - message: Namespace is immutable. If you need to change it, delete
+                    and recreate the resource.
+                  rule: self == oldSelf
               processor:
                 description: |-
                   `processor` defines the settings of the component that receives the flows from the agent,
@@ -7066,6 +7070,10 @@ spec:
                 default: netobserv
                 description: Namespace where NetObserv pods are deployed.
                 type: string
+                x-kubernetes-validations:
+                - message: Namespace is immutable. If you need to change it, delete
+                    and recreate the resource.
+                  rule: self == oldSelf
               networkPolicy:
                 description: '`networkPolicy` defines ingress network policy settings
                   for NetObserv components isolation.'

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -1657,6 +1657,9 @@ spec:
                   default: netobserv
                   description: Namespace where NetObserv pods are deployed.
                   type: string
+                  x-kubernetes-validations:
+                    - message: Namespace is immutable. If you need to change it, delete and recreate the resource.
+                      rule: self == oldSelf
                 processor:
                   description: |-
                     `processor` defines the settings of the component that receives the flows from the agent,
@@ -6476,6 +6479,9 @@ spec:
                   default: netobserv
                   description: Namespace where NetObserv pods are deployed.
                   type: string
+                  x-kubernetes-validations:
+                    - message: Namespace is immutable. If you need to change it, delete and recreate the resource.
+                      rule: self == oldSelf
                 networkPolicy:
                   description: '`networkPolicy` defines ingress network policy settings for NetObserv components isolation.'
                   properties:

--- a/controllers/consoleplugin/consoleplugin_reconciler.go
+++ b/controllers/consoleplugin/consoleplugin_reconciler.go
@@ -51,11 +51,6 @@ func NewReconciler(cmn *reconcilers.Instance) CPReconciler {
 	return rec
 }
 
-// CleanupNamespace cleans up old namespace
-func (r *CPReconciler) CleanupNamespace(ctx context.Context) {
-	r.Managed.CleanupPreviousNamespace(ctx)
-}
-
 // Reconcile is the reconciler entry point to reconcile the current plugin state with the desired configuration
 func (r *CPReconciler) Reconcile(ctx context.Context, desired *flowslatest.FlowCollector) error {
 	l := log.FromContext(ctx).WithName("console-plugin")

--- a/controllers/ebpf/internal/permissions/permissions.go
+++ b/controllers/ebpf/internal/permissions/permissions.go
@@ -50,11 +50,6 @@ func (c *Reconciler) Reconcile(ctx context.Context, desired *flowslatest.FlowCol
 
 func (c *Reconciler) reconcileNamespace(ctx context.Context) error {
 	ns := c.PrivilegedNamespace()
-	if ns != c.PreviousPrivilegedNamespace() {
-		if err := c.cleanupPreviousNamespace(ctx); err != nil {
-			return err
-		}
-	}
 	rlog := log.FromContext(ctx, "PrivilegedNamespace", ns)
 	actual := &v1.Namespace{}
 	if err := c.Get(ctx, client.ObjectKey{Name: ns}, actual); err != nil {
@@ -184,46 +179,5 @@ func (c *Reconciler) reconcileOpenshiftPermissions(
 		return c.UpdateIfOwned(ctx, actual, scc)
 	}
 	rlog.Info("SecurityContextConstraints already reconciled. Doing nothing")
-	return nil
-}
-
-func (c *Reconciler) cleanupPreviousNamespace(ctx context.Context) error {
-	rlog := log.FromContext(ctx, "PreviousPrivilegedNamespace", c.PreviousPrivilegedNamespace())
-
-	// Delete service account
-	if err := c.Delete(ctx, &v1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.EBPFServiceAccount,
-			Namespace: c.PreviousPrivilegedNamespace(),
-		},
-	}); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("deleting eBPF agent ServiceAccount: %w", err)
-	}
-	// Do not delete SCC as it's not namespace-scoped (it will be reconciled "as usual")
-
-	previous := &v1.Namespace{}
-	if err := c.Get(ctx, client.ObjectKey{Name: c.PreviousPrivilegedNamespace()}, previous); err != nil {
-		if errors.IsNotFound(err) {
-			// Not found => return without error
-			rlog.Info("Previous privileged namespace not found, skipping cleanup")
-			return nil
-		}
-		return fmt.Errorf("can't retrieve previous namespace: %w", err)
-	}
-	// Make sure we own that namespace
-	if helper.IsOwned(previous) {
-		rlog.Info("Owning previous privileged namespace: deleting it")
-		if err := c.Delete(ctx, previous); err != nil {
-			if errors.IsNotFound(err) {
-				return nil
-			}
-			return fmt.Errorf("deleting privileged namespace: %w", err)
-		}
-	} else {
-		rlog.Info("Not owning previous privileged namespace: delete related content only")
-	}
 	return nil
 }

--- a/controllers/flowcollector_controller_console_test.go
+++ b/controllers/flowcollector_controller_console_test.go
@@ -357,52 +357,6 @@ func flowCollectorConsolePluginSpecs() {
 		})
 	})
 
-	Context("Changing namespace", func() {
-		const otherNamespace = "other-namespace"
-		cpKey2 := types.NamespacedName{
-			Name:      "netobserv-plugin",
-			Namespace: otherNamespace,
-		}
-
-		It("Should update namespace successfully", func() {
-			updateCR(crKey, func(fc *flowslatest.FlowCollector) {
-				fc.Spec.Namespace = otherNamespace
-			})
-		})
-
-		It("Should redeploy console plugin in new namespace", func() {
-			By("Expecting deployment in previous namespace to be deleted")
-			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, cpKey, &appsv1.Deployment{})
-			}, timeout, interval).Should(MatchError(`deployments.apps "netobserv-plugin" not found`))
-
-			By("Expecting service in previous namespace to be deleted")
-			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, cpKey, &v1.Service{})
-			}, timeout, interval).Should(MatchError(`services "netobserv-plugin" not found`))
-
-			By("Expecting service account in previous namespace to be deleted")
-			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, cpKey, &v1.ServiceAccount{})
-			}, timeout, interval).Should(MatchError(`serviceaccounts "netobserv-plugin" not found`))
-
-			By("Expecting deployment to be created in new namespace")
-			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, cpKey2, &appsv1.Deployment{})
-			}, timeout, interval).Should(Succeed())
-
-			By("Expecting service to be created in new namespace")
-			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, cpKey2, &v1.Service{})
-			}, timeout, interval).Should(Succeed())
-
-			By("Expecting service account to be created in new namespace")
-			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, cpKey2, &v1.ServiceAccount{})
-			}, timeout, interval).Should(Succeed())
-		})
-	})
-
 	Context("Cleanup", func() {
 		It("Should delete CR", func() {
 			cleanupCR(crKey)

--- a/controllers/flp/flp_controller.go
+++ b/controllers/flp/flp_controller.go
@@ -76,7 +76,6 @@ func Start(ctx context.Context, mgr *manager.Manager) error {
 
 type subReconciler interface {
 	context(context.Context) context.Context
-	cleanupNamespace(context.Context)
 	reconcile(context.Context, *flowslatest.FlowCollector, *metricslatest.FlowMetricList, []flowslatest.SubnetLabel) error
 	getStatus() *status.Instance
 }
@@ -120,7 +119,7 @@ func (r *Reconciler) reconcile(ctx context.Context, clh *helper.Client, fc *flow
 	r.currentNamespace = ns
 	previousNamespace := r.status.GetDeployedNamespace(fc)
 	loki := helper.NewLokiConfig(&fc.Spec.Loki, ns)
-	cmn := r.newCommonInfo(clh, ns, previousNamespace, &loki)
+	cmn := r.newCommonInfo(clh, ns, &loki)
 
 	r.watcher.Reset(ns)
 
@@ -157,12 +156,6 @@ func (r *Reconciler) reconcile(ctx context.Context, clh *helper.Client, fc *flow
 
 	// Check namespace changed
 	if ns != previousNamespace {
-		if previousNamespace != "" {
-			log.Info("FlowCollector namespace change detected: cleaning up previous namespace", "old", previousNamespace, "new", ns)
-			for _, sr := range reconcilers {
-				sr.cleanupNamespace(sr.context(ctx))
-			}
-		}
 		// Update namespace in status
 		if err := r.status.SetDeployedNamespace(ctx, r.Client, ns); err != nil {
 			return r.status.Error("ChangeNamespaceError", err)
@@ -178,15 +171,14 @@ func (r *Reconciler) reconcile(ctx context.Context, clh *helper.Client, fc *flow
 	return nil
 }
 
-func (r *Reconciler) newCommonInfo(clh *helper.Client, ns, prevNs string, loki *helper.LokiConfig) reconcilers.Common {
+func (r *Reconciler) newCommonInfo(clh *helper.Client, ns string, loki *helper.LokiConfig) reconcilers.Common {
 	return reconcilers.Common{
-		Client:            *clh,
-		Namespace:         ns,
-		PreviousNamespace: prevNs,
-		ClusterInfo:       r.mgr.ClusterInfo,
-		Watcher:           r.watcher,
-		Loki:              loki,
-		IsDownstream:      r.mgr.Config.DownstreamDeployment,
+		Client:       *clh,
+		Namespace:    ns,
+		ClusterInfo:  r.mgr.ClusterInfo,
+		Watcher:      r.watcher,
+		Loki:         loki,
+		IsDownstream: r.mgr.Config.DownstreamDeployment,
 	}
 }
 

--- a/controllers/flp/flp_controller_flowmetrics_test.go
+++ b/controllers/flp/flp_controller_flowmetrics_test.go
@@ -118,12 +118,15 @@ func ControllerFlowMetricsSpecs() {
 
 			By("Expecting flowlogs-pipeline-config-dynamic configmap to be created")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, dcmKey, &dcm)
-			}, timeout, interval).Should(Succeed())
-
-			metrics, err := getConfiguredMetrics(&dcm)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(metrics).To(HaveLen(5)) // only default metrics
+				if err := k8sClient.Get(ctx, dcmKey, &dcm); err != nil {
+					return err
+				}
+				metrics, err := getConfiguredMetrics(&dcm)
+				if err != nil {
+					return err
+				}
+				return metrics
+			}, timeout, interval).Should(HaveLen(5)) // only default metrics
 		})
 	})
 

--- a/controllers/flp/flp_controller_test.go
+++ b/controllers/flp/flp_controller_test.go
@@ -47,17 +47,12 @@ var (
 // nolint:cyclop
 func ControllerSpecs() {
 	const operatorNamespace = "main-namespace"
-	const otherNamespace = "other-namespace"
 	crKey := types.NamespacedName{
 		Name: "cluster",
 	}
 	flpKey1 := types.NamespacedName{
 		Name:      constants.FLPName,
 		Namespace: operatorNamespace,
-	}
-	flpKey2 := types.NamespacedName{
-		Name:      constants.FLPName,
-		Namespace: otherNamespace,
 	}
 	flpKeyKafkaTransformer := types.NamespacedName{
 		Name:      constants.FLPName + FlpConfSuffix[ConfKafkaTransformer],
@@ -713,42 +708,6 @@ func ControllerSpecs() {
 		})
 	})
 
-	Context("Changing namespace", func() {
-		It("Should update namespace successfully", func() {
-			updateCR(crKey, func(fc *flowslatest.FlowCollector) {
-				fc.Spec.Processor.Advanced.Port = ptr.To(int32(9999))
-				fc.Spec.Namespace = otherNamespace
-			})
-		})
-
-		It("Should redeploy FLP in new namespace", func() {
-			By("Expecting daemonset in previous namespace to be deleted")
-			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, flpKey1, &appsv1.DaemonSet{})
-			}, timeout, interval).Should(MatchError(`daemonsets.apps "flowlogs-pipeline" not found`))
-
-			By("Expecting deployment in previous namespace to be deleted")
-			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, flpKey1, &appsv1.Deployment{})
-			}, timeout, interval).Should(MatchError(`deployments.apps "flowlogs-pipeline" not found`))
-
-			By("Expecting service account in previous namespace to be deleted")
-			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, flpKey1, &v1.ServiceAccount{})
-			}, timeout, interval).Should(MatchError(`serviceaccounts "flowlogs-pipeline" not found`))
-
-			By("Expecting daemonset to be created in new namespace")
-			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, flpKey2, &appsv1.DaemonSet{})
-			}, timeout, interval).Should(Succeed())
-
-			By("Expecting service account to be created in new namespace")
-			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, flpKey2, &v1.ServiceAccount{})
-			}, timeout, interval).Should(Succeed())
-		})
-	})
-
 	Context("Checking CR ownership", func() {
 		It("Should be garbage collected", func() {
 			// Retrieve CR to get its UID
@@ -758,14 +717,14 @@ func ControllerSpecs() {
 			By("Expecting flowlogs-pipeline daemonset to be garbage collected")
 			Eventually(func() interface{} {
 				d := appsv1.DaemonSet{}
-				_ = k8sClient.Get(ctx, flpKey2, &d)
+				_ = k8sClient.Get(ctx, flpKey1, &d)
 				return &d
 			}, timeout, interval).Should(BeGarbageCollectedBy(flowCR))
 
 			By("Expecting flowlogs-pipeline service account to be garbage collected")
 			Eventually(func() interface{} {
 				svcAcc := v1.ServiceAccount{}
-				_ = k8sClient.Get(ctx, flpKey2, &svcAcc)
+				_ = k8sClient.Get(ctx, flpKey1, &svcAcc)
 				return &svcAcc
 			}, timeout, interval).Should(BeGarbageCollectedBy(flowCR))
 
@@ -774,7 +733,7 @@ func ControllerSpecs() {
 				cm := v1.ConfigMap{}
 				_ = k8sClient.Get(ctx, types.NamespacedName{
 					Name:      "flowlogs-pipeline-config",
-					Namespace: otherNamespace,
+					Namespace: operatorNamespace,
 				}, &cm)
 				return &cm
 			}, timeout, interval).Should(BeGarbageCollectedBy(flowCR))

--- a/controllers/flp/flp_monolith_reconciler.go
+++ b/controllers/flp/flp_monolith_reconciler.go
@@ -57,11 +57,6 @@ func (r *monolithReconciler) context(ctx context.Context) context.Context {
 	return log.IntoContext(ctx, l)
 }
 
-// cleanupNamespace cleans up old namespace
-func (r *monolithReconciler) cleanupNamespace(ctx context.Context) {
-	r.Managed.CleanupPreviousNamespace(ctx)
-}
-
 func (r *monolithReconciler) getStatus() *status.Instance {
 	return &r.Status
 }

--- a/controllers/flp/flp_transfo_reconciler.go
+++ b/controllers/flp/flp_transfo_reconciler.go
@@ -58,11 +58,6 @@ func (r *transformerReconciler) context(ctx context.Context) context.Context {
 	return log.IntoContext(ctx, l)
 }
 
-// cleanupNamespace cleans up old namespace
-func (r *transformerReconciler) cleanupNamespace(ctx context.Context) {
-	r.Managed.CleanupPreviousNamespace(ctx)
-}
-
 func (r *transformerReconciler) getStatus() *status.Instance {
 	return &r.Status
 }

--- a/controllers/reconcilers/common.go
+++ b/controllers/reconcilers/common.go
@@ -14,20 +14,15 @@ import (
 
 type Common struct {
 	helper.Client
-	Watcher           *watchers.Watcher
-	Namespace         string
-	PreviousNamespace string
-	ClusterInfo       *cluster.Info
-	Loki              *helper.LokiConfig
-	IsDownstream      bool
+	Watcher      *watchers.Watcher
+	Namespace    string
+	ClusterInfo  *cluster.Info
+	Loki         *helper.LokiConfig
+	IsDownstream bool
 }
 
 func (c *Common) PrivilegedNamespace() string {
 	return c.Namespace + constants.EBPFPrivilegedNSSuffix
-}
-
-func (c *Common) PreviousPrivilegedNamespace() string {
-	return c.PreviousNamespace + constants.EBPFPrivilegedNSSuffix
 }
 
 type Instance struct {

--- a/controllers/reconcilers/namespaced_objects_manager.go
+++ b/controllers/reconcilers/namespaced_objects_manager.go
@@ -18,10 +18,9 @@ import (
 
 // NamespacedObjectManager provides some helpers to manage (fetch, delete) namespace-scoped objects
 type NamespacedObjectManager struct {
-	client            client.Client
-	Namespace         string
-	PreviousNamespace string
-	managedObjects    []managedObject
+	client         client.Client
+	Namespace      string
+	managedObjects []managedObject
 }
 
 type managedObject struct {
@@ -33,9 +32,8 @@ type managedObject struct {
 
 func NewNamespacedObjectManager(cmn *Common) *NamespacedObjectManager {
 	return &NamespacedObjectManager{
-		client:            cmn.Client,
-		Namespace:         cmn.Namespace,
-		PreviousNamespace: cmn.PreviousNamespace,
+		client:    cmn.Client,
+		Namespace: cmn.Namespace,
 	}
 }
 
@@ -134,25 +132,6 @@ func (m *NamespacedObjectManager) FetchAll(ctx context.Context) error {
 		log.Info("(Items not deployed: " + strings.Join(notFound, ",") + ")")
 	}
 	return nil
-}
-
-// CleanupPreviousNamespace removes all managed objects (registered using AddManagedObject) from the previous namespace.
-func (m *NamespacedObjectManager) CleanupPreviousNamespace(ctx context.Context) {
-	m.cleanup(ctx, m.PreviousNamespace)
-}
-
-func (m *NamespacedObjectManager) cleanup(ctx context.Context, namespace string) {
-	log := log.FromContext(ctx)
-	for _, obj := range m.managedObjects {
-		ref := obj.placeholder.DeepCopyObject().(client.Object)
-		ref.SetName(obj.name)
-		ref.SetNamespace(namespace)
-		log.Info("DELETING "+obj.kind, "Namespace", namespace, "Name", obj.name)
-		err := m.client.Delete(ctx, ref)
-		if client.IgnoreNotFound(err) != nil {
-			log.Error(err, "Failed to delete old "+obj.kind, "Namespace", namespace, "Name", obj.name)
-		}
-	}
 }
 
 // TryDeleteAll is an helper function that tries to delete all managed objects previously loaded using FetchAll.

--- a/helm/templates/flows.netobserv.io_flowcollectors.yaml
+++ b/helm/templates/flows.netobserv.io_flowcollectors.yaml
@@ -1671,6 +1671,9 @@ spec:
                   default: netobserv
                   description: Namespace where NetObserv pods are deployed.
                   type: string
+                  x-kubernetes-validations:
+                    - message: Namespace is immutable. If you need to change it, delete and recreate the resource.
+                      rule: self == oldSelf
                 processor:
                   description: |-
                     `processor` defines the settings of the component that receives the flows from the agent,
@@ -6490,6 +6493,9 @@ spec:
                   default: netobserv
                   description: Namespace where NetObserv pods are deployed.
                   type: string
+                  x-kubernetes-validations:
+                    - message: Namespace is immutable. If you need to change it, delete and recreate the resource.
+                      rule: self == oldSelf
                 networkPolicy:
                   description: '`networkPolicy` defines ingress network policy settings for NetObserv components isolation.'
                   properties:


### PR DESCRIPTION
## Description

It's now impossible to change the namespace where netobserv components are deployed (driven by `spec.namespace`); if users want to do so, they need to delete then recreate the FlowCollector.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
