### PR TITLE
NETOBSERV-2185: fix loki writer role name

### DIFF
--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -50,8 +50,8 @@ const (
 	ConsoleNamespace         = "openshift-console"
 
 	// [Cluster]Roles, must match names in config/rbac/component_roles.yaml (without netobserv- prefix)
-	LokiWriterRole         ClusterRoleName = "netobserv-writer"
-	LokiReaderRole         ClusterRoleName = "netobserv-reader"
+	LokiWriterRole         ClusterRoleName = "netobserv-loki-writer"
+	LokiReaderRole         ClusterRoleName = "netobserv-loki-reader"
 	PromReaderRole         ClusterRoleName = "netobserv-metrics-reader"
 	ExposeMetricsRole      RoleName        = "netobserv-expose-metrics"
 	FLPInformersRole       ClusterRoleName = "netobserv-informers"

--- a/controllers/flp/flp_controller_test.go
+++ b/controllers/flp/flp_controller_test.go
@@ -172,7 +172,7 @@ func ControllerSpecs() {
 			By("Not expecting Loki role (requires LokiStack)")
 			Eventually(func() interface{} {
 				return k8sClient.Get(ctx, rbKeyLokiWriterMono, &rbacv1.ClusterRoleBinding{})
-			}, timeout, interval).Should(MatchError(`clusterrolebindings.rbac.authorization.k8s.io "netobserv-writer-flp" not found`))
+			}, timeout, interval).Should(MatchError(`clusterrolebindings.rbac.authorization.k8s.io "netobserv-loki-writer-flp" not found`))
 
 			By("Not expecting transformer role bindings")
 			Eventually(func() interface{} {
@@ -186,7 +186,7 @@ func ControllerSpecs() {
 			}, timeout, interval).Should(MatchError(`clusterrolebindings.rbac.authorization.k8s.io "netobserv-informers-flptransfo" not found`))
 			Eventually(func() interface{} {
 				return k8sClient.Get(ctx, rbKeyLokiWriterTransfo, &rbacv1.ClusterRoleBinding{})
-			}, timeout, interval).Should(MatchError(`clusterrolebindings.rbac.authorization.k8s.io "netobserv-writer-flptransfo" not found`))
+			}, timeout, interval).Should(MatchError(`clusterrolebindings.rbac.authorization.k8s.io "netobserv-loki-writer-flptransfo" not found`))
 
 			By("Expecting flowlogs-pipeline-config configmap to be created")
 			Eventually(func() interface{} {
@@ -344,7 +344,7 @@ func ControllerSpecs() {
 			By("Not expecting Loki role (requires LokiStack)")
 			Eventually(func() interface{} {
 				return k8sClient.Get(ctx, rbKeyLokiWriterTransfo, &rbacv1.ClusterRoleBinding{})
-			}, timeout, interval).Should(MatchError(`clusterrolebindings.rbac.authorization.k8s.io "netobserv-writer-flptransfo" not found`))
+			}, timeout, interval).Should(MatchError(`clusterrolebindings.rbac.authorization.k8s.io "netobserv-loki-writer-flptransfo" not found`))
 
 			By("Not expecting mono role bindings")
 			Eventually(func() interface{} {
@@ -358,7 +358,7 @@ func ControllerSpecs() {
 			}, timeout, interval).Should(MatchError(`clusterrolebindings.rbac.authorization.k8s.io "netobserv-informers-flp" not found`))
 			Eventually(func() interface{} {
 				return k8sClient.Get(ctx, rbKeyLokiWriterMono, &rbacv1.ClusterRoleBinding{})
-			}, timeout, interval).Should(MatchError(`clusterrolebindings.rbac.authorization.k8s.io "netobserv-writer-flp" not found`))
+			}, timeout, interval).Should(MatchError(`clusterrolebindings.rbac.authorization.k8s.io "netobserv-loki-writer-flp" not found`))
 		})
 
 		It("Should delete previous flp deployment", func() {


### PR DESCRIPTION
## Description

See new role name here: https://github.com/netobserv/network-observability-operator/pull/1209/files#diff-e5a2e6e8caf9f06bb8c993c1db5500f89267fd7aeda28b9ac7e9461337b615c1

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
