### PR TITLE
chore(deps): update netobserv-ebpf-agent-1-8 to 9a5e0f0

### DIFF
--- a/hack/nudging/container_digest.sh
+++ b/hack/nudging/container_digest.sh
@@ -1,7 +1,7 @@
 # Do not remove empty lines, they are there to reduce conflicts
 export OPERATOR_IMAGE_PULLSPEC='registry.redhat.io/network-observability/network-observability-rhel9-operator@sha256:6774db5791e9927efa281767ee81b0be4affed531b7b836df047931f182ff484'
 #
-export EBPF_IMAGE_PULLSPEC='registry.redhat.io/network-observability/network-observability-ebpf-agent-rhel9@sha256:d09d626771cf538bae34e88c07deeb1580280592b8690fad8d85548fe6bc475f'
+export EBPF_IMAGE_PULLSPEC='registry.redhat.io/network-observability/network-observability-ebpf-agent-rhel9@sha256:9a5e0f02e09543df425041e36ca9f5e40b4285d0f9e1dd96779d96d257a13ebc'
 #
 export FLP_IMAGE_PULLSPEC='registry.redhat.io/network-observability/network-observability-flowlogs-pipeline-rhel9@sha256:02c87a6ecfda32c04584e542bd83feea649f0ccc93d20c20754b97c8c51e958b'
 #


### PR DESCRIPTION
Image created from 'https://github.com/netobserv/netobserv-ebpf-agent?rev=45cf6cfce75fcf2ede29876df32f349d1fcbfed8'

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
