### PR TITLE
NETOBSERV-2227: plugin feature "multiNetworks", and promote NetworkName columns

### DIFF
--- a/bundle/manifests/netobserv-informers_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/netobserv-informers_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -22,3 +22,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - k8s.ovn.org
+  resources:
+  - clusteruserdefinednetworks
+  - userdefinednetworks
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -1110,6 +1110,15 @@ spec:
           - patch
           - update
         - apiGroups:
+          - k8s.ovn.org
+          resources:
+          - clusteruserdefinednetworks
+          - userdefinednetworks
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - loki.grafana.com
           resources:
           - lokistacks

--- a/config/rbac/component_roles.yaml
+++ b/config/rbac/component_roles.yaml
@@ -78,6 +78,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - k8s.ovn.org
+  resources:
+  - clusteruserdefinednetworks
+  - userdefinednetworks
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -156,6 +156,15 @@ rules:
   - patch
   - update
 - apiGroups:
+  - k8s.ovn.org
+  resources:
+  - clusteruserdefinednetworks
+  - userdefinednetworks
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - loki.grafana.com
   resources:
   - lokistacks

--- a/controllers/consoleplugin/config/config.go
+++ b/controllers/consoleplugin/config/config.go
@@ -105,7 +105,6 @@ type FieldConfig struct {
 	Type        string `yaml:"type" json:"type"`
 	Description string `yaml:"description" json:"description"`
 	LokiLabel   bool   `yaml:"lokiLabel,omitempty" json:"lokiLabel,omitempty"`
-	Filter      string `yaml:"filter,omitempty" json:"filter,omitempty"`
 }
 
 type FrontendConfig struct {

--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -485,7 +485,6 @@ columns:
     fields:
       - Packets
       - PktDropPackets
-    filter: pkt_drop_cause
     default: true
     width: 5
   - id: FlowDuration
@@ -525,6 +524,7 @@ columns:
     name: Drop State
     tooltip: TCP state on last dropped packet.
     field: PktDropLatestState
+    filter: pkt_drop_state
     default: false
     width: 10
     feature: pktDrop
@@ -532,6 +532,7 @@ columns:
     name: Drop Cause
     tooltip: TCP state on last dropped packet.
     field: PktDropLatestDropCause
+    filter: pkt_drop_cause
     default: false
     width: 10
     feature: pktDrop
@@ -1379,11 +1380,9 @@ fields:
   - name: PktDropLatestState
     type: string
     description: TCP state on last dropped packet
-    filter: pkt_drop_state # couldn't guess from config
   - name: PktDropLatestDropCause
     type: string
     description: Latest drop cause
-    filter: pkt_drop_cause # couldn't guess from config
   - name: PktDropLatestFlags
     type: number
     description: TCP flags on last dropped packet

--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -175,8 +175,9 @@ columns:
     tooltip: Network name, such as Secondary network or UDN.
     field: SrcK8S_NetworkName
     filter: src_network
-    default: false
+    default: true
     width: 15
+    feature: multiNetworks
   - id: DstK8S_Name
     group: Destination
     name: Name
@@ -315,8 +316,9 @@ columns:
     tooltip: Network name, such as Secondary network or UDN.
     field: DstK8S_NetworkName
     filter: dst_network
-    default: false
+    default: true
     width: 15
+    feature: multiNetworks
   - id: K8S_Name
     name: Names
     calculated: '[SrcK8S_Name,DstK8S_Name]'
@@ -458,7 +460,7 @@ columns:
     tooltip: The list of User Defined Networks.
     field: Udns
     filter: udns
-    default: true
+    default: false
     width: 15
     feature: udnMapping
   - id: FlowDirInts
@@ -1094,7 +1096,7 @@ scopes:
     labels:
       - SrcK8S_NetworkName
       - DstK8S_NetworkName
-    feature: udnMapping
+    feature: multiNetworks
     filters:
       - src_network
       - dst_network

--- a/controllers/consoleplugin/consoleplugin_objects.go
+++ b/controllers/consoleplugin/consoleplugin_objects.go
@@ -455,6 +455,10 @@ func (b *builder) setFrontendConfig(fconf *cfg.FrontendConfig) error {
 		fconf.Features = append(fconf.Features, "udnMapping")
 	}
 
+	if helper.IsUDNMappingEnabled(&b.desired.Agent.EBPF) || helper.HasSecondaryIndexes(&b.desired.Processor) {
+		fconf.Features = append(fconf.Features, "multiNetworks")
+	}
+
 	if helper.IsIPSecEnabled(&b.desired.Agent.EBPF) {
 		fconf.Features = append(fconf.Features, "ipsec")
 	}

--- a/helm/templates/clusterrole.yaml
+++ b/helm/templates/clusterrole.yaml
@@ -155,6 +155,15 @@ rules:
       - patch
       - update
   - apiGroups:
+      - k8s.ovn.org
+    resources:
+      - clusteruserdefinednetworks
+      - userdefinednetworks
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - loki.grafana.com
     resources:
       - lokistacks

--- a/pkg/helper/flowcollector.go
+++ b/pkg/helper/flowcollector.go
@@ -166,6 +166,10 @@ func IsEBPFFlowFilterEnabled(spec *flowslatest.FlowCollectorEBPF) bool {
 	return spec.FlowFilter != nil && spec.FlowFilter.Enable != nil && *spec.FlowFilter.Enable
 }
 
+func HasSecondaryIndexes(spec *flowslatest.FlowCollectorFLP) bool {
+	return spec.Advanced != nil && len(spec.Advanced.SecondaryNetworks) > 0
+}
+
 func GetEBPFMetricsPort(spec *flowslatest.FlowCollectorEBPF) int32 {
 	port := int32(constants.EBPFMetricPort)
 	if spec.Metrics.Server.Port != nil {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -41,6 +41,7 @@ import (
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions/status,verbs=update;patch
 //+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=create;delete;patch;update;get;watch;list
+//+kubebuilder:rbac:groups=k8s.ovn.org,resources=userdefinednetworks;clusteruserdefinednetworks,verbs=get;list;watch
 
 type Registerer func(context.Context, *Manager) error
 


### PR DESCRIPTION
## Description

- multiNetworks feature is enabled if UDN or secondary indexes are enabled
- By default, don't show UDN labels, but show NetworkName columns instead


<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
Console plugin: https://github.com/netobserv/network-observability-console-plugin/pull/846

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
