### PR TITLE
NETOBSERV-2225 - Deploy static plugin at operator startup - fix

### DIFF
--- a/internal/controller/monitoring/monitoring_controller.go
+++ b/internal/controller/monitoring/monitoring_controller.go
@@ -105,7 +105,7 @@ func (r *Reconciler) reconcile(ctx context.Context, clh *helper.Client, desired 
 		if err != nil {
 			return err
 		}
-	} else if helper.IsManaged(nsExist) && !helper.IsSubSet(nsExist.ObjectMeta.Labels, desiredNs.ObjectMeta.Labels) {
+	} else if !helper.SkipOwnership(nsExist) && !helper.IsSubSet(nsExist.ObjectMeta.Labels, desiredNs.ObjectMeta.Labels) {
 		err = r.Update(ctx, desiredNs)
 		if err != nil {
 			return err

--- a/internal/pkg/helper/flowcollector.go
+++ b/internal/pkg/helper/flowcollector.go
@@ -218,6 +218,13 @@ func IsManaged(obj client.Object) bool {
 	return labels[netobservManagedLabel] == "true"
 }
 
+// special case where ownership is ignored if netobserv-managed label is explicitly set to false
+// this is used to allow users to create namespaces with custom labels and annotations prior to the reconciliation
+func SkipOwnership(obj client.Object) bool {
+	labels := obj.GetLabels()
+	return labels != nil && labels[netobservManagedLabel] == "false"
+}
+
 func IsOwned(obj client.Object) bool {
 	// ownership is forced if netobserv-managed label is explicitly set to true
 	if IsManaged(obj) {


### PR DESCRIPTION
## Description

Fix namespace reconciliation when create by the user.
Since https://github.com/netobserv/network-observability-operator/pull/1345 `openshift.io/cluster-monitoring: "true"` is missing when the user created the namespace by himself.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
