### PR TITLE
NETOBSERV-2348: validate prometheus names

### DIFF
--- a/api/flowmetrics/v1alpha1/flowmetric_types.go
+++ b/api/flowmetrics/v1alpha1/flowmetric_types.go
@@ -24,6 +24,9 @@ type MetricType string
 type FilterMatchType string
 type FlowDirection string
 
+// +kubebuilder:validation:Pattern:="^[a-zA-Z_][a-zA-Z0-9_]*$"
+type Label string
+
 const (
 	CounterMetric   MetricType      = "Counter"
 	GaugeMetric     MetricType      = "Gauge"
@@ -61,6 +64,7 @@ type MetricFilter struct {
 // To check the cardinality of all NetObserv metrics, run as `promql`: `count({__name__=~"netobserv.*"}) by (__name__)`.
 type FlowMetricSpec struct {
 	// Name of the metric. In Prometheus, it is automatically prefixed with "netobserv_".
+	// +kubebuilder:validation:Pattern:="^[a-zA-Z_][a-zA-Z0-9:_]*$"
 	// +optional
 	MetricName string `json:"metricName"`
 
@@ -99,7 +103,7 @@ type FlowMetricSpec struct {
 
 	// Set the `remap` property to use different names for the generated metric labels than the flow fields. Use the origin flow fields as keys, and the desired label names as values.
 	// +optional
-	Remap map[string]string `json:"remap"`
+	Remap map[string]Label `json:"remap"`
 
 	// Filter for ingress, egress or any direction flows.
 	// When set to `Ingress`, it is equivalent to adding the regular expression filter on `FlowDirection`: `0|2`.

--- a/api/flowmetrics/v1alpha1/flowmetric_webhook.go
+++ b/api/flowmetrics/v1alpha1/flowmetric_webhook.go
@@ -62,7 +62,7 @@ func (r *FlowMetricWebhook) ValidateDelete(_ context.Context, _ runtime.Object) 
 	return nil, nil
 }
 
-func checkFlowMetricCartinality(fMetric *FlowMetric) admission.Warnings {
+func checkFlowMetricCardinality(fMetric *FlowMetric) admission.Warnings {
 	w := admission.Warnings{}
 	r, err := cardinality.CheckCardinality(fMetric.Spec.Labels...)
 	if err != nil {
@@ -140,6 +140,6 @@ func validateFlowMetric(_ context.Context, fMetric *FlowMetric) (admission.Warni
 			schema.GroupKind{Group: GroupVersion.Group, Kind: FlowMetric{}.Kind},
 			fMetric.Name, allErrs)
 	}
-	w := checkFlowMetricCartinality(fMetric)
+	w := checkFlowMetricCardinality(fMetric)
 	return w, nil
 }

--- a/api/flowmetrics/v1alpha1/flowmetric_webhook_test.go
+++ b/api/flowmetrics/v1alpha1/flowmetric_webhook_test.go
@@ -121,7 +121,7 @@ func TestFlowMetric(t *testing.T) {
 							Value: "acl",
 						},
 					},
-					Remap: map[string]string{"NetworkEvents>Name": "name"},
+					Remap: map[string]Label{"NetworkEvents>Name": "name"},
 				},
 			},
 			expectedError: "",

--- a/api/flowmetrics/v1alpha1/zz_generated.deepcopy.go
+++ b/api/flowmetrics/v1alpha1/zz_generated.deepcopy.go
@@ -124,7 +124,7 @@ func (in *FlowMetricSpec) DeepCopyInto(out *FlowMetricSpec) {
 	}
 	if in.Remap != nil {
 		in, out := &in.Remap, &out.Remap
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string]Label, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/bundle/manifests/flows.netobserv.io_flowmetrics.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowmetrics.yaml
@@ -216,9 +216,11 @@ spec:
               metricName:
                 description: Name of the metric. In Prometheus, it is automatically
                   prefixed with "netobserv_".
+                pattern: ^[a-zA-Z_][a-zA-Z0-9:_]*$
                 type: string
               remap:
                 additionalProperties:
+                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                   type: string
                 description: Set the `remap` property to use different names for the
                   generated metric labels than the flow fields. Use the origin flow

--- a/config/crd/bases/flows.netobserv.io_flowmetrics.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowmetrics.yaml
@@ -206,9 +206,11 @@ spec:
               metricName:
                 description: Name of the metric. In Prometheus, it is automatically
                   prefixed with "netobserv_".
+                pattern: ^[a-zA-Z_][a-zA-Z0-9:_]*$
                 type: string
               remap:
                 additionalProperties:
+                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                   type: string
                 description: Set the `remap` property to use different names for the
                   generated metric labels than the flow fields. Use the origin flow

--- a/helm/crds/flows.netobserv.io_flowmetrics.yaml
+++ b/helm/crds/flows.netobserv.io_flowmetrics.yaml
@@ -193,9 +193,11 @@ spec:
                   type: array
                 metricName:
                   description: Name of the metric. In Prometheus, it is automatically prefixed with "netobserv_".
+                  pattern: ^[a-zA-Z_][a-zA-Z0-9:_]*$
                   type: string
                 remap:
                   additionalProperties:
+                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                     type: string
                   description: Set the `remap` property to use different names for the generated metric labels than the flow fields. Use the origin flow fields as keys, and the desired label names as values.
                   type: object

--- a/internal/controller/flp/flp_pipeline_builder.go
+++ b/internal/controller/flp/flp_pipeline_builder.go
@@ -399,12 +399,16 @@ func flowMetricToFLP(fm *metricslatest.FlowMetric) (*api.MetricsItem, error) {
 	if metricName == "" {
 		metricName = helper.PrometheusMetricName(fm.Name)
 	}
+	remap := make(map[string]string, len(fm.Spec.Remap))
+	for k, v := range fm.Spec.Remap {
+		remap[k] = string(v)
+	}
 	m := &api.MetricsItem{
 		Name:     metricName,
 		Type:     api.MetricEncodeOperationEnum(strings.ToLower(string(fm.Spec.Type))),
 		Filters:  []api.MetricsFilter{},
 		Labels:   fm.Spec.Labels,
-		Remap:    fm.Spec.Remap,
+		Remap:    remap,
 		Flatten:  fm.Spec.Flatten,
 		ValueKey: fm.Spec.ValueField,
 	}

--- a/internal/pkg/metrics/predefined_metrics.go
+++ b/internal/pkg/metrics/predefined_metrics.go
@@ -192,7 +192,7 @@ func init() {
 				Labels:     netpolLabels,
 				Filters:    []metricslatest.MetricFilter{{Field: "NetworkEvents>Feature", Value: "acl"}},
 				Flatten:    []string{"NetworkEvents"},
-				Remap: map[string]string{
+				Remap: map[string]metricslatest.Label{
 					"NetworkEvents>Type":      "type",
 					"NetworkEvents>Namespace": "namespace",
 					"NetworkEvents>Name":      "name",


### PR DESCRIPTION
## Description


## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
