### PR TITLE
[backport 1.9] NETOBSERV-2290: fix using tc hook for ocp4.14 (#1670)

### DIFF
--- a/pkg/helper/env.go
+++ b/pkg/helper/env.go
@@ -1,0 +1,26 @@
+package helper
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func BuildEnvFromDefaults(config, defaults map[string]string) []corev1.EnvVar {
+	var result []corev1.EnvVar
+	// we need to sort env map to keep idempotency,
+	// as equal maps could be iterated in different order
+	for _, pair := range KeySorted(defaults) {
+		k, def := pair[0], pair[1]
+		if override, ok := config[k]; ok {
+			result = append(result, corev1.EnvVar{Name: k, Value: override})
+		} else {
+			result = append(result, corev1.EnvVar{Name: k, Value: def})
+		}
+	}
+	for _, pair := range KeySorted(config) {
+		k, cfg := pair[0], pair[1]
+		if _, ok := defaults[k]; !ok {
+			result = append(result, corev1.EnvVar{Name: k, Value: cfg})
+		}
+	}
+	return result
+}

--- a/pkg/helper/env_test.go
+++ b/pkg/helper/env_test.go
@@ -1,0 +1,34 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestBuildEnvFromDefaults(t *testing.T) {
+	envs := BuildEnvFromDefaults(
+		// config:
+		map[string]string{
+			"a": "1",
+			"z": "99",
+			"b": "11",
+		},
+		// default:
+		map[string]string{
+			"a": "2",
+			"y": "88",
+			"c": "18",
+		},
+	)
+	assert.Equal(t, []corev1.EnvVar{
+		// configs present in defaults come first, ordered
+		{Name: "a", Value: "1"},
+		{Name: "c", Value: "18"},
+		{Name: "y", Value: "88"},
+		// then configs only in the override, ordered as well
+		{Name: "b", Value: "11"},
+		{Name: "z", Value: "99"},
+	}, envs)
+}


### PR DESCRIPTION
backport of https://github.com/netobserv/network-observability-operator/pull/1670