### PR TITLE
NETOBSERV-1929 add resources recommendations to install page

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -918,6 +918,27 @@ spec:
 
     - To enable availability zones awareness, set `spec.processor.addZone` to `true`.
 
+    ## Resource considerations
+
+    The following table outlines examples of resource considerations for clusters with certain workload sizes.
+    The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+    | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+    | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+    | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+    | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+    | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+    | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+    | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+    | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+    | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+    | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+    | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+    *. Tested with AWS M6i instances.
+    **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
+
     ## Further reading
 
     Please refer to the documentation on GitHub for more information.

--- a/catalog/released/bundles.yaml
+++ b/catalog/released/bundles.yaml
@@ -252,6 +252,27 @@ properties:
 
         - Exporters (`spec.exporters`, _experimental_) an optional list of exporters to which to send enriched flows. Currently only KAFKA is supported. This allows you to define any custom storage or processing that can read from Kafka. This feature is flagged as _experimental_ as it has not been thoroughly or stress tested yet, so use at your own risk.
 
+        ## Resource considerations
+
+        The following table outlines examples of resource considerations for clusters with certain workload sizes.
+        The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+        | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+        | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+        | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+        | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+        | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+        | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+        | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+        | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+        | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+        | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+        | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+        *. Tested with AWS M6i instances.
+        **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
+
         ## Further reading
 
         Please refer to the documentation on GitHub for more information.
