### PR TITLE
NETOBSERV-2294: Adding egress support to network policy

### DIFF
--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -14,6 +14,7 @@ const (
 	OperatorName             = "netobserv-operator"
 	ControllerName           = "netobserv-controller-manager"
 	WebhookPort              = 9443
+	K8sAPIServerPort         = 6443
 	FLPName                  = "flowlogs-pipeline"
 	FLPShortName             = "flp"
 	FLPPortName              = "flp" // must be <15 chars
@@ -53,6 +54,7 @@ const (
 	MonitoringServiceAccount = "prometheus-k8s"
 	UWMonitoringNamespace    = "openshift-user-workload-monitoring"
 	ConsoleNamespace         = "openshift-console"
+	DNSNamespace             = "openshift-dns"
 
 	// [Cluster]Roles, must match names in config/rbac/component_roles.yaml (without netobserv- prefix)
 	LokiWriterRole         ClusterRoleName = "netobserv-loki-writer"

--- a/internal/controller/networkpolicy/np_test.go
+++ b/internal/controller/networkpolicy/np_test.go
@@ -97,6 +97,8 @@ func TestNpBuilder(t *testing.T) {
 	assert.Equal([]networkingv1.NetworkPolicyIngressRule{
 		{From: []networkingv1.NetworkPolicyPeer{
 			{PodSelector: &metav1.LabelSelector{}},
+		}},
+		{From: []networkingv1.NetworkPolicyPeer{
 			{NamespaceSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"kubernetes.io/metadata.name": "netobserv-privileged",
@@ -104,6 +106,19 @@ func TestNpBuilder(t *testing.T) {
 			}},
 		}},
 	}, np.Spec.Ingress)
+
+	assert.Equal([]networkingv1.NetworkPolicyEgressRule{
+		{To: []networkingv1.NetworkPolicyPeer{
+			{PodSelector: &metav1.LabelSelector{}},
+		}},
+		{To: []networkingv1.NetworkPolicyPeer{
+			{NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kubernetes.io/metadata.name": "netobserv-privileged",
+				},
+			}},
+		}},
+	}[1], np.Spec.Egress[1])
 
 	name, np = buildPrivilegedNetworkPolicy(&desired, mgr)
 	assert.NotNil(np)
@@ -119,6 +134,8 @@ func TestNpBuilder(t *testing.T) {
 	assert.Equal([]networkingv1.NetworkPolicyIngressRule{
 		{From: []networkingv1.NetworkPolicyPeer{
 			{PodSelector: &metav1.LabelSelector{}},
+		}},
+		{From: []networkingv1.NetworkPolicyPeer{
 			{NamespaceSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"kubernetes.io/metadata.name": "netobserv-privileged",
@@ -140,6 +157,33 @@ func TestNpBuilder(t *testing.T) {
 			}},
 		}},
 	}, np.Spec.Ingress)
+
+	assert.Equal([]networkingv1.NetworkPolicyEgressRule{
+		{To: []networkingv1.NetworkPolicyPeer{
+			{PodSelector: &metav1.LabelSelector{}},
+		}},
+		{To: []networkingv1.NetworkPolicyPeer{
+			{NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kubernetes.io/metadata.name": "netobserv-privileged",
+				},
+			}},
+		}},
+		{To: []networkingv1.NetworkPolicyPeer{
+			{NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kubernetes.io/metadata.name": "foo",
+				},
+			}},
+		}},
+		{To: []networkingv1.NetworkPolicyPeer{
+			{NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kubernetes.io/metadata.name": "bar",
+				},
+			}},
+		}},
+	}, np.Spec.Egress)
 
 	name, np = buildPrivilegedNetworkPolicy(&desired, mgr)
 	assert.NotNil(np)


### PR DESCRIPTION
## Description

Adding egress support to network policy

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [X] Does this PR require a product release notes entry?
  * [X] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
