### PR TITLE
NETOBSERV-2290: fix using tc hook for ocp4.14

### DIFF
--- a/internal/controller/ebpf/agent_controller.go
+++ b/internal/controller/ebpf/agent_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/netobserv/network-observability-operator/internal/controller/constants"
 	"github.com/netobserv/network-observability-operator/internal/controller/ebpf/internal/permissions"
 	"github.com/netobserv/network-observability-operator/internal/controller/reconcilers"
+	"github.com/netobserv/network-observability-operator/internal/pkg/cluster"
 	"github.com/netobserv/network-observability-operator/internal/pkg/helper"
 	"github.com/netobserv/network-observability-operator/internal/pkg/volumes"
 	"github.com/netobserv/network-observability-operator/internal/pkg/watchers"
@@ -71,6 +72,7 @@ const (
 	envEnableIPsec                = "ENABLE_IPSEC_TRACKING"
 	envDNSTrackingPort            = "DNS_TRACKING_PORT"
 	envPreferredInterface         = "PREFERRED_INTERFACE_FOR_MAC_PREFIX"
+	envAttachMode                 = "TC_ATTACH_MODE"
 	envListSeparator              = ","
 )
 
@@ -91,6 +93,7 @@ const (
 	ovsHostMountPath            = "/var/run/openvswitch"
 	ovsMountName                = "var-run-ovs"
 	defaultNetworkEventsGroupID = "10"
+	defaultPreferredInterface   = "0a:58=eth0" // Hard-coded default config to deal with OVN-generated MACs
 )
 
 const (
@@ -403,7 +406,7 @@ func (c *AgentController) desired(ctx context.Context, coll *flowslatest.FlowCol
 }
 
 func (c *AgentController) envConfig(ctx context.Context, coll *flowslatest.FlowCollector, annots map[string]string) ([]corev1.EnvVar, error) {
-	config := c.getEnvConfig(coll)
+	config := getEnvConfig(coll, c.ClusterInfo)
 
 	if helper.UseKafka(&coll.Spec) {
 		config = append(config,
@@ -473,19 +476,6 @@ func (c *AgentController) envConfig(ctx context.Context, coll *flowslatest.FlowC
 			Name:  envFlowsTargetPort,
 			Value: strconv.Itoa(int(*advancedConfig.Port)),
 		})
-	}
-
-	if helper.IsEBPFFlowFilterEnabled(&coll.Spec.Agent.EBPF) {
-		config = append(config, corev1.EnvVar{Name: envEnableFlowFilter, Value: "true"})
-		if len(coll.Spec.Agent.EBPF.FlowFilter.Rules) != 0 {
-			if filterRules := c.configureFlowFiltersRules(coll.Spec.Agent.EBPF.FlowFilter.Rules); filterRules != nil {
-				config = append(config, filterRules...)
-			}
-		} else {
-			if filter := c.configureFlowFilter(coll.Spec.Agent.EBPF.FlowFilter); filter != nil {
-				config = append(config, filter...)
-			}
-		}
 	}
 
 	return config, nil
@@ -581,7 +571,7 @@ func processPorts(ports intstr.IntOrString, single *int32, list *string, rangeFi
 	}
 }
 
-func (c *AgentController) configureFlowFiltersRules(rules []flowslatest.EBPFFlowFilterRule) []corev1.EnvVar {
+func configureFlowFiltersRules(rules []flowslatest.EBPFFlowFilterRule) []corev1.EnvVar {
 	filters := make([]ebpfconfig.FlowFilter, 0)
 	for i := range rules {
 		filters = append(filters, mapFlowFilterRuleToFilter(&rules[i]))
@@ -595,7 +585,7 @@ func (c *AgentController) configureFlowFiltersRules(rules []flowslatest.EBPFFlow
 	return []corev1.EnvVar{{Name: envFilterRules, Value: string(jsonData)}}
 }
 
-func (c *AgentController) configureFlowFilter(filter *flowslatest.EBPFFlowFilter) []corev1.EnvVar {
+func configureFlowFilter(filter *flowslatest.EBPFFlowFilter) []corev1.EnvVar {
 	f := mapFlowFilterToFilter(filter)
 	jsonData, err := json.Marshal([]ebpfconfig.FlowFilter{f})
 	if err != nil {
@@ -620,11 +610,8 @@ func (c *AgentController) securityContext(coll *flowslatest.FlowCollector) *core
 }
 
 // nolint:golint,cyclop
-func (c *AgentController) getEnvConfig(coll *flowslatest.FlowCollector) []corev1.EnvVar {
+func getEnvConfig(coll *flowslatest.FlowCollector, cinfo *cluster.Info) []corev1.EnvVar {
 	var config []corev1.EnvVar
-
-	// Hard-coded config to deal with OVN unrecognized MAC
-	config = append(config, corev1.EnvVar{Name: envPreferredInterface, Value: "0a:58=eth0"})
 
 	if coll.Spec.Agent.EBPF.CacheActiveTimeout != "" {
 		config = append(config, corev1.EnvVar{
@@ -750,25 +737,19 @@ func (c *AgentController) getEnvConfig(coll *flowslatest.FlowCollector) []corev1
 		})
 	}
 
-	dnsTrackingPort := defaultDNSTrackingPort
-	networkEventsGroupID := defaultNetworkEventsGroupID
-	// we need to sort env map to keep idempotency,
-	// as equal maps could be iterated in different order
-	advancedConfig := helper.GetAdvancedAgentConfig(coll.Spec.Agent.EBPF.Advanced)
-	for _, pair := range helper.KeySorted(advancedConfig.Env) {
-		k, v := pair[0], pair[1]
-		switch k {
-		case envDNSTrackingPort:
-			dnsTrackingPort = v
-		case envNetworkEventsGroupID:
-			networkEventsGroupID = v
-		default:
-			config = append(config, corev1.EnvVar{Name: k, Value: v})
+	if helper.IsEBPFFlowFilterEnabled(&coll.Spec.Agent.EBPF) {
+		config = append(config, corev1.EnvVar{Name: envEnableFlowFilter, Value: "true"})
+		if len(coll.Spec.Agent.EBPF.FlowFilter.Rules) != 0 {
+			if filterRules := configureFlowFiltersRules(coll.Spec.Agent.EBPF.FlowFilter.Rules); filterRules != nil {
+				config = append(config, filterRules...)
+			}
+		} else {
+			if filter := configureFlowFilter(coll.Spec.Agent.EBPF.FlowFilter); filter != nil {
+				config = append(config, filter...)
+			}
 		}
 	}
 
-	config = append(config, corev1.EnvVar{Name: envDNSTrackingPort, Value: dnsTrackingPort})
-	config = append(config, corev1.EnvVar{Name: envNetworkEventsGroupID, Value: networkEventsGroupID})
 	config = append(config, corev1.EnvVar{
 		Name: envAgentIP,
 		ValueFrom: &corev1.EnvVarSource{
@@ -778,6 +759,22 @@ func (c *AgentController) getEnvConfig(coll *flowslatest.FlowCollector) []corev1
 			},
 		},
 	})
+
+	defaultAttach := "tcx"
+	if old, _ := cinfo.IsOpenShiftVersionLessThan("4.15.0"); old {
+		defaultAttach = "tc"
+	}
+
+	// Other default config that can be overriden by env
+	defaults := map[string]string{
+		envDNSTrackingPort:      defaultDNSTrackingPort,
+		envNetworkEventsGroupID: defaultNetworkEventsGroupID,
+		envPreferredInterface:   defaultPreferredInterface,
+		envAttachMode:           defaultAttach,
+	}
+	advancedConfig := helper.GetAdvancedAgentConfig(coll.Spec.Agent.EBPF.Advanced)
+	moreConfig := helper.BuildEnvFromDefaults(advancedConfig.Env, defaults)
+	config = append(config, moreConfig...)
 
 	return config
 }

--- a/internal/controller/ebpf/agent_controller_test.go
+++ b/internal/controller/ebpf/agent_controller_test.go
@@ -3,11 +3,14 @@ package ebpf
 import (
 	"testing"
 
+	flowslatest "github.com/netobserv/network-observability-operator/api/flowcollector/v1beta2"
+	"github.com/netobserv/network-observability-operator/internal/pkg/cluster"
 	"github.com/netobserv/network-observability-operator/internal/pkg/helper"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func sampleDS() appsv1.DaemonSet {
@@ -39,7 +42,7 @@ func sampleDS() appsv1.DaemonSet {
 	}
 }
 
-func DaemonSetChanged(t *testing.T) {
+func TestDaemonSetChanged(t *testing.T) {
 	assert := assert.New(t)
 
 	action := helper.DaemonSetChanged(nil, nil)
@@ -79,4 +82,113 @@ func DaemonSetChanged(t *testing.T) {
 	desired.Spec.Template.Spec.Containers[0].Env[0] = corev1.EnvVar{}
 	action = helper.DaemonSetChanged(&current, &desired)
 	assert.Equal(helper.ActionUpdate, int(action))
+}
+
+func TestGetEnvConfig_Default(t *testing.T) {
+	fc := flowslatest.FlowCollector{
+		Spec: flowslatest.FlowCollectorSpec{
+			Agent: flowslatest.FlowCollectorAgent{
+				EBPF: flowslatest.FlowCollectorEBPF{},
+			},
+		},
+	}
+
+	env := getEnvConfig(&fc, &cluster.Info{})
+	assert.Equal(t, []corev1.EnvVar{
+		{Name: "GOMEMLIMIT", Value: "0"},
+		{Name: "METRICS_ENABLE", Value: "true"},
+		{Name: "METRICS_SERVER_PORT", Value: "9400"},
+		{Name: "METRICS_PREFIX", Value: "netobserv_agent_"},
+		{Name: "AGENT_IP", Value: "",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "status.hostIP",
+				},
+			}},
+		{Name: "DNS_TRACKING_PORT", Value: "53"},
+		{Name: "NETWORK_EVENTS_MONITORING_GROUP_ID", Value: "10"},
+		{Name: "PREFERRED_INTERFACE_FOR_MAC_PREFIX", Value: "0a:58=eth0"},
+		{Name: "TC_ATTACH_MODE", Value: "tcx"},
+	}, env)
+}
+
+func TestGetEnvConfig_WithOverrides(t *testing.T) {
+	fc := flowslatest.FlowCollector{
+		Spec: flowslatest.FlowCollectorSpec{
+			Agent: flowslatest.FlowCollectorAgent{
+				EBPF: flowslatest.FlowCollectorEBPF{
+					Advanced: &flowslatest.AdvancedAgentConfig{
+						Env: map[string]string{
+							"PREFERRED_INTERFACE_FOR_MAC_PREFIX": "0a:58=ens5",
+							"DNS_TRACKING_PORT":                  "5353",
+							"NETWORK_EVENTS_MONITORING_GROUP_ID": "any",
+							"TC_ATTACH_MODE":                     "any",
+						},
+					},
+					Metrics: flowslatest.EBPFMetrics{
+						Enable: ptr.To(false),
+					},
+					FlowFilter: &flowslatest.EBPFFlowFilter{
+						Enable: ptr.To(true),
+						Rules: []flowslatest.EBPFFlowFilterRule{
+							{
+								CIDR:   "0.0.0.0/0",
+								Action: "Accept",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	env := getEnvConfig(&fc, &cluster.Info{})
+	assert.Equal(t, []corev1.EnvVar{
+		{Name: "GOMEMLIMIT", Value: "0"},
+		{Name: "ENABLE_FLOW_FILTER", Value: "true"},
+		{Name: "FLOW_FILTER_RULES", Value: `[{"ip_cidr":"0.0.0.0/0","action":"Accept"}]`},
+		{Name: "AGENT_IP", Value: "",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "status.hostIP",
+				},
+			}},
+		{Name: "DNS_TRACKING_PORT", Value: "5353"},
+		{Name: "NETWORK_EVENTS_MONITORING_GROUP_ID", Value: "any"},
+		{Name: "PREFERRED_INTERFACE_FOR_MAC_PREFIX", Value: "0a:58=ens5"},
+		{Name: "TC_ATTACH_MODE", Value: "any"},
+	}, env)
+}
+
+func TestGetEnvConfig_OCP4_14(t *testing.T) {
+	fc := flowslatest.FlowCollector{
+		Spec: flowslatest.FlowCollectorSpec{
+			Agent: flowslatest.FlowCollectorAgent{
+				EBPF: flowslatest.FlowCollectorEBPF{},
+			},
+		},
+	}
+
+	info := cluster.Info{}
+	info.MockOpenShiftVersion("4.14.5")
+	env := getEnvConfig(&fc, &info)
+	assert.Equal(t, []corev1.EnvVar{
+		{Name: "GOMEMLIMIT", Value: "0"},
+		{Name: "METRICS_ENABLE", Value: "true"},
+		{Name: "METRICS_SERVER_PORT", Value: "9400"},
+		{Name: "METRICS_PREFIX", Value: "netobserv_agent_"},
+		{Name: "AGENT_IP", Value: "",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "status.hostIP",
+				},
+			}},
+		{Name: "DNS_TRACKING_PORT", Value: "53"},
+		{Name: "NETWORK_EVENTS_MONITORING_GROUP_ID", Value: "10"},
+		{Name: "PREFERRED_INTERFACE_FOR_MAC_PREFIX", Value: "0a:58=eth0"},
+		{Name: "TC_ATTACH_MODE", Value: "tc"},
+	}, env)
 }

--- a/internal/pkg/helper/env.go
+++ b/internal/pkg/helper/env.go
@@ -1,0 +1,26 @@
+package helper
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func BuildEnvFromDefaults(config, defaults map[string]string) []corev1.EnvVar {
+	var result []corev1.EnvVar
+	// we need to sort env map to keep idempotency,
+	// as equal maps could be iterated in different order
+	for _, pair := range KeySorted(defaults) {
+		k, def := pair[0], pair[1]
+		if override, ok := config[k]; ok {
+			result = append(result, corev1.EnvVar{Name: k, Value: override})
+		} else {
+			result = append(result, corev1.EnvVar{Name: k, Value: def})
+		}
+	}
+	for _, pair := range KeySorted(config) {
+		k, cfg := pair[0], pair[1]
+		if _, ok := defaults[k]; !ok {
+			result = append(result, corev1.EnvVar{Name: k, Value: cfg})
+		}
+	}
+	return result
+}

--- a/internal/pkg/helper/env_test.go
+++ b/internal/pkg/helper/env_test.go
@@ -1,0 +1,34 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestBuildEnvFromDefaults(t *testing.T) {
+	envs := BuildEnvFromDefaults(
+		// config:
+		map[string]string{
+			"a": "1",
+			"z": "99",
+			"b": "11",
+		},
+		// default:
+		map[string]string{
+			"a": "2",
+			"y": "88",
+			"c": "18",
+		},
+	)
+	assert.Equal(t, []corev1.EnvVar{
+		// configs present in defaults come first, ordered
+		{Name: "a", Value: "1"},
+		{Name: "c", Value: "18"},
+		{Name: "y", Value: "88"},
+		// then configs only in the override, ordered as well
+		{Name: "b", Value: "11"},
+		{Name: "z", Value: "99"},
+	}, envs)
+}


### PR DESCRIPTION
## Description

Add the default tcx attach mode, except when openshift <= 4.14 is detected, then use tc hook

There's a small refactoring added to how EnvVar are created, because they were previously creating duplicates when overriding default values - which kinda still works, but isn't clean. This is now covered by tests.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
