### PR TITLE
NETOBSERV-2240: do not fail in case of error while discovering APIs

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -80,7 +80,7 @@ func NewManager(
 	if err != nil {
 		return nil, fmt.Errorf("can't instantiate discovery client: %w", err)
 	}
-	info, err := cluster.NewInfo(dc)
+	info, err := cluster.NewInfo(ctx, dc)
 	if err != nil {
 		return nil, fmt.Errorf("can't collect cluster info: %w", err)
 	}


### PR DESCRIPTION
## Description

- Get as much data as possible from discovery, without failing
- Report error if the errors are related to one of the API that we want to check; ignore others.

Also addresses #1473

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
