### PR TITLE
Add console plugin to bundle

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -4,7 +4,7 @@
 # More info: https://book.kubebuilder.io/reference/project-config.html
 domain: netobserv.io
 layout:
-- go.kubebuilder.io/v3
+- go.kubebuilder.io/v4
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
 projectName: netobserv-operator

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,9 +7,9 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=netobserv-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=latest,community
 LABEL operators.operatorframework.io.bundle.channel.default.v1=community
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.3
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-unknown
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle.Dockerfile.downstream
+++ b/bundle.Dockerfile.downstream
@@ -19,7 +19,7 @@ LABEL operators.operatorframework.io.bundle.channels.v1=stable,v1.0.x
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.3
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle/manifests/netobserv-netobserv-static-plugin_console.openshift.io_v1_consoleplugin.yaml
+++ b/bundle/manifests/netobserv-netobserv-static-plugin_console.openshift.io_v1_consoleplugin.yaml
@@ -1,0 +1,22 @@
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  name: netobserv-netobserv-static-plugin
+spec:
+  backend:
+    service:
+      basePath: /
+      name: netobserv-static-plugin
+      namespace: system
+      port: 9001
+    type: Service
+  displayName: NetObserv configuration plugin
+  proxy:
+  - alias: backend
+    authorization: UserToken
+    endpoint:
+      service:
+        name: netobserv-static-plugin
+        namespace: netobserv
+        port: 9001
+      type: Service

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -434,14 +434,14 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring, Networking
     console.openshift.io/plugins: '["netobserv-plugin"]'
-    containerImage: quay.io/netobserv/network-observability-operator:1.8.2-community
-    createdAt: ':created-at:'
+    containerImage: quay.io/netobserv/network-observability-operator:main
+    createdAt: "2025-04-09T09:07:54Z"
     description: Network flows collector and monitoring solution
     operatorframework.io/initialization-resource: '{"apiVersion":"flows.netobserv.io/v1beta2",
       "kind":"FlowCollector","metadata":{"name":"cluster"},"spec": {}}'
     operatorframework.io/suggested-namespace: openshift-netobserv-operator
-    operators.operatorframework.io/builder: operator-sdk-v1.25.3
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    operators.operatorframework.io/builder: operator-sdk-unknown
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/netobserv/network-observability-operator
     support: NetObserv team
   labels:
@@ -894,7 +894,7 @@ spec:
 
     ## Configuration
 
-    The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/1.8.2-community/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/1.8.2-community/config/samples/flows_v1beta2_flowcollector.yaml).
+    The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/main/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/main/config/samples/flows_v1beta2_flowcollector.yaml).
 
     To edit configuration in cluster, run:
 
@@ -910,7 +910,7 @@ spec:
 
     - Loki (`spec.loki`): configure here how to reach Loki. The default values match the Loki quick install paths mentioned above, but you might have to configure differently if you used another installation method. Make sure to disable it (`spec.loki.enable`) if you don't want to use Loki.
 
