### PR TITLE
Fix: config-watcher must be a ClusterRole

### DIFF
--- a/bundle/manifests/netobserv-config-watcher_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/netobserv-config-watcher_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: netobserv-config-watcher

--- a/config/rbac/component_roles.yaml
+++ b/config/rbac/component_roles.yaml
@@ -106,7 +106,7 @@ rules:
   - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: config-watcher
 rules:

--- a/controllers/flp/flp_monolith_reconciler.go
+++ b/controllers/flp/flp_monolith_reconciler.go
@@ -221,7 +221,7 @@ func (r *monolithReconciler) reconcilePermissions(ctx context.Context, builder *
 	}
 
 	// Config watcher
-	r.rbConfigWatcher = resources.GetRoleBinding(r.Namespace, monoShortName, monoName, monoName, constants.ConfigWatcherRole)
+	r.rbConfigWatcher = resources.GetRoleBinding(r.Namespace, monoShortName, monoName, monoName, constants.ConfigWatcherRole, true)
 	if err := r.ReconcileRoleBinding(ctx, r.rbConfigWatcher); err != nil {
 		return err
 	}

--- a/controllers/flp/flp_transfo_reconciler.go
+++ b/controllers/flp/flp_transfo_reconciler.go
@@ -235,7 +235,7 @@ func (r *transformerReconciler) reconcilePermissions(ctx context.Context, builde
 	}
 
 	// Config watcher
-	r.rbConfigWatcher = resources.GetRoleBinding(r.Namespace, transfoShortName, transfoName, transfoName, constants.ConfigWatcherRole)
+	r.rbConfigWatcher = resources.GetRoleBinding(r.Namespace, transfoShortName, transfoName, transfoName, constants.ConfigWatcherRole, true)
 	if err := r.ReconcileRoleBinding(ctx, r.rbConfigWatcher); err != nil {
 		return err
 	}

--- a/pkg/resources/roles.go
+++ b/pkg/resources/roles.go
@@ -14,7 +14,11 @@ func GetClusterRoleBindingName(shortName string, ref constants.ClusterRoleName) 
 	return string(ref) + "-" + shortName
 }
 
-func GetRoleBinding(namespace, shortName, app, sa string, ref constants.RoleName) *rbacv1.RoleBinding {
+func GetRoleBinding(namespace, shortName, app, sa string, ref constants.RoleName, fromClusterRole bool) *rbacv1.RoleBinding {
+	roleKind := "Role"
+	if fromClusterRole {
+		roleKind = "ClusterRole"
+	}
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      string(ref) + "-" + shortName,
@@ -23,7 +27,7 @@ func GetRoleBinding(namespace, shortName, app, sa string, ref constants.RoleName
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
+			Kind:     roleKind,
 			Name:     string(ref),
 		},
 		Subjects: []rbacv1.Subject{{


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
