### PR TITLE
NETOBSERV-2190: fix openshift version check with nightly builds

### DIFF
--- a/apis/flowcollector/v1beta2/flowcollector_validation_webhook_test.go
+++ b/apis/flowcollector/v1beta2/flowcollector_validation_webhook_test.go
@@ -152,6 +152,24 @@ func TestValidateAgent(t *testing.T) {
 			expectedWarnings: admission.Warnings{"The NetworkEvents/UDNMapping/EbpfManager features require OpenShift 4.18 or above (version detected: 4.16.5)"},
 		},
 		{
+			name:       "NetworkEvents on ocp 4.18.0-0 doesn't trigger warnings",
+			ocpVersion: "4.18.0-0.nightly-2025-03-20-063534",
+			fc: &FlowCollector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: FlowCollectorSpec{
+					Agent: FlowCollectorAgent{
+						Type: AgentEBPF,
+						EBPF: FlowCollectorEBPF{
+							Features:   []AgentFeature{NetworkEvents},
+							Privileged: true,
+						},
+					},
+				},
+			},
+		},
+		{
 			name:       "NetworkEvents without privilege triggers warning",
 			ocpVersion: "4.18.0",
 			fc: &FlowCollector{

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -120,7 +120,10 @@ func (c *Info) OpenShiftVersionIsAtLeast(v string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return !c.openShiftVersion.LessThan(*version), nil
+	openshiftVersion := *c.openShiftVersion
+	// Ignore pre-release block for comparison
+	openshiftVersion.PreRelease = ""
+	return !openshiftVersion.LessThan(*version), nil
 }
 
 // IsOpenShift assumes having openshift SCC API <=> being on openshift


### PR DESCRIPTION
## Description

Openshift nightly builds don't follow semver conventions: they're like `4.18.0-0.nightly-2025-03-20-063534` even if they're after 4.18.6. In semver, that's considered as a 4.18.0 pre-release, so it is technically _less than_ 4.18.0.

I'm relaxing here the checks for version to just ignore the pre-release information, so `4.18.0-0.nightly-2025-03-20-063534` == `4.18.0`

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