-    - Quick filters (`spec.consolePlugin.quickFilters`): configure preset filters to be displayed in the Console plugin. They offer a way to quickly switch from filters to others, such as showing / hiding pods network, or infrastructure network, or application network, etc. They can be tuned to reflect the different workloads running on your cluster. For a list of available filters, [check this page](https://github.com/netobserv/network-observability-operator/blob/1.8.2-community/docs/QuickFilters.md).
+    - Quick filters (`spec.consolePlugin.quickFilters`): configure preset filters to be displayed in the Console plugin. They offer a way to quickly switch from filters to others, such as showing / hiding pods network, or infrastructure network, or application network, etc. They can be tuned to reflect the different workloads running on your cluster. For a list of available filters, [check this page](https://github.com/netobserv/network-observability-operator/blob/main/docs/QuickFilters.md).
 
     - Kafka (`spec.deploymentModel: KAFKA` and `spec.kafka`): when enabled, integrates the flow collection pipeline with Kafka, by splitting ingestion from transformation (kube enrichment, derived metrics, ...). Kafka can provide better scalability, resiliency and high availability ([view more details](https://www.redhat.com/en/topics/integration/what-is-apache-kafka)). Assumes Kafka is already deployed and a topic is created.
 
@@ -925,7 +925,7 @@ spec:
     This documentation includes:
 
     - An [overview](https://github.com/netobserv/network-observability-operator#openshift-console) of the features, with screenshots
-    - More information on [configuring metrics](https://github.com/netobserv/network-observability-operator/blob/1.8.2-community/docs/Metrics.md).
+    - More information on [configuring metrics](https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md).
     - A [performance](https://github.com/netobserv/network-observability-operator#performance-fine-tuning) section, for fine-tuning
     - A [security](https://github.com/netobserv/network-observability-operator#securing-data-and-communications) section
     - An [F.A.Q.](https://github.com/netobserv/network-observability-operator#faq--troubleshooting) section
@@ -1228,7 +1228,7 @@ spec:
                 - name: DOWNSTREAM_DEPLOYMENT
                   value: "false"
                 - name: PROFILING_BIND_ADDRESS
-                image: quay.io/netobserv/network-observability-operator:1.8.2-community
+                image: quay.io/netobserv/network-observability-operator:main
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -1279,6 +1279,52 @@ spec:
                 secret:
                   defaultMode: 420
                   secretName: manager-metrics-tls
+      - label:
+          app: static-console-plugin
+        name: netobserv-static-console-plugin
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: static-console-plugin
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app: static-console-plugin
+            spec:
+              containers:
+              - command:
+                - /static-plugin
+                env:
+                - name: GODEBUG
+                  value: http2server=0
+                image: quay.io/netobserv/network-observability-console-plugin:main
+                imagePullPolicy: Always
+                name: static-plugin
+                resources:
+                  limits:
+                    memory: 200Mi
+                  requests:
+                    cpu: 100m
+                    memory: 100Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
+                volumeMounts:
+                - mountPath: /var/serving-cert
+                  name: static-console-plugin-tls
+                  readOnly: true
+              securityContext:
+                runAsNonRoot: true
+              volumes:
+              - name: static-console-plugin-tls
+                secret:
+                  defaultMode: 420
+                  secretName: static-console-plugin-tls
       permissions:
       - rules:
         - apiGroups:

--- a/bundle/manifests/netobserv-static-console-plugin_v1_service.yaml
+++ b/bundle/manifests/netobserv-static-console-plugin_v1_service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: static-console-plugin-tls
+  creationTimestamp: null
+  labels:
+    app: static-console-plugin
+  name: netobserv-static-console-plugin
+spec:
+  ports:
+  - name: https
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: static-console-plugin
+status:
+  loadBalancer: {}

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,9 +6,9 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: netobserv-operator
   operators.operatorframework.io.bundle.channels.v1: latest,community
   operators.operatorframework.io.bundle.channel.default.v1: community
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.3
+  operators.operatorframework.io.metrics.builder: operator-sdk-unknown
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/catalog/released/bundles.yaml
+++ b/catalog/released/bundles.yaml
@@ -185,7 +185,7 @@ properties:
         description: Network flows collector and monitoring solution
         operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
         operators.operatorframework.io/builder: operator-sdk-v1.25.3
-        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/netobserv/network-observability-operator
       apiServiceDefinitions: {}
       crdDescriptions:
@@ -505,7 +505,7 @@ properties:
         description: Network flows collector and monitoring solution
         operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
         operators.operatorframework.io/builder: operator-sdk-v1.25.3
-        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/netobserv/network-observability-operator
       apiServiceDefinitions: {}
       crdDescriptions:
@@ -1013,7 +1013,7 @@ properties:
         operatorframework.io/suggested-namespace: openshift-netobserv-operator
         operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
         operators.operatorframework.io/builder: operator-sdk-v1.25.3
-        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/netobserv/network-observability-operator
       apiServiceDefinitions: {}
       crdDescriptions:
@@ -1525,7 +1525,7 @@ properties:
         operatorframework.io/suggested-namespace: openshift-netobserv-operator
         operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
         operators.operatorframework.io/builder: operator-sdk-v1.25.3
-        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/netobserv/network-observability-operator
       apiServiceDefinitions: {}
       crdDescriptions:
@@ -2056,7 +2056,7 @@ properties:
         operatorframework.io/suggested-namespace: openshift-netobserv-operator
         operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
         operators.operatorframework.io/builder: operator-sdk-v1.25.3
-        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/netobserv/network-observability-operator
       apiServiceDefinitions: {}
       crdDescriptions:
@@ -2583,7 +2583,7 @@ properties:
         operatorframework.io/suggested-namespace: openshift-netobserv-operator
         operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
         operators.operatorframework.io/builder: operator-sdk-v1.25.3
-        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/netobserv/network-observability-operator
       apiServiceDefinitions: {}
       crdDescriptions:
@@ -3110,7 +3110,7 @@ properties:
         operatorframework.io/suggested-namespace: openshift-netobserv-operator
         operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
         operators.operatorframework.io/builder: operator-sdk-v1.25.3
-        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/netobserv/network-observability-operator
       apiServiceDefinitions: {}
       crdDescriptions:
@@ -3709,7 +3709,7 @@ properties:
         operatorframework.io/suggested-namespace: openshift-netobserv-operator
         operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
         operators.operatorframework.io/builder: operator-sdk-v1.25.3
-        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/netobserv/network-observability-operator
       apiServiceDefinitions: {}
       crdDescriptions:
@@ -4654,7 +4654,7 @@ properties:
         operatorframework.io/suggested-namespace: openshift-netobserv-operator
         operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
         operators.operatorframework.io/builder: operator-sdk-v1.25.3
-        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/netobserv/network-observability-operator
         support: NetObserv team
       apiServiceDefinitions: {}
@@ -5644,7 +5644,7 @@ properties:
         operatorframework.io/suggested-namespace: openshift-netobserv-operator
         operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
         operators.operatorframework.io/builder: operator-sdk-v1.25.3
-        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/netobserv/network-observability-operator
         support: NetObserv team
       apiServiceDefinitions: {}
@@ -6636,7 +6636,7 @@ properties:
         operatorframework.io/suggested-namespace: openshift-netobserv-operator
         operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
         operators.operatorframework.io/builder: operator-sdk-v1.25.3
-        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/netobserv/network-observability-operator
         support: NetObserv team
       apiServiceDefinitions: {}
@@ -7633,7 +7633,7 @@ properties:
         operatorframework.io/suggested-namespace: openshift-netobserv-operator
         operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
         operators.operatorframework.io/builder: operator-sdk-v1.25.3
-        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/netobserv/network-observability-operator
         support: NetObserv team
       apiServiceDefinitions: {}
@@ -8635,7 +8635,7 @@ properties:
         operatorframework.io/suggested-namespace: openshift-netobserv-operator
         operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
         operators.operatorframework.io/builder: operator-sdk-v1.25.3
-        operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+        operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
         repository: https://github.com/netobserv/network-observability-operator
         support: NetObserv team
       apiServiceDefinitions: {}

--- a/catalog/unreleased/downstream-test-fbc/bundle.yaml
+++ b/catalog/unreleased/downstream-test-fbc/bundle.yaml
@@ -481,7 +481,7 @@ properties:
       operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine",
         "OpenShift Container Platform", "OpenShift Platform Plus"]'
       operators.operatorframework.io/builder: operator-sdk-v1.25.3
-      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
       repository: https://github.com/netobserv/network-observability-operator
       support: NetObserv team
     apiServiceDefinitions: {}

--- a/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
@@ -11,8 +11,7 @@ metadata:
     description: Network flows collector and monitoring solution
     support: NetObserv team
     operatorframework.io/suggested-namespace: openshift-netobserv-operator
-    operatorframework.io/initialization-resource: '{"apiVersion":"flows.netobserv.io/v1beta2",
-      "kind":"FlowCollector","metadata":{"name":"cluster"},"spec": {}}'
+    operatorframework.io/initialization-resource: '{"apiVersion":"flows.netobserv.io/v1beta2", "kind":"FlowCollector","metadata":{"name":"cluster"},"spec": {}}'
     repository: https://github.com/netobserv/network-observability-operator
   labels:
     operatorframework.io/arch.amd64: supported
@@ -26,332 +25,450 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: '`FlowCollector` is the schema for the network flows collection
-        API, which pilots and configures the underlying deployments.'
-      displayName: Flow Collector
-      kind: FlowCollector
-      name: flowcollectors.flows.netobserv.io
-      version: v1beta1
-    - description: '`FlowCollector` is the schema for the network flows collection
-        API, which pilots and configures the underlying deployments.'
-      displayName: Flow Collector
-      kind: FlowCollector
-      name: flowcollectors.flows.netobserv.io
-      version: v1beta2
-      specDescriptors:
-        # Reference: https://github.com/openshift/console/blob/master/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md
-        # ROOT
-        - description: defines the desired type of deployment for flow processing.
-          path: deploymentModel
-        # AGENT
-        - description: for flows extraction.
-          displayName: Agent configuration
-          path: agent
-        - path: agent.type
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:hidden
-        - path: agent.ipfix
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:hidden
-        - description: Settings related to the eBPF-based flow reporter.
-          displayName: eBPF Agent configuration
-          path: agent.ebpf
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:eBPF
-        - displayName: Privileged mode
-          path: agent.ebpf.privileged
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - path: agent.ebpf.cacheActiveTimeout
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - path: agent.ebpf.cacheMaxFlows
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - path: agent.ebpf.kafkaBatchSize
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - path: agent.ebpf.logLevel
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - path: agent.ebpf.imagePullPolicy
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Resource Requirements
-          path: agent.ebpf.resources
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-        - path: agent.ebpf.advanced
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:hidden
-        - path: agent.ebpf.flowFilter
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:hidden
-        - path: agent.ebpf.metrics.enable
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:hidden
-        # KAFKA
-        - description: to use Kafka as a broker as part of the flow collection pipeline.
-          displayName: Kafka configuration
-          path: kafka
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
-        - displayName: TLS configuration
-          path: kafka.tls
-        - path: kafka.tls.enable
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - displayName: Insecure
-          path: kafka.tls.insecureSkipVerify
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
-        - displayName: User certificate when using mTLS
-          path: kafka.tls.userCert
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
-        - displayName: CA certificate
-          path: kafka.tls.caCert
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
-        - path: kafka.sasl
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:hidden
-        # PROCESSOR / FLP
-        - description: of the component that receives the flows from the agent, enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.
-          displayName: Processor configuration
-          path: processor
-        - displayName: Multi-cluster deployment
-          path: processor.multiClusterDeployment
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - path: processor.clusterName
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.multiClusterDeployment:true
-        - displayName: Availability zones
-          path: processor.addZone
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - path: processor.advanced
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:hidden
-        - displayName: Metrics configuration
-          path: processor.metrics
-        - displayName: Server configuration
-          path: processor.metrics.server
-        - displayName: TLS configuration
-          path: processor.metrics.server.tls
-        - displayName: Insecure
-          path: processor.metrics.server.tls.insecureSkipVerify
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided
-        - displayName: Cert
-          path: processor.metrics.server.tls.provided
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided
-        - displayName: CA
-          path: processor.metrics.server.tls.providedCaFile
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided
-        - path: processor.kafkaConsumerReplicas
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: kafka consumer autoscaler
-          path: processor.kafkaConsumerAutoscaler
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - path: processor.kafkaConsumerQueueCapacity
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - path: processor.kafkaConsumerBatchSize
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - path: processor.subnetLabels.openShiftAutoDetect
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:hidden
-        - path: processor.logLevel
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - path: processor.imagePullPolicy
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Resource Requirements
-          path: processor.resources
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-        # LOKI
-        - description: for the flow store.
-          displayName: Loki client settings
-          path: loki
-        - path: loki.enable
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - path: loki.mode
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-        - path: loki.lokiStack
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:LokiStack
-        - path: loki.monolithic
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Monolithic
-        - path: loki.microservices
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Microservices
-        - path: loki.manual
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Manual
-        - path: loki.writeBatchWait
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - path: loki.writeBatchSize
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - path: loki.writeTimeout
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - path: loki.advanced
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:hidden
-        # CONSOLE PLUGIN
-        - description: related to the OpenShift Console integration.
-          displayName: Console plugin configuration
-          path: consolePlugin
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
-        - path: consolePlugin.enable
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - path: consolePlugin.portNaming
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
-        - path: consolePlugin.quickFilters
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
-        - path: consolePlugin.replicas
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Horizontal pod autoscaler
-          path: consolePlugin.autoscaler
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - path: consolePlugin.logLevel
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - path: consolePlugin.imagePullPolicy
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy"
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Resource Requirements
-          path: consolePlugin.resources
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-            - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
-        - path: consolePlugin.advanced
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:hidden
-        # EXPORTERS
-        - description: additional optional exporters for custom consumption or storage.
-          path: exporters
-          x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-        - displayName: Type
-          path: exporters[0].type
-        - displayName: IPFIX configuration
-          path: exporters[0].ipfix
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:IPFIX"
-        - displayName: Kafka configuration
-          path: exporters[0].kafka
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:Kafka"
-        - displayName: OpenTelemetry configuration
-          path: exporters[0].openTelemetry
-          x-descriptors:
-            - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:OpenTelemetry"
-      statusDescriptors:
-        - displayName: Namespace
-          description: Namespace where console plugin and flowlogs-pipeline have been deployed.
-          path: namespace
-          x-descriptors:
-            - urn:alm:descriptor:text
-        - description: Conditions of the FlowCollector instance health.
-          displayName: Conditions
-          path: conditions
-          x-descriptors:
-            - urn:alm:descriptor:io.kubernetes.conditions
-    - description: '`FlowMetric` is the schema for the custom metrics API,
-        which allows to generate more metrics out of flow logs.
-        You can find examples here: https://github.com/netobserv/network-observability-operator/tree/main/config/samples/flowmetrics'
-      displayName: Flow Metric
-      kind: FlowMetric
-      name: flowmetrics.flows.netobserv.io
-      version: v1alpha1
+      - description: '`FlowCollector` is the schema for the network flows collection API, which pilots and configures the underlying deployments.'
+        displayName: Flow Collector
+        kind: FlowCollector
+        name: flowcollectors.flows.netobserv.io
+        version: v1beta1
+      - description: '`FlowCollector` is the schema for the network flows collection API, which pilots and configures the underlying deployments.'
+        displayName: Flow Collector
+        kind: FlowCollector
+        name: flowcollectors.flows.netobserv.io
+        version: v1beta2
+        specDescriptors:
+          # Reference: https://github.com/openshift/console/blob/master/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md
+          # ROOT
+          - description: defines the desired type of deployment for flow processing.
+            path: deploymentModel
+            displayName: Deployment model
+          # AGENT
+          - description: for flows extraction.
+            displayName: Agent configuration
+            path: agent
+          - path: agent.type
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - path: agent.ipfix
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: Settings related to the eBPF-based flow reporter.
+            displayName: eBPF Agent configuration
+            path: agent.ebpf
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:agent.type:eBPF
+          - displayName: Privileged mode
+            path: agent.ebpf.privileged
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - path: agent.ebpf.cacheActiveTimeout
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Cache active timeout
+          - path: agent.ebpf.cacheMaxFlows
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Cache max flows
+          - path: agent.ebpf.kafkaBatchSize
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Kafka batch size
+          - path: agent.ebpf.logLevel
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Log level
+          - path: agent.ebpf.imagePullPolicy
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Image pull policy
+          - displayName: Resource Requirements
+            path: agent.ebpf.resources
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+          - path: agent.ebpf.advanced
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - path: agent.ebpf.flowFilter
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - path: agent.ebpf.metrics.enable
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          # KAFKA
+          - description: to use Kafka as a broker as part of the flow collection pipeline.
+            displayName: Kafka configuration
+            path: kafka
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
+          - displayName: TLS configuration
+            path: kafka.tls
+          - path: kafka.tls.enable
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - displayName: Insecure
+            path: kafka.tls.insecureSkipVerify
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
+          - displayName: User certificate when using mTLS
+            path: kafka.tls.userCert
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
+          - displayName: CA certificate
+            path: kafka.tls.caCert
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:kafka.tls.enable:true
+          - path: kafka.sasl
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          # PROCESSOR / FLP
+          - description: of the component that receives the flows from the agent, enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.
+            displayName: Processor configuration
+            path: processor
+          - displayName: Multi-cluster deployment
+            path: processor.multiClusterDeployment
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - path: processor.clusterName
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.multiClusterDeployment:true
+            displayName: Cluster name
+          - displayName: Availability zones
+            path: processor.addZone
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - path: processor.advanced
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - displayName: Metrics configuration
+            path: processor.metrics
+          - displayName: Server configuration
+            path: processor.metrics.server
+          - displayName: TLS configuration
+            path: processor.metrics.server.tls
+          - displayName: Insecure
+            path: processor.metrics.server.tls.insecureSkipVerify
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided
+          - displayName: Cert
+            path: processor.metrics.server.tls.provided
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided
+          - displayName: CA
+            path: processor.metrics.server.tls.providedCaFile
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:processor.metrics.server.tls.type:Provided
+          - path: processor.kafkaConsumerReplicas
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Kafka consumer replicas
+          - displayName: kafka consumer autoscaler
+            path: processor.kafkaConsumerAutoscaler
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+          - path: processor.kafkaConsumerQueueCapacity
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Kafka consumer queue capacity
+          - path: processor.kafkaConsumerBatchSize
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:deploymentModel:Kafka
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Kafka consumer batch size
+          - path: processor.subnetLabels.openShiftAutoDetect
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          - path: processor.logLevel
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Log level
+          - path: processor.imagePullPolicy
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Image pull policy
+          - displayName: Resource Requirements
+            path: processor.resources
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+          # LOKI
+          - description: for the flow store.
+            displayName: Loki client settings
+            path: loki
+          - path: loki.enable
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+            displayName: Enable
+          - path: loki.mode
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+            displayName: Mode
+          - path: loki.lokiStack
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:LokiStack
+            displayName: Loki stack
+          - path: loki.monolithic
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Monolithic
+            displayName: Monolithic
+          - path: loki.microservices
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Microservices
+            displayName: Microservices
+          - path: loki.manual
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.mode:Manual
+            displayName: Manual
+          - path: loki.writeBatchWait
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Write batch wait
+          - path: loki.writeBatchSize
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Write batch size
+          - path: loki.writeTimeout
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Write timeout
+          - path: loki.advanced
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          # CONSOLE PLUGIN
+          - description: related to the OpenShift Console integration.
+            displayName: Console plugin configuration
+            path: consolePlugin
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:loki.enable:true
+          - path: consolePlugin.enable
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+            displayName: Enable
+          - path: consolePlugin.portNaming
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+            displayName: Port naming
+          - path: consolePlugin.quickFilters
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+            displayName: Quick filters
+          - path: consolePlugin.replicas
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Replicas
+          - displayName: Horizontal pod autoscaler
+            path: consolePlugin.autoscaler
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+          - path: consolePlugin.logLevel
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Log level
+          - path: consolePlugin.imagePullPolicy
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy"
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Image pull policy
+          - displayName: Resource Requirements
+            path: consolePlugin.resources
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+              - urn:alm:descriptor:com.tectonic.ui:fieldDependency:consolePlugin.enable:true
+          - path: consolePlugin.advanced
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
+          # EXPORTERS
+          - description: additional optional exporters for custom consumption or storage.
+            path: exporters
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+            displayName: Exporters
+          - displayName: Type
+            path: exporters[0].type
+          - displayName: IPFIX configuration
+            path: exporters[0].ipfix
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:IPFIX"
+          - displayName: Kafka configuration
+            path: exporters[0].kafka
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:Kafka"
+          - displayName: OpenTelemetry configuration
+            path: exporters[0].openTelemetry
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:exporters.type:OpenTelemetry"
+          - path: agent.ebpf.excludeInterfaces
+            displayName: Exclude interfaces
+          - path: agent.ebpf.features
+            displayName: Features
+          - path: agent.ebpf.interfaces
+            displayName: Interfaces
+          - path: agent.ebpf.metrics
+            displayName: Metrics
+          - path: agent.ebpf.metrics.disableAlerts
+            displayName: Disable alerts
+          - path: agent.ebpf.metrics.server
+            displayName: Server
+          - path: agent.ebpf.metrics.server.port
+            displayName: Port
+          - path: agent.ebpf.sampling
+            displayName: Sampling
+          - path: consolePlugin.portNaming.enable
+            displayName: Enable
+          - path: consolePlugin.portNaming.portNames
+            displayName: Port names
+          - path: kafka.address
+            displayName: Address
+          - path: kafka.topic
+            displayName: Topic
+          - path: loki.lokiStack.name
+            displayName: Name
+          - path: loki.lokiStack.namespace
+            displayName: Namespace
+          - path: loki.manual.authToken
+            displayName: Auth token
+          - path: loki.manual.ingesterUrl
+            displayName: Ingester url
+          - path: loki.manual.querierUrl
+            displayName: Querier url
+          - path: loki.manual.statusUrl
+            displayName: Status url
+          - path: loki.manual.tenantID
+            displayName: Tenant id
+          - path: loki.microservices.ingesterUrl
+            displayName: Ingester url
+          - path: loki.microservices.querierUrl
+            displayName: Querier url
+          - path: loki.microservices.tenantID
+            displayName: Tenant id
+          - path: loki.monolithic.tenantID
+            displayName: Tenant id
+          - path: loki.monolithic.url
+            displayName: Url
+          - path: loki.readTimeout
+            displayName: Read timeout
+          - path: namespace
+            displayName: Namespace
+          - path: networkPolicy
+            displayName: Network policy
+          - path: networkPolicy.additionalNamespaces
+            displayName: Additional namespaces
+          - path: networkPolicy.enable
+            displayName: Enable
+          - path: processor.deduper
+            displayName: Deduper
+          - path: processor.deduper.mode
+            displayName: Mode
+          - path: processor.deduper.sampling
+            displayName: Sampling
+          - path: processor.filters
+            displayName: Filters
+          - path: processor.logTypes
+            displayName: Log types
+          - path: processor.metrics.disableAlerts
+            displayName: Disable alerts
+          - path: processor.metrics.includeList
+            displayName: Include list
+          - path: processor.metrics.server.port
+            displayName: Port
+          - path: processor.subnetLabels
+            displayName: Subnet labels
+          - path: processor.subnetLabels.customLabels
+            displayName: Custom labels
+          - path: prometheus
+            displayName: Prometheus
+          - path: prometheus.querier
+            displayName: Querier
+          - path: prometheus.querier.enable
+            displayName: Enable
+          - path: prometheus.querier.manual
+            displayName: Manual
+          - path: prometheus.querier.manual.forwardUserToken
+            displayName: Forward user token
+          - path: prometheus.querier.manual.url
+            displayName: Url
+          - path: prometheus.querier.mode
+            displayName: Mode
+          - path: prometheus.querier.timeout
+            displayName: Timeout
+        statusDescriptors:
+          - displayName: Namespace
+            description: Namespace where console plugin and flowlogs-pipeline have been deployed.
+            path: namespace
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - description: Conditions of the FlowCollector instance health.
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+      - description: '`FlowMetric` is the schema for the custom metrics API, which allows to generate more metrics out of flow logs. You can find examples here: https://github.com/netobserv/network-observability-operator/tree/main/config/samples/flowmetrics'
+        displayName: Flow Metric
+        kind: FlowMetric
+        name: flowmetrics.flows.netobserv.io
+        version: v1alpha1
   description: ':full-description:'
   displayName: NetObserv Operator
   icon:
-  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI2LjAuMiwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMDAgMTAwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAxMDAgMTAwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6dXJsKCNTVkdJRF8xXyk7fQoJLnN0MXtmaWxsOiNGRkZGRkY7fQoJLnN0MntvcGFjaXR5OjAuNjt9Cgkuc3Qze29wYWNpdHk6MC41O30KCS5zdDR7b3BhY2l0eTowLjQ7fQo8L3N0eWxlPgo8Zz4KCTxnPgoJCTxnPgoJCQk8cmFkaWFsR3JhZGllbnQgaWQ9IlNWR0lEXzFfIiBjeD0iMTQuNzc1OCIgY3k9Ii0yLjk3NzEiIHI9IjkxLjYyNyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgoJCQkJPHN0b3AgIG9mZnNldD0iMCIgc3R5bGU9InN0b3AtY29sb3I6IzNDM0ZBNiIvPgoJCQkJPHN0b3AgIG9mZnNldD0iMSIgc3R5bGU9InN0b3AtY29sb3I6IzNCMDM0MCIvPgoJCQk8L3JhZGlhbEdyYWRpZW50PgoJCQk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNTAsOTljLTEzLjMsMC0yNS40LTUuMy0zNC4yLTEzLjlDNi43LDc2LjIsMSw2My43LDEsNTBDMSwyMi45LDIyLjksMSw1MCwxYzEzLjcsMCwyNi4yLDUuNywzNS4xLDE0LjgKCQkJCUM5My43LDI0LjYsOTksMzYuNyw5OSw1MEM5OSw3Ny4xLDc3LjEsOTksNTAsOTl6Ii8+CgkJPC9nPgoJCTxnPgoJCQk8Y2lyY2xlIGNsYXNzPSJzdDEiIGN4PSIzNy41IiBjeT0iODEuOSIgcj0iNSIvPgoJCTwvZz4KCQk8cGF0aCBjbGFzcz0ic3QxIiBkPSJNNDguNiw5MS45bDE4LjgtNDMuM2MtMi41LTAuMS01LTAuNy03LjItMkwzMy4yLDY4LjJsMS40LTEuOGwyMC0yNS4xYy0xLjUtMi40LTIuMy01LjEtMi4zLTcuOUw5LDUyLjIKCQkJbDQ3LjYtMjkuOWwwLDBjMC4xLTAuMSwwLjItMC4yLDAuMi0wLjJjNi4xLTYuMSwxNS45LTYuMSwyMiwwbDAuMSwwLjFjNiw2LjEsNiwxNS45LTAuMSwyMS45Yy0wLjEsMC4xLTAuMiwwLjItMC4yLDAuMmwwLDAKCQkJTDQ4LjYsOTEuOXoiLz4KCQk8ZyBjbGFzcz0ic3QyIj4KCQkJPGNpcmNsZSBjbGFzcz0ic3QxIiBjeD0iNTAuMyIgY3k9IjE0LjciIHI9IjMuMSIvPgoJCTwvZz4KCQk8ZyBjbGFzcz0ic3QzIj4KCQkJPGNpcmNsZSBjbGFzcz0ic3QxIiBjeD0iMjcuNyIgY3k9IjU4IiByPSIxLjciLz4KCQk8L2c+CgkJPGc+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9Ijc3LjQiIGN5PSI2OS4zIiByPSIxLjciLz4KCQk8L2c+CgkJPGc+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9IjE2LjMiIGN5PSIzNi42IiByPSIxLjciLz4KCQk8L2c+CgkJPGcgY2xhc3M9InN0NCI+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9IjYzLjciIGN5PSI4NS45IiByPSIyLjIiLz4KCQk8L2c+CgkJPGc+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9IjI5LjQiIGN5PSIxOS42IiByPSI0LjgiLz4KCQk8L2c+CgkJPGcgY2xhc3M9InN0MyI+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9Ijg4IiBjeT0iNTAiIHI9IjQuOCIvPgoJCTwvZz4KCTwvZz4KPC9nPgo8L3N2Zz4K
-    mediatype: image/svg+xml
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI2LjAuMiwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMDAgMTAwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAxMDAgMTAwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6dXJsKCNTVkdJRF8xXyk7fQoJLnN0MXtmaWxsOiNGRkZGRkY7fQoJLnN0MntvcGFjaXR5OjAuNjt9Cgkuc3Qze29wYWNpdHk6MC41O30KCS5zdDR7b3BhY2l0eTowLjQ7fQo8L3N0eWxlPgo8Zz4KCTxnPgoJCTxnPgoJCQk8cmFkaWFsR3JhZGllbnQgaWQ9IlNWR0lEXzFfIiBjeD0iMTQuNzc1OCIgY3k9Ii0yLjk3NzEiIHI9IjkxLjYyNyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgoJCQkJPHN0b3AgIG9mZnNldD0iMCIgc3R5bGU9InN0b3AtY29sb3I6IzNDM0ZBNiIvPgoJCQkJPHN0b3AgIG9mZnNldD0iMSIgc3R5bGU9InN0b3AtY29sb3I6IzNCMDM0MCIvPgoJCQk8L3JhZGlhbEdyYWRpZW50PgoJCQk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNTAsOTljLTEzLjMsMC0yNS40LTUuMy0zNC4yLTEzLjlDNi43LDc2LjIsMSw2My43LDEsNTBDMSwyMi45LDIyLjksMSw1MCwxYzEzLjcsMCwyNi4yLDUuNywzNS4xLDE0LjgKCQkJCUM5My43LDI0LjYsOTksMzYuNyw5OSw1MEM5OSw3Ny4xLDc3LjEsOTksNTAsOTl6Ii8+CgkJPC9nPgoJCTxnPgoJCQk8Y2lyY2xlIGNsYXNzPSJzdDEiIGN4PSIzNy41IiBjeT0iODEuOSIgcj0iNSIvPgoJCTwvZz4KCQk8cGF0aCBjbGFzcz0ic3QxIiBkPSJNNDguNiw5MS45bDE4LjgtNDMuM2MtMi41LTAuMS01LTAuNy03LjItMkwzMy4yLDY4LjJsMS40LTEuOGwyMC0yNS4xYy0xLjUtMi40LTIuMy01LjEtMi4zLTcuOUw5LDUyLjIKCQkJbDQ3LjYtMjkuOWwwLDBjMC4xLTAuMSwwLjItMC4yLDAuMi0wLjJjNi4xLTYuMSwxNS45LTYuMSwyMiwwbDAuMSwwLjFjNiw2LjEsNiwxNS45LTAuMSwyMS45Yy0wLjEsMC4xLTAuMiwwLjItMC4yLDAuMmwwLDAKCQkJTDQ4LjYsOTEuOXoiLz4KCQk8ZyBjbGFzcz0ic3QyIj4KCQkJPGNpcmNsZSBjbGFzcz0ic3QxIiBjeD0iNTAuMyIgY3k9IjE0LjciIHI9IjMuMSIvPgoJCTwvZz4KCQk8ZyBjbGFzcz0ic3QzIj4KCQkJPGNpcmNsZSBjbGFzcz0ic3QxIiBjeD0iMjcuNyIgY3k9IjU4IiByPSIxLjciLz4KCQk8L2c+CgkJPGc+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9Ijc3LjQiIGN5PSI2OS4zIiByPSIxLjciLz4KCQk8L2c+CgkJPGc+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9IjE2LjMiIGN5PSIzNi42IiByPSIxLjciLz4KCQk8L2c+CgkJPGcgY2xhc3M9InN0NCI+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9IjYzLjciIGN5PSI4NS45IiByPSIyLjIiLz4KCQk8L2c+CgkJPGc+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9IjI5LjQiIGN5PSIxOS42IiByPSI0LjgiLz4KCQk8L2c+CgkJPGcgY2xhc3M9InN0MyI+CgkJCTxjaXJjbGUgY2xhc3M9InN0MSIgY3g9Ijg4IiBjeT0iNTAiIHI9IjQuOCIvPgoJCTwvZz4KCTwvZz4KPC9nPgo8L3N2Zz4K
+      mediatype: image/svg+xml
   install:
     spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
-    type: OwnNamespace
-  - supported: false
-    type: SingleNamespace
-  - supported: false
-    type: MultiNamespace
-  - supported: true
-    type: AllNamespaces
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
   keywords:
-  - network observability
-  - ebpf
-  - ipfix
-  - flow tracing
-  - flows
-  - topology
-  - network
-  - observability
+    - network observability
+    - ebpf
+    - ipfix
+    - flow tracing
+    - flows
+    - topology
+    - network
+    - observability
   links:
-  - name: Project page
-    url: https://github.com/netobserv/network-observability-operator
-  - name: Issue tracker
-    url: https://github.com/netobserv/network-observability-operator/issues
-  - name: Discussion board
-    url: https://github.com/netobserv/network-observability-operator/discussions
+    - name: Project page
+      url: https://github.com/netobserv/network-observability-operator
+    - name: Issue tracker
+      url: https://github.com/netobserv/network-observability-operator/issues
+    - name: Discussion board
+      url: https://github.com/netobserv/network-observability-operator/discussions
   maintainers:
-  - email: jpinsonn@redhat.com
-    name: Julien Pinsonneau
-  - email: jtakvori@redhat.com
-    name: Joel Takvorian
-  - email: kmeth@redhat.com
-    name: Kalman Meth
-  - email: mmahmoud@redhat.com
-    name: Mohamed S. Mahmoud
-  - email: ocazade@redhat.com
-    name: Olivier Cazade
-  - email: rschaffe@redhat.com
-    name: Ronen Schaffer
-  - email: stlee@redhat.com
-    name: Steven Lee
+    - email: jpinsonn@redhat.com
+      name: Julien Pinsonneau
+    - email: jtakvori@redhat.com
+      name: Joel Takvorian
+    - email: kmeth@redhat.com
+      name: Kalman Meth
+    - email: mmahmoud@redhat.com
+      name: Mohamed S. Mahmoud
+    - email: ocazade@redhat.com
+      name: Olivier Cazade
+    - email: rschaffe@redhat.com
+      name: Ronen Schaffer
+    - email: stlee@redhat.com
+      name: Steven Lee
   maturity: alpha
   minKubeVersion: 1.23.0
   provider:

--- a/config/descriptions/ocp.md
+++ b/config/descriptions/ocp.md
@@ -38,7 +38,7 @@ In that case, you can still get the Prometheus metrics or export raw flows to a 
 
 ## Configuration
 
-The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/1.8.2-community/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/1.8.2-community/config/samples/flows_v1beta2_flowcollector.yaml).
+The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/main/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/main/config/samples/flows_v1beta2_flowcollector.yaml).
 
 To edit configuration in cluster, run:
 
@@ -54,7 +54,7 @@ A couple of settings deserve special attention:
 
 - Loki (`spec.loki`): configure here how to reach Loki. The default values match the Loki quick install paths mentioned above, but you might have to configure differently if you used another installation method. Make sure to disable it (`spec.loki.enable`) if you don't want to use Loki.
 
-- Quick filters (`spec.consolePlugin.quickFilters`): configure preset filters to be displayed in the Console plugin. They offer a way to quickly switch from filters to others, such as showing / hiding pods network, or infrastructure network, or application network, etc. They can be tuned to reflect the different workloads running on your cluster. For a list of available filters, [check this page](https://github.com/netobserv/network-observability-operator/blob/1.8.2-community/docs/QuickFilters.md).
+- Quick filters (`spec.consolePlugin.quickFilters`): configure preset filters to be displayed in the Console plugin. They offer a way to quickly switch from filters to others, such as showing / hiding pods network, or infrastructure network, or application network, etc. They can be tuned to reflect the different workloads running on your cluster. For a list of available filters, [check this page](https://github.com/netobserv/network-observability-operator/blob/main/docs/QuickFilters.md).
 
 - Kafka (`spec.deploymentModel: KAFKA` and `spec.kafka`): when enabled, integrates the flow collection pipeline with Kafka, by splitting ingestion from transformation (kube enrichment, derived metrics, ...). Kafka can provide better scalability, resiliency and high availability ([view more details](https://www.redhat.com/en/topics/integration/what-is-apache-kafka)). Assumes Kafka is already deployed and a topic is created.
 
@@ -69,7 +69,7 @@ Please refer to the documentation on GitHub for more information.
 This documentation includes:
 
 - An [overview](https://github.com/netobserv/network-observability-operator#openshift-console) of the features, with screenshots
-- More information on [configuring metrics](https://github.com/netobserv/network-observability-operator/blob/1.8.2-community/docs/Metrics.md).
+- More information on [configuring metrics](https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md).
 - A [performance](https://github.com/netobserv/network-observability-operator#performance-fine-tuning) section, for fine-tuning
 - A [security](https://github.com/netobserv/network-observability-operator#securing-data-and-communications) section
 - An [F.A.Q.](https://github.com/netobserv/network-observability-operator#faq--troubleshooting) section

--- a/config/descriptions/upstream.md
+++ b/config/descriptions/upstream.md
@@ -42,7 +42,7 @@ In that case, you can still get the Prometheus metrics or export raw flows to a 
 
 ## Configuration
 
-The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/1.8.2-community/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/1.8.2-community/config/samples/flows_v1beta2_flowcollector.yaml).
+The `FlowCollector` resource is used to configure the operator and its managed components. A comprehensive documentation is [available here](https://github.com/netobserv/network-observability-operator/blob/main/docs/FlowCollector.md), and a full sample file [there](https://github.com/netobserv/network-observability-operator/blob/main/config/samples/flows_v1beta2_flowcollector.yaml).
 
 To edit configuration in cluster, run:
 
@@ -58,7 +58,7 @@ A couple of settings deserve special attention:
 
 - Loki (`spec.loki`): configure here how to reach Loki. The default values match the Loki quick install paths mentioned above, but you might have to configure differently if you used another installation method. Make sure to disable it (`spec.loki.enable`) if you don't want to use Loki.
 
-- Quick filters (`spec.consolePlugin.quickFilters`): configure preset filters to be displayed in the Console plugin. They offer a way to quickly switch from filters to others, such as showing / hiding pods network, or infrastructure network, or application network, etc. They can be tuned to reflect the different workloads running on your cluster. For a list of available filters, [check this page](https://github.com/netobserv/network-observability-operator/blob/1.8.2-community/docs/QuickFilters.md).
+- Quick filters (`spec.consolePlugin.quickFilters`): configure preset filters to be displayed in the Console plugin. They offer a way to quickly switch from filters to others, such as showing / hiding pods network, or infrastructure network, or application network, etc. They can be tuned to reflect the different workloads running on your cluster. For a list of available filters, [check this page](https://github.com/netobserv/network-observability-operator/blob/main/docs/QuickFilters.md).
 
 - Kafka (`spec.deploymentModel: KAFKA` and `spec.kafka`): when enabled, integrates the flow collection pipeline with Kafka, by splitting ingestion from transformation (kube enrichment, derived metrics, ...). Kafka can provide better scalability, resiliency and high availability ([view more details](https://www.redhat.com/en/topics/integration/what-is-apache-kafka)). Assumes Kafka is already deployed and a topic is created.
 
@@ -73,7 +73,7 @@ Please refer to the documentation on GitHub for more information.
 This documentation includes:
 
 - An [overview](https://github.com/netobserv/network-observability-operator#openshift-console) of the features, with screenshots
-- More information on [configuring metrics](https://github.com/netobserv/network-observability-operator/blob/1.8.2-community/docs/Metrics.md).
+- More information on [configuring metrics](https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md).
 - A [performance](https://github.com/netobserv/network-observability-operator#performance-fine-tuning) section, for fine-tuning
 - A [security](https://github.com/netobserv/network-observability-operator#securing-data-and-communications) section
 - An [F.A.Q.](https://github.com/netobserv/network-observability-operator#faq--troubleshooting) section

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -16,6 +16,6 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/netobserv/network-observability-operator
-  newTag: 1.8.2-community
+  newTag: main
 commonLabels:
   app: netobserv-operator

--- a/config/openshift-olm/default/kustomization.yaml
+++ b/config/openshift-olm/default/kustomization.yaml
@@ -24,6 +24,7 @@ bases:
 - ../../crd
 - ../../rbac
 - ../../manager
+- ../../static-console-plugin
 - ../../webhook
 patchesStrategicMerge:
 - patch.yaml

--- a/config/static-console-plugin/kustomization.yaml
+++ b/config/static-console-plugin/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+- static_console_plugin.yaml
+- static_console_plugin_deployment.yaml
+- static_console_plugin_service.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: static-console-plugin
+  newName: quay.io/netobserv/network-observability-console-plugin
+  newTag: main
+

--- a/config/static-console-plugin/static_console_plugin.yaml
+++ b/config/static-console-plugin/static_console_plugin.yaml
@@ -1,0 +1,22 @@
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  name: netobserv-static-plugin
+spec:
+  backend:
+    service:
+      basePath: /
+      name: netobserv-static-plugin
+      namespace: system
+      port: 9001
+    type: Service
+  displayName: NetObserv configuration plugin
+  proxy:
+  - alias: backend
+    authorization: UserToken
+    endpoint:
+      service:
+        name: netobserv-static-plugin
+        namespace: netobserv
+        port: 9001
+      type: Service

--- a/config/static-console-plugin/static_console_plugin_deployment.yaml
+++ b/config/static-console-plugin/static_console_plugin_deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: static-console-plugin
+  namespace: system
+  labels:
+    app: static-console-plugin
+spec:
+  selector:
+    matchLabels:
+      app: static-console-plugin
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: static-console-plugin
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - command:
+        - /static-plugin
+        env:
+        - name: GODEBUG
+          value: http2server=0
+        image: static-console-plugin
+        name: static-plugin
+        imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /var/serving-cert
+          name: static-console-plugin-tls
+          readOnly: true
+      volumes:
+      - name: static-console-plugin-tls
+        secret:
+          defaultMode: 420
+          secretName: static-console-plugin-tls

--- a/config/static-console-plugin/static_console_plugin_service.yaml
+++ b/config/static-console-plugin/static_console_plugin_service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: static-console-plugin
+  annotations:
+        service.beta.openshift.io/serving-cert-secret-name: static-console-plugin-tls
+  name: static-console-plugin
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: static-console-plugin


### PR DESCRIPTION
Slightly modified from https://github.com/netobserv/network-observability-operator/pull/1346 

To update the bundle, you need to pull https://github.com/openshift/ocp-release-operator-sdk and replace the operator registry depency with the one including `ConsolePlugin` support.

Check https://github.com/operator-framework/operator-lifecycle-manager/pull/3551 & https://github.com/operator-framework/operator-registry/pull/1634