### PR TITLE
NETOBSERV-2293 : Set default value for network policy to true

### DIFF
--- a/api/flowcollector/v1beta2/flowcollector_types.go
+++ b/api/flowcollector/v1beta2/flowcollector_types.go
@@ -86,7 +86,7 @@ type FlowCollectorSpec struct {
 	// +k8s:conversion-gen=false
 	Exporters []*FlowCollectorExporter `json:"exporters"`
 
-	// `networkPolicy` defines ingress network policy settings for NetObserv components isolation.
+	// `networkPolicy` defines network policy settings for NetObserv components isolation.
 	// +k8s:conversion-gen=false
 	NetworkPolicy NetworkPolicy `json:"networkPolicy,omitempty"`
 }
@@ -94,8 +94,8 @@ type FlowCollectorSpec struct {
 type NetworkPolicy struct {
 	// Set `enable` to `true` to deploy network policies on the namespaces used by NetObserv (main and privileged). It is disabled by default.
 	// These network policies better isolate the NetObserv components to prevent undesired connections to them.
-	// To increase the security of connections, enable this option or create your own network policy.
-	// +optional
+	// This option is enabled by default, disable it to manually manage network policies
+	// +kubebuilder:default:=true
 	Enable *bool `json:"enable,omitempty"`
 
 	// `additionalNamespaces` contains additional namespaces allowed to connect to the NetObserv namespace.

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -4245,8 +4245,8 @@ spec:
                     and recreate the resource.
                   rule: self == oldSelf
               networkPolicy:
-                description: '`networkPolicy` defines ingress network policy settings
-                  for NetObserv components isolation.'
+                description: '`networkPolicy` defines network policy settings for
+                  NetObserv components isolation.'
                 properties:
                   additionalNamespaces:
                     description: |-
@@ -4257,10 +4257,11 @@ spec:
                       type: string
                     type: array
                   enable:
+                    default: true
                     description: |-
                       Set `enable` to `true` to deploy network policies on the namespaces used by NetObserv (main and privileged). It is disabled by default.
                       These network policies better isolate the NetObserv components to prevent undesired connections to them.
-                      To increase the security of connections, enable this option or create your own network policy.
+                      This option is enabled by default, disable it to manually manage network policies
                     type: boolean
                 type: object
               processor:

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -213,7 +213,7 @@ metadata:
             "namespace": "netobserv",
             "networkPolicy": {
               "additionalNamespaces": [],
-              "enable": false
+              "enable": true
             },
             "processor": {
               "imagePullPolicy": "IfNotPresent",
@@ -253,7 +253,7 @@ metadata:
     categories: Monitoring, Networking, Observability
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: quay.io/netobserv/network-observability-operator:1.9.2-community
-    createdAt: "2025-09-08T09:08:19Z"
+    createdAt: "2025-09-18T08:50:21Z"
     description: Network flows collector and monitoring solution
     operatorframework.io/initialization-resource: '{"apiVersion":"flows.netobserv.io/v1beta2",
       "kind":"FlowCollector","metadata":{"name":"cluster"},"spec": {}}'

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -3895,7 +3895,7 @@ spec:
                     - message: Namespace is immutable. If you need to change it, delete and recreate the resource.
                       rule: self == oldSelf
                 networkPolicy:
-                  description: '`networkPolicy` defines ingress network policy settings for NetObserv components isolation.'
+                  description: '`networkPolicy` defines network policy settings for NetObserv components isolation.'
                   properties:
                     additionalNamespaces:
                       description: |-
@@ -3906,10 +3906,11 @@ spec:
                         type: string
                       type: array
                     enable:
+                      default: true
                       description: |-
                         Set `enable` to `true` to deploy network policies on the namespaces used by NetObserv (main and privileged). It is disabled by default.
                         These network policies better isolate the NetObserv components to prevent undesired connections to them.
-                        To increase the security of connections, enable this option or create your own network policy.
+                        This option is enabled by default, disable it to manually manage network policies
                       type: boolean
                   type: object
                 processor:

--- a/config/samples/flows_v1beta2_flowcollector.yaml
+++ b/config/samples/flows_v1beta2_flowcollector.yaml
@@ -6,7 +6,7 @@ spec:
   namespace: netobserv
   deploymentModel: Direct
   networkPolicy:
-    enable: false
+    enable: true
     additionalNamespaces: []
   agent:
     type: eBPF

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -154,7 +154,7 @@ Kafka can provide better scalability, resiliency, and high availability (for mor
         <td><b><a href="#flowcollectorspecnetworkpolicy">networkPolicy</a></b></td>
         <td>object</td>
         <td>
-          `networkPolicy` defines ingress network policy settings for NetObserv components isolation.<br/>
+          `networkPolicy` defines network policy settings for NetObserv components isolation.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -8325,7 +8325,7 @@ If the namespace is different, the config map or the secret is copied so that it
 
 
 
-`networkPolicy` defines ingress network policy settings for NetObserv components isolation.
+`networkPolicy` defines network policy settings for NetObserv components isolation.
 
 <table>
     <thead>
@@ -8351,7 +8351,9 @@ configuration, you can disable it and install your own instead.<br/>
         <td>
           Set `enable` to `true` to deploy network policies on the namespaces used by NetObserv (main and privileged). It is disabled by default.
 These network policies better isolate the NetObserv components to prevent undesired connections to them.
-To increase the security of connections, enable this option or create your own network policy.<br/>
+This option is enabled by default, disable it to manually manage network policies<br/>
+          <br/>
+            <i>Default</i>: true<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/helm/crds/flows.netobserv.io_flowcollectors.yaml
+++ b/helm/crds/flows.netobserv.io_flowcollectors.yaml
@@ -3899,7 +3899,7 @@ spec:
                     - message: Namespace is immutable. If you need to change it, delete and recreate the resource.
                       rule: self == oldSelf
                 networkPolicy:
-                  description: '`networkPolicy` defines ingress network policy settings for NetObserv components isolation.'
+                  description: '`networkPolicy` defines network policy settings for NetObserv components isolation.'
                   properties:
                     additionalNamespaces:
                       description: |-
@@ -3910,10 +3910,11 @@ spec:
                         type: string
                       type: array
                     enable:
+                      default: true
                       description: |-
                         Set `enable` to `true` to deploy network policies on the namespaces used by NetObserv (main and privileged). It is disabled by default.
                         These network policies better isolate the NetObserv components to prevent undesired connections to them.
-                        To increase the security of connections, enable this option or create your own network policy.
+                        This option is enabled by default, disable it to manually manage network policies
                       type: boolean
                   type: object
                 processor:

--- a/internal/controller/flowcollector_controller_iso_test.go
+++ b/internal/controller/flowcollector_controller_iso_test.go
@@ -217,7 +217,7 @@ func flowCollectorIsoSpecs() {
 			},
 			Exporters: []*flowslatest.FlowCollectorExporter{},
 			NetworkPolicy: flowslatest.NetworkPolicy{
-				Enable:               nil,
+				Enable:               ptr.To(true),
 				AdditionalNamespaces: []string{},
 			},
 		}

--- a/internal/controller/networkpolicy/np_test.go
+++ b/internal/controller/networkpolicy/np_test.go
@@ -189,5 +189,19 @@ func TestNpBuilder(t *testing.T) {
 	assert.NotNil(np)
 	assert.Equal(np.ObjectMeta.Name, name.Name)
 	assert.Equal(np.ObjectMeta.Namespace, name.Namespace)
-	assert.Equal([]networkingv1.NetworkPolicyIngressRule{}, np.Spec.Ingress)
+	assert.Equal([]networkingv1.NetworkPolicyIngressRule{
+		{From: []networkingv1.NetworkPolicyPeer{
+			{NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kubernetes.io/metadata.name": "foo",
+				},
+			}},
+		}},
+		{From: []networkingv1.NetworkPolicyPeer{
+			{NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kubernetes.io/metadata.name": "bar",
+				},
+			}},
+		}}}, np.Spec.Ingress)
 }

