### PR TITLE
Add operator to "Observability" category in OperatorHub

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -432,7 +432,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    categories: Monitoring, Networking
+    categories: Monitoring, Networking, Observability
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: quay.io/netobserv/network-observability-operator:1.8.2-community
     createdAt: ':created-at:'

--- a/catalog/released/bundles.yaml
+++ b/catalog/released/bundles.yaml
@@ -8867,7 +8867,7 @@ properties:
             }
           ]
         capabilities: Seamless Upgrades
-        categories: Monitoring, Networking
+        categories: Monitoring, Networking, Observability
         console.openshift.io/plugins: '["netobserv-plugin"]'
         containerImage: ""
         createdAt: 2024-11-15T09:48:09

--- a/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
-    categories: Monitoring, Networking
+    categories: Monitoring, Networking, Observability
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: ':container-image:'
     createdAt: ':created-at:'


### PR DESCRIPTION
Add Network Observability to the "Observability" category.  The "Observability" category has been added to the set of defaults in [https://github.com/operator-framework/api/blob/master/pkg/validation/internal/standardcategories.go#L31](https://github.com/operator-framework/api/blob/master/pkg/validation/internal/standardcategories.go#L31)

For bundles.yaml, it is only done for 1.8.0.

Fixes [OCPSTRAT-954](https://issues.redhat.com/browse/OCPSTRAT-954) and [NETOBSERV-1340](https://issues.redhat.com/browse/NETOBSERV-1340)