@@ -571,6 +592,27 @@ properties:
         - Kafka (`spec.deploymentModel: KAFKA` and `spec.kafka`): when enabled, integrates the flow collection pipeline with Kafka, by splitting ingestion from transformation (kube enrichment, derived metrics, ...). Kafka can provide better scalability, resiliency and high availability ([view more details](https://www.redhat.com/en/topics/integration/what-is-apache-kafka)). Assumes Kafka is already deployed and a topic is created.
 
         - Exporters (`spec.exporters`, _experimental_) an optional list of exporters to which to send enriched flows. Currently only KAFKA is supported. This allows you to define any custom storage or processing that can read from Kafka. This feature is flagged as _experimental_ as it has not been thoroughly or stress tested yet, so use at your own risk.
+
+        ## Resource considerations
+
+        The following table outlines examples of resource considerations for clusters with certain workload sizes.
+        The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+        | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+        | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+        | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+        | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+        | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+        | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+        | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+        | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+        | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+        | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+        | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+        *. Tested with AWS M6i instances.
+        **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
 
         ## Further reading
 
@@ -1085,6 +1127,27 @@ properties:
 
         - Exporters (`spec.exporters`, _experimental_) an optional list of exporters to which to send enriched flows. Currently only KAFKA is supported. This allows you to define any custom storage or processing that can read from Kafka. This feature is flagged as _experimental_ as it has not been thoroughly or stress tested yet, so use at your own risk.
 
+        ## Resource considerations
+
+        The following table outlines examples of resource considerations for clusters with certain workload sizes.
+        The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+        | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+        | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+        | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+        | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+        | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+        | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+        | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+        | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+        | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+        | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+        | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+        *. Tested with AWS M6i instances.
+        **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
+
         ## Further reading
 
         Please refer to the documentation on GitHub for more information.
@@ -1596,6 +1659,27 @@ properties:
         - Kafka (`spec.deploymentModel: KAFKA` and `spec.kafka`): when enabled, integrates the flow collection pipeline with Kafka, by splitting ingestion from transformation (kube enrichment, derived metrics, ...). Kafka can provide better scalability, resiliency and high availability ([view more details](https://www.redhat.com/en/topics/integration/what-is-apache-kafka)). Assumes Kafka is already deployed and a topic is created.
 
         - Exporters (`spec.exporters`, _experimental_) an optional list of exporters to which to send enriched flows. Currently only KAFKA is supported. This allows you to define any custom storage or processing that can read from Kafka. This feature is flagged as _experimental_ as it has not been thoroughly or stress tested yet, so use at your own risk.
+
+        ## Resource considerations
+
+        The following table outlines examples of resource considerations for clusters with certain workload sizes.
+        The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+        | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+        | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+        | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+        | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+        | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+        | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+        | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+        | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+        | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+        | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+        | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+        *. Tested with AWS M6i instances.
+        **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
 
         ## Further reading
 
@@ -2124,6 +2208,27 @@ properties:
 
         - Exporters (`spec.exporters`) an optional list of exporters to which to send enriched flows. KAFKA and IPFIX exporters are supported. This allows you to define any custom storage or processing that can read from Kafka or use the IPFIX standard.
 
+        ## Resource considerations
+
+        The following table outlines examples of resource considerations for clusters with certain workload sizes.
+        The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+        | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+        | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+        | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+        | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+        | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+        | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+        | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+        | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+        | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+        | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+        | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+        *. Tested with AWS M6i instances.
+        **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
+
         ## Further reading
 
         Please refer to the documentation on GitHub for more information.
@@ -2651,6 +2756,27 @@ properties:
 
         - Exporters (`spec.exporters`) an optional list of exporters to which to send enriched flows. KAFKA and IPFIX exporters are supported. This allows you to define any custom storage or processing that can read from Kafka or use the IPFIX standard.
 
+        ## Resource considerations
+
+        The following table outlines examples of resource considerations for clusters with certain workload sizes.
+        The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+        | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+        | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+        | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+        | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+        | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+        | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+        | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+        | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+        | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+        | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+        | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+        *. Tested with AWS M6i instances.
+        **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
+
         ## Further reading
 
         Please refer to the documentation on GitHub for more information.
@@ -3177,6 +3303,27 @@ properties:
         - Kafka (`spec.deploymentModel: KAFKA` and `spec.kafka`): when enabled, integrates the flow collection pipeline with Kafka, by splitting ingestion from transformation (kube enrichment, derived metrics, ...). Kafka can provide better scalability, resiliency and high availability ([view more details](https://www.redhat.com/en/topics/integration/what-is-apache-kafka)). Assumes Kafka is already deployed and a topic is created.
 
         - Exporters (`spec.exporters`) an optional list of exporters to which to send enriched flows. KAFKA and IPFIX exporters are supported. This allows you to define any custom storage or processing that can read from Kafka or use the IPFIX standard.
+
+        ## Resource considerations
+
+        The following table outlines examples of resource considerations for clusters with certain workload sizes.
+        The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+        | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+        | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+        | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+        | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+        | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+        | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+        | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+        | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+        | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+        | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+        | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+        *. Tested with AWS M6i instances.
+        **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
 
         ## Further reading
 
@@ -4103,6 +4250,27 @@ properties:
         - Kafka (`spec.deploymentModel: KAFKA` and `spec.kafka`): when enabled, integrates the flow collection pipeline with Kafka, by splitting ingestion from transformation (kube enrichment, derived metrics, ...). Kafka can provide better scalability, resiliency and high availability ([view more details](https://www.redhat.com/en/topics/integration/what-is-apache-kafka)). Assumes Kafka is already deployed and a topic is created.
 
         - Exporters (`spec.exporters`) an optional list of exporters to which to send enriched flows. KAFKA and IPFIX exporters are supported. This allows you to define any custom storage or processing that can read from Kafka or use the IPFIX standard.
+
+        ## Resource considerations
+
+        The following table outlines examples of resource considerations for clusters with certain workload sizes.
+        The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+        | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+        | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+        | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+        | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+        | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+        | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+        | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+        | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+        | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+        | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+        | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+        *. Tested with AWS M6i instances.
+        **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
 
         ## Further reading
 
@@ -5091,6 +5259,27 @@ properties:
         - Exporters (`spec.exporters`) an optional list of exporters to which to send enriched flows. KAFKA and IPFIX exporters are supported. This allows you to define any custom storage or processing that can read from Kafka or use the IPFIX standard.
 
         - To enable availability zones awareness, set `spec.processor.addZone` to `true`.
+
+        ## Resource considerations
+
+        The following table outlines examples of resource considerations for clusters with certain workload sizes.
+        The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+        | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+        | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+        | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+        | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+        | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+        | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+        | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+        | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+        | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+        | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+        | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+        *. Tested with AWS M6i instances.
+        **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
 
         ## Further reading
 
@@ -6084,6 +6273,27 @@ properties:
 
         - To enable availability zones awareness, set `spec.processor.addZone` to `true`.
 
+        ## Resource considerations
+
+        The following table outlines examples of resource considerations for clusters with certain workload sizes.
+        The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+        | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+        | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+        | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+        | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+        | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+        | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+        | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+        | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+        | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+        | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+        | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+        *. Tested with AWS M6i instances.
+        **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
+
         ## Further reading
 
         Please refer to the documentation on GitHub for more information.
@@ -7075,6 +7285,27 @@ properties:
         - Exporters (`spec.exporters`) an optional list of exporters to which to send enriched flows. KAFKA and IPFIX exporters are supported. This allows you to define any custom storage or processing that can read from Kafka or use the IPFIX standard.
 
         - To enable availability zones awareness, set `spec.processor.addZone` to `true`.
+
+        ## Resource considerations
+
+        The following table outlines examples of resource considerations for clusters with certain workload sizes.
+        The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+        | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+        | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+        | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+        | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+        | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+        | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+        | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+        | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+        | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+        | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+        | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+        *. Tested with AWS M6i instances.
+        **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
 
         ## Further reading
 
@@ -8079,6 +8310,27 @@ properties:
 
         - To enable availability zones awareness, set `spec.processor.addZone` to `true`.
 
+        ## Resource considerations
+
+        The following table outlines examples of resource considerations for clusters with certain workload sizes.
+        The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+        | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+        | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+        | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+        | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+        | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+        | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+        | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+        | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+        | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+        | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+        | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+        *. Tested with AWS M6i instances.
+        **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
+
         ## Further reading
 
         Please refer to the documentation on GitHub for more information.
@@ -9080,6 +9332,27 @@ properties:
         - Exporters (`spec.exporters`) an optional list of exporters to which to send enriched flows. KAFKA and IPFIX exporters are supported. This allows you to define any custom storage or processing that can read from Kafka or use the IPFIX standard.
 
         - To enable availability zones awareness, set `spec.processor.addZone` to `true`.
+
+        ## Resource considerations
+
+        The following table outlines examples of resource considerations for clusters with certain workload sizes.
+        The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+        | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+        | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+        | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+        | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+        | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+        | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+        | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+        | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+        | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+        | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+        | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+        *. Tested with AWS M6i instances.
+        **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
 
         ## Further reading
 

--- a/catalog/unreleased/downstream-test-fbc/bundle.yaml
+++ b/catalog/unreleased/downstream-test-fbc/bundle.yaml
@@ -946,6 +946,27 @@ properties:
 
       - To enable availability zones awareness, set `spec.processor.addZone` to `true`.
 
+      ## Resource considerations
+
+      The following table outlines examples of resource considerations for clusters with certain workload sizes.
+      The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+      | Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+      | ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+      | *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+      | *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+      | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+      | *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+      | *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+      | *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+      | *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+      | *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+      | *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+      *. Tested with AWS M6i instances.
+      **. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
+
       ## Further reading
 
       Please refer to the documentation on GitHub for more information.

--- a/config/descriptions/ocp.md
+++ b/config/descriptions/ocp.md
@@ -62,6 +62,27 @@ A couple of settings deserve special attention:
 
 - To enable availability zones awareness, set `spec.processor.addZone` to `true`.
 
+## Resource considerations
+
+The following table outlines examples of resource considerations for clusters with certain workload sizes.
+The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+| Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+| ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+| *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+| *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+| *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+| *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+| *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+| *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+| *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+| *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+| *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+*. Tested with AWS M6i instances.
+**. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
+
 ## Further reading
 
 Please refer to the documentation on GitHub for more information.

--- a/config/descriptions/upstream.md
+++ b/config/descriptions/upstream.md
@@ -66,6 +66,27 @@ A couple of settings deserve special attention:
 
 - To enable availability zones awareness, set `spec.processor.addZone` to `true`.
 
+## Resource considerations
+
+The following table outlines examples of resource considerations for clusters with certain workload sizes.
+The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+
+| Resource recommendations                        | Extra small (10 nodes) | Small (25 nodes)       | Medium (65 nodes) **    | Large (120 nodes) **          |
+| ----------------------------------------------- | ---------------------- | ---------------------- | ----------------------- | ----------------------------- |
+| *Worker Node vCPU and memory*                   | 4 vCPUs\| 16GiB mem *  | 16 vCPUs\| 64GiB mem * | 16 vCPUs\| 64GiB mem  * |16 vCPUs\| 64GiB Mem *         |
+| *LokiStack size*                                | `1x.extra-small`       | `1x.small`             | `1x.small`              | `1x.medium`                   |
+| *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)        | 400Mi (default)         | 800Mi                         |
+| *eBPF sampling rate*                            | 50 (default)           | 50 (default)           | 50 (default)            | 50 (default)                  |
+| *eBPF memory limit*                             | 800Mi (default)        | 800Mi (default)        | 2000Mi                  | 800Mi (default)               |
+| *FLP memory limit*                              | 800Mi (default)        | 800Mi (default)        | 800Mi (default)         | 800Mi (default)               |
+| *FLP Kafka partitions*                          | N/A                    | 48                     | 48                      | 48                            |
+| *Kafka consumer replicas*                       | N/A                    | 24                     | 24                      | 24                            |
+| *Kafka brokers*                                 | N/A                    | 3 (default)            | 3 (default)             | 3 (default)                   |
+
+*. Tested with AWS M6i instances.
+**. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
+
 ## Further reading
 
 Please refer to the documentation on GitHub for more information.


### PR DESCRIPTION
## Description

Table taken from https://github.com/skrthomas/openshift-docs/blob/main/modules/network-observability-resources-table.adoc?plain=1 and converted to markdown.

![image](https://github.com/user-attachments/assets/ec94c4c0-696f-434f-8c43-82b39f19fff7)
![image](https://github.com/user-attachments/assets/f0887b69-4613-4b8d-8608-253949f0aca2)


## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [X] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