--- a/internal/pkg/helper/flowcollector.go
+++ b/internal/pkg/helper/flowcollector.go
@@ -14,6 +14,34 @@ const (
 	netobservManagedLabel = "netobserv-managed"
 )
 
+func GetSampling(spec *flowslatest.FlowCollectorSpec) int {
+	if spec.Agent.EBPF.Sampling == nil {
+		return 50
+	}
+	return int(*spec.Agent.EBPF.Sampling)
+}
+
+func UseKafka(spec *flowslatest.FlowCollectorSpec) bool {
+	return spec.DeploymentModel == flowslatest.DeploymentModelKafka
+}
+
+func DeployNetworkPolicy(spec *flowslatest.FlowCollectorSpec) bool {
+	return spec.NetworkPolicy.Enable != nil && *spec.NetworkPolicy.Enable
+}
+
+func HasKafkaExporter(spec *flowslatest.FlowCollectorSpec) bool {
+	for _, ex := range spec.Exporters {
+		if ex.Type == flowslatest.KafkaExporter {
+			return true
+		}
+	}
+	return false
+}
+
+func HPAEnabled(spec *flowslatest.FlowCollectorHPA) bool {
+	return spec != nil && spec.Status == flowslatest.HPAStatusEnabled
+}
+
 func GetRecordTypes(processor *flowslatest.FlowCollectorFLP) []api.ConnTrackOutputRecordTypeEnum {
 	if processor.LogTypes != nil {
 		switch *processor.LogTypes {


### PR DESCRIPTION
## Description

Set the default value for network policy to true.

This story first intended to also add a network policy for the operator namespace but this is going to be done in a later task.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [X] Does this PR require product documentation?
  * [X] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [X] Does this PR require a product release notes entry?
  * [X] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
