### PR TITLE
[Trivial] Use faster way to get metrics cardinality

### DIFF
--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -16,6 +16,9 @@ const (
 	FLPName                  = "flowlogs-pipeline"
 	FLPShortName             = "flp"
 	FLPPortName              = "flp" // must be <15 chars
+	FLPMetricsSvcName        = FLPName + "-prom"
+	FLPTransfoName           = FLPName + "-transformer"
+	FLPTransfoMetricsSvcName = FLPTransfoName + "-prom"
 	FLPMetricsPort           = 9401
 	PluginName               = "netobserv-plugin"
 	PluginShortName          = "plugin"
@@ -24,7 +27,7 @@ const (
 	EBPFAgentName                     = "netobserv-ebpf-agent"
 	EBPFAgentMetricsSvcName           = "ebpf-agent-svc-prom"
 	EBPFAgentMetricsSvcMonitoringName = "ebpf-agent-svc-monitor"
-	EBPFAgentPromoAlertRule           = "ebpf-agent-prom-alert"
+	EBPFAgentPromAlertRule            = "ebpf-agent-prom-alert"
 	EBPFPrivilegedNSSuffix            = "-privileged"
 	EBPFServiceAccount                = EBPFAgentName
 	EBPFSecurityContext               = EBPFAgentName

--- a/internal/controller/ebpf/agent_controller.go
+++ b/internal/controller/ebpf/agent_controller.go
@@ -125,7 +125,7 @@ func NewAgentController(common *reconcilers.Instance) *AgentController {
 		agent.serviceMonitor = common.Managed.NewServiceMonitor(constants.EBPFAgentMetricsSvcMonitoringName)
 	}
 	if common.ClusterInfo.HasPromRule() {
-		agent.prometheusRule = common.Managed.NewPrometheusRule(constants.EBPFAgentPromoAlertRule)
+		agent.prometheusRule = common.Managed.NewPrometheusRule(constants.EBPFAgentPromAlertRule)
 	}
 	return &agent
 }

--- a/internal/controller/ebpf/agent_metrics.go
+++ b/internal/controller/ebpf/agent_metrics.go
@@ -138,7 +138,7 @@ func (c *AgentController) agentPrometheusRule(target *flowslatest.FlowCollectorE
 
 	prometheusRuleObject := monitoringv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: constants.EBPFAgentPromoAlertRule,
+			Name: constants.EBPFAgentPromAlertRule,
 			Labels: map[string]string{
 				"app": constants.EBPFAgentName,
 			},

--- a/internal/controller/flp/flp_monolith_objects.go
+++ b/internal/controller/flp/flp_monolith_objects.go
@@ -19,7 +19,6 @@ const (
 	monoShortName      = constants.FLPShortName
 	monoConfigMap      = monoName + "-config"
 	monoDynConfigMap   = monoName + "-config-dynamic"
-	monoPromService    = monoName + "-prom"
 	monoServiceMonitor = monoName + "-monitor"
 	monoPromRule       = monoName + "-alert"
 )
@@ -36,7 +35,7 @@ type monolithBuilder struct {
 
 func newMonolithBuilder(info *reconcilers.Instance, desired *flowslatest.FlowCollectorSpec, flowMetrics *metricslatest.FlowMetricList, detectedSubnets []flowslatest.SubnetLabel) (monolithBuilder, error) {
 	version := helper.ExtractVersion(info.Images[reconcilers.MainImage])
-	promTLS, err := getPromTLS(desired, monoPromService)
+	promTLS, err := getPromTLS(desired, constants.FLPMetricsSvcName)
 	if err != nil {
 		return monolithBuilder{}, err
 	}
@@ -132,7 +131,7 @@ func (b *monolithBuilder) configMaps() (*corev1.ConfigMap, string, *corev1.Confi
 func (b *monolithBuilder) promService() *corev1.Service {
 	return promService(
 		b.desired,
-		monoPromService,
+		constants.FLPMetricsSvcName,
 		b.info.Namespace,
 		monoName,
 	)
@@ -152,7 +151,7 @@ func (b *monolithBuilder) serviceMonitor() *monitoringv1.ServiceMonitor {
 	return serviceMonitor(
 		b.desired,
 		monoServiceMonitor,
-		monoPromService,
+		constants.FLPMetricsSvcName,
 		b.info.Namespace,
 		monoName,
 		b.version,

--- a/internal/controller/flp/flp_monolith_reconciler.go
+++ b/internal/controller/flp/flp_monolith_reconciler.go
@@ -38,7 +38,7 @@ func newMonolithReconciler(cmn *reconcilers.Instance) *monolithReconciler {
 	rec := monolithReconciler{
 		Instance:         cmn,
 		daemonSet:        cmn.Managed.NewDaemonSet(monoName),
-		promService:      cmn.Managed.NewService(monoPromService),
+		promService:      cmn.Managed.NewService(constants.FLPMetricsSvcName),
 		serviceAccount:   cmn.Managed.NewServiceAccount(monoName),
 		staticConfigMap:  cmn.Managed.NewConfigMap(monoConfigMap),
 		dynamicConfigMap: cmn.Managed.NewConfigMap(monoDynConfigMap),

--- a/internal/controller/flp/flp_transfo_objects.go
+++ b/internal/controller/flp/flp_transfo_objects.go
@@ -16,11 +16,10 @@ import (
 )
 
 const (
-	transfoName           = constants.FLPName + "-transformer"
+	transfoName           = constants.FLPTransfoName
 	transfoShortName      = constants.FLPShortName + "transfo"
 	transfoConfigMap      = transfoName + "-config"
 	transfoDynConfigMap   = transfoName + "-config-dynamic"
-	transfoPromService    = transfoName + "-prom"
 	transfoServiceMonitor = transfoName + "-monitor"
 	transfoPromRule       = transfoName + "-alert"
 )
@@ -37,7 +36,7 @@ type transfoBuilder struct {
 
 func newTransfoBuilder(info *reconcilers.Instance, desired *flowslatest.FlowCollectorSpec, flowMetrics *metricslatest.FlowMetricList, detectedSubnets []flowslatest.SubnetLabel) (transfoBuilder, error) {
 	version := helper.ExtractVersion(info.Images[reconcilers.MainImage])
-	promTLS, err := getPromTLS(desired, transfoPromService)
+	promTLS, err := getPromTLS(desired, constants.FLPTransfoMetricsSvcName)
 	if err != nil {
 		return transfoBuilder{}, err
 	}
@@ -134,7 +133,7 @@ func (b *transfoBuilder) configMaps() (*corev1.ConfigMap, string, *corev1.Config
 func (b *transfoBuilder) promService() *corev1.Service {
 	return promService(
 		b.desired,
-		transfoPromService,
+		constants.FLPTransfoMetricsSvcName,
 		b.info.Namespace,
 		transfoName,
 	)
@@ -174,7 +173,7 @@ func (b *transfoBuilder) serviceMonitor() *monitoringv1.ServiceMonitor {
 	return serviceMonitor(
 		b.desired,
 		transfoServiceMonitor,
-		transfoPromService,
+		constants.FLPTransfoMetricsSvcName,
 		b.info.Namespace,
 		transfoName,
 		b.version,

--- a/internal/controller/flp/flp_transfo_reconciler.go
+++ b/internal/controller/flp/flp_transfo_reconciler.go
@@ -39,7 +39,7 @@ func newTransformerReconciler(cmn *reconcilers.Instance) *transformerReconciler 
 	rec := transformerReconciler{
 		Instance:         cmn,
 		deployment:       cmn.Managed.NewDeployment(transfoName),
-		promService:      cmn.Managed.NewService(transfoPromService),
+		promService:      cmn.Managed.NewService(constants.FLPTransfoMetricsSvcName),
 		hpa:              cmn.Managed.NewHPA(transfoName),
 		serviceAccount:   cmn.Managed.NewServiceAccount(transfoName),
 		staticConfigMap:  cmn.Managed.NewConfigMap(transfoConfigMap),


### PR DESCRIPTION
## Description

Use scrape_samples_post_metric_relabeling instead of "count({__name__=~"netobserv_.*"})", which can be orders of magnitude faster on large clusters. It gives approximately the same values (the cardinality is a bit higher, because of generic metrics provided by our jobs but not directly from us, e.g. Go metrics)

Also move & export some constants to constants.go

See also: https://github.com/openshift-eng/ocp-qe-perfscale-ci/pull/799

**Before:**
<img width="530" height="412" alt="Capture d’écran du 2025-07-16 14-53-39" src="https://github.com/user-attachments/assets/64ce0df5-22b5-4b57-b94c-92378ee97bec" />


**After:**
<img width="530" height="412" alt="Capture d’écran du 2025-07-16 14-52-33" src="https://github.com/user-attachments/assets/692273f3-11cc-4b4f-8db6-12a7b3d4e6d7" />


## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
