### PR TITLE
NETOBSERV-2222: single column ipsec status

### DIFF
--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -1072,6 +1072,7 @@ filters:
     name: IPSec Status
     component: text
     placeholder: 'E.g: success, error'
+    hint: Status of the IPSec encryption (on egress, provided by the kernel function xfrm_output) or decryption (on ingress, via xfrm_input).
 scopes:
   - id: cluster
     name: Cluster

--- a/controllers/consoleplugin/config/static-frontend-config.yaml
+++ b/controllers/consoleplugin/config/static-frontend-config.yaml
@@ -660,17 +660,11 @@ columns:
     default: false
     width: 15
     feature: packetTranslation
-  - id: IPSec
-    name: Is IPSec operation successful?
-    field: IPSecSuccess
-    filter: ipsec_success
-    default: true
-    width: 10
-    feature: ipsec
-  - id: IPSecCode
-    name: IPSec Return Code
-    field: IPSecRetCode
-    filter: ipsec_retcode
+  - id: IPSecStatus
+    name: IPSec Status
+    tooltip: Status of the IPSec encryption (on egress, provided by the kernel function xfrm_output) or decryption (on ingress, via xfrm_input).
+    field: IPSecStatus
+    filter: ipsec_status
     default: true
     width: 10
     feature: ipsec
@@ -1074,12 +1068,10 @@ filters:
     component: autocomplete
     category: destination
     hint: Specify a single port number or name.
-  - id: ipsec_success
-    name: IPSec processing succeeded ?
-    component: number
-  - id: ipsec_retcode
-    name: IPSec processing return code
-    component: number
+  - id: ipsec_status
+    name: IPSec Status
+    component: text
+    placeholder: 'E.g: success, error'
 scopes:
   - id: cluster
     name: Cluster
@@ -1433,12 +1425,9 @@ fields:
   - name: K8S_ClusterName
     type: string
     description: Cluster name or identifier
-  - name: IPSecRetCode
-    type: number
-    description: IPSec operation return code
-  - name: IPSecSuccess
-    type: boolean
-    description: IPSec processing succeeded
+  - name: IPSecStatus
+    type: string
+    description: Status of the IPSec encryption (on egress, given by the kernel xfrm_output function) or decryption (on ingress, via xfrm_input)
   - name: _RecordType
     type: string
     description: "Type of record: `flowLog` for regular flow logs, or `newConnection`, `heartbeat`, `endConnection` for conversation tracking"


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
agent: https://github.com/netobserv/netobserv-ebpf-agent/pull/708
flp: https://github.com/netobserv/flowlogs-pipeline/pull/976

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
