### PR TITLE
NETOBSERV-2194:: use OCP4.19 version check for networkEvents/UDN/ebpfMgr

### DIFF
--- a/apis/flowcollector/v1beta2/flowcollector_validation_webhook.go
+++ b/apis/flowcollector/v1beta2/flowcollector_validation_webhook.go
@@ -90,11 +90,11 @@ func (r *FlowCollector) validateAgent(_ context.Context, fc *FlowCollectorSpec) 
 		slices.Contains(fc.Agent.EBPF.Features, EbpfManager) {
 		// Make sure required version of ocp is installed
 		if CurrentClusterInfo != nil && CurrentClusterInfo.IsOpenShift() {
-			b, err := CurrentClusterInfo.OpenShiftVersionIsAtLeast("4.18.0")
+			b, err := CurrentClusterInfo.OpenShiftVersionIsAtLeast("4.19.0")
 			if err != nil {
 				warnings = append(warnings, fmt.Sprintf("Could not detect OpenShift cluster version: %s", err.Error()))
 			} else if !b {
-				warnings = append(warnings, fmt.Sprintf("The NetworkEvents/UDNMapping/EbpfManager features require OpenShift 4.18 or above (version detected: %s)", CurrentClusterInfo.GetOpenShiftVersion()))
+				warnings = append(warnings, fmt.Sprintf("The NetworkEvents/UDNMapping/EbpfManager features require OpenShift 4.19 or above (version detected: %s)", CurrentClusterInfo.GetOpenShiftVersion()))
 			}
 		} else {
 			warnings = append(warnings, "The NetworkEvents/UDNMapping/EbpfManager features are only supported with OpenShift")

--- a/apis/flowcollector/v1beta2/flowcollector_validation_webhook_test.go
+++ b/apis/flowcollector/v1beta2/flowcollector_validation_webhook_test.go
@@ -149,11 +149,11 @@ func TestValidateAgent(t *testing.T) {
 					},
 				},
 			},
-			expectedWarnings: admission.Warnings{"The NetworkEvents/UDNMapping/EbpfManager features require OpenShift 4.18 or above (version detected: 4.16.5)"},
+			expectedWarnings: admission.Warnings{"The NetworkEvents/UDNMapping/EbpfManager features require OpenShift 4.19 or above (version detected: 4.16.5)"},
 		},
 		{
-			name:       "NetworkEvents on ocp 4.18.0-0 doesn't trigger warnings",
-			ocpVersion: "4.18.0-0.nightly-2025-03-20-063534",
+			name:       "NetworkEvents on ocp 4.19.0-0 doesn't trigger warnings",
+			ocpVersion: "4.19.0-0.nightly-2025-03-20-063534",
 			fc: &FlowCollector{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster",
@@ -171,7 +171,7 @@ func TestValidateAgent(t *testing.T) {
 		},
 		{
 			name:       "NetworkEvents without privilege triggers warning",
-			ocpVersion: "4.18.0",
+			ocpVersion: "4.19.0",
 			fc: &FlowCollector{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster",


### PR DESCRIPTION
## Description

make sure OCP4.19 is required for network events, UDN and eventMgr
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
