### PR TITLE
NETOBSERV-2286: automatic metric naming after resource name

### DIFF
--- a/api/flowmetrics/v1alpha1/flowmetric_types.go
+++ b/api/flowmetrics/v1alpha1/flowmetric_types.go
@@ -61,7 +61,7 @@ type MetricFilter struct {
 // To check the cardinality of all NetObserv metrics, run as `promql`: `count({__name__=~"netobserv.*"}) by (__name__)`.
 type FlowMetricSpec struct {
 	// Name of the metric. In Prometheus, it is automatically prefixed with "netobserv_".
-	// +required
+	// +optional
 	MetricName string `json:"metricName"`
 
 	// Metric type: "Counter", "Histogram" or "Gauge".
@@ -193,13 +193,16 @@ type Query struct {
 type FlowMetricStatus struct {
 	// `conditions` represent the latest available observations of an object's state
 	Conditions []metav1.Condition `json:"conditions"`
+	// Metric name, including prefix, as it appears in Prometheus
+	// +optional
+	PrometheusName string `json:"prometheusName"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Metric Name",type="string",JSONPath=`.spec.metricName`
+// +kubebuilder:printcolumn:name="Metric Name",type="string",JSONPath=`.status.prometheusName`
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
-// +kubebuilder:printcolumn:name="Cardinality",type="string",JSONPath=`.status.conditions[?(@.type=="CardinalityOK")].reason`
+// +kubebuilder:printcolumn:name="Cardinality",type="string",JSONPath=`.status.conditions[?(@.type=="CardinalityWarning")].reason`
 // FlowMetric is the API allowing to create custom metrics from the collected flow logs.
 type FlowMetric struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/bundle/manifests/flows.netobserv.io_flowmetrics.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowmetrics.yaml
@@ -25,13 +25,13 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.metricName
+    - jsonPath: .status.prometheusName
       name: Metric Name
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].reason
       name: Status
       type: string
-    - jsonPath: .status.conditions[?(@.type=="CardinalityOK")].reason
+    - jsonPath: .status.conditions[?(@.type=="CardinalityWarning")].reason
       name: Cardinality
       type: string
     name: v1alpha1
@@ -241,7 +241,6 @@ spec:
                   Refer to the documentation for the list of available fields: https://docs.openshift.com/container-platform/latest/observability/network_observability/json-flows-format-reference.html.
                 type: string
             required:
-            - metricName
             - type
             type: object
           status:
@@ -305,6 +304,9 @@ spec:
                   - type
                   type: object
                 type: array
+              prometheusName:
+                description: Metric name, including prefix, as it appears in Prometheus
+                type: string
             required:
             - conditions
             type: object

--- a/config/crd/bases/flows.netobserv.io_flowmetrics.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowmetrics.yaml
@@ -15,13 +15,13 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.metricName
+    - jsonPath: .status.prometheusName
       name: Metric Name
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].reason
       name: Status
       type: string
-    - jsonPath: .status.conditions[?(@.type=="CardinalityOK")].reason
+    - jsonPath: .status.conditions[?(@.type=="CardinalityWarning")].reason
       name: Cardinality
       type: string
     name: v1alpha1
@@ -231,7 +231,6 @@ spec:
                   Refer to the documentation for the list of available fields: https://docs.openshift.com/container-platform/latest/observability/network_observability/json-flows-format-reference.html.
                 type: string
             required:
-            - metricName
             - type
             type: object
           status:
@@ -295,6 +294,9 @@ spec:
                   - type
                   type: object
                 type: array
+              prometheusName:
+                description: Metric name, including prefix, as it appears in Prometheus
+                type: string
             required:
             - conditions
             type: object

--- a/docs/FlowMetric.md
+++ b/docs/FlowMetric.md
@@ -92,13 +92,6 @@ To check the cardinality of all NetObserv metrics, run as `promql`: `count({__na
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>metricName</b></td>
-        <td>string</td>
-        <td>
-          Name of the metric. In Prometheus, it is automatically prefixed with "netobserv_".<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
         <td>
@@ -169,6 +162,13 @@ It must be done carefully as it impacts the metric cardinality (cf https://rhobs
 In general, avoid setting very high cardinality labels such as IP or MAC addresses.
 "SrcK8S_OwnerName" or "DstK8S_OwnerName" should be preferred over "SrcK8S_Name" or "DstK8S_Name" as much as possible.
 Refer to the documentation for the list of available fields: https://docs.openshift.com/container-platform/latest/observability/network_observability/json-flows-format-reference.html.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>metricName</b></td>
+        <td>string</td>
+        <td>
+          Name of the metric. In Prometheus, it is automatically prefixed with "netobserv_".<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -377,6 +377,13 @@ FlowMetricStatus defines the observed state of FlowMetric
           `conditions` represent the latest available observations of an object's state<br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b>prometheusName</b></td>
+        <td>string</td>
+        <td>
+          Metric name, including prefix, as it appears in Prometheus<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/helm/crds/flows.netobserv.io_flowmetrics.yaml
+++ b/helm/crds/flows.netobserv.io_flowmetrics.yaml
@@ -15,13 +15,13 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .spec.metricName
+        - jsonPath: .status.prometheusName
           name: Metric Name
           type: string
         - jsonPath: .status.conditions[?(@.type=="Ready")].reason
           name: Status
           type: string
-        - jsonPath: .status.conditions[?(@.type=="CardinalityOK")].reason
+        - jsonPath: .status.conditions[?(@.type=="CardinalityWarning")].reason
           name: Cardinality
           type: string
       name: v1alpha1
@@ -216,7 +216,6 @@ spec:
                     Refer to the documentation for the list of available fields: https://docs.openshift.com/container-platform/latest/observability/network_observability/json-flows-format-reference.html.
                   type: string
               required:
-                - metricName
                 - type
               type: object
             status:
@@ -278,6 +277,9 @@ spec:
                       - type
                     type: object
                   type: array
+                prometheusName:
+                  description: Metric name, including prefix, as it appears in Prometheus
+                  type: string
               required:
                 - conditions
               type: object

--- a/internal/controller/flp/flp_test.go
+++ b/internal/controller/flp/flp_test.go
@@ -168,9 +168,13 @@ func getAutoScalerSpecs() (ascv2.HorizontalPodAutoscaler, flowslatest.FlowCollec
 }
 
 func monoBuilder(ns string, cfg *flowslatest.FlowCollectorSpec) monolithBuilder {
+	return monoBuilderWithMetrics(ns, cfg, &metricslatest.FlowMetricList{})
+}
+
+func monoBuilderWithMetrics(ns string, cfg *flowslatest.FlowCollectorSpec, metrics *metricslatest.FlowMetricList) monolithBuilder {
 	loki := helper.NewLokiConfig(&cfg.Loki, "any")
 	info := reconcilers.Common{Namespace: ns, Loki: &loki, ClusterInfo: &cluster.Info{}}
-	b, _ := newMonolithBuilder(info.NewInstance(image, status.Instance{}), cfg, &metricslatest.FlowMetricList{}, nil)
+	b, _ := newMonolithBuilder(info.NewInstance(image, status.Instance{}), cfg, metrics, nil)
 	return b
 }
 

--- a/internal/pkg/helper/helpers.go
+++ b/internal/pkg/helper/helpers.go
@@ -3,6 +3,7 @@
 package helper
 
 import (
+	"regexp"
 	"sort"
 	"strings"
 
@@ -130,4 +131,10 @@ func FindFields(labels []string, isNumber bool) bool {
 
 func NamespacedName(obj client.Object) types.NamespacedName {
 	return types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+}
+
+var promInvalidChars = regexp.MustCompile(`[^a-zA-Z0-9:_]`)
+
+func PrometheusMetricName(from string) string {
+	return promInvalidChars.ReplaceAllString(from, "_")
 }

--- a/internal/pkg/helper/helpers_test.go
+++ b/internal/pkg/helper/helpers_test.go
@@ -154,5 +154,9 @@ func TestCRDDefault(t *testing.T) {
 	assert.Equal(t, false, IsDefaultValue([]string{"spec", "processor", "debug"}, "lokiMaxRetries", "12"))
 	// lokiStaticLabels
 	assert.Equal(t, "app: netobserv-flowcollector\n", GetFieldDefaultString([]string{"spec", "processor", "debug"}, "lokiStaticLabels"))
+}
 
+func TestPrometheusMetricName(t *testing.T) {
+	name := PrometheusMetricName("a-metric-name:unit")
+	assert.Equal(t, "a_metric_name:unit", name)
 }


### PR DESCRIPTION
## Description

Also, improve printColumn to show the final metric name in prometheus
Add a test

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
