### PR TITLE
[NETOBSERV-2274] Remove ENABLE_FLOW_FILTER environment variable 

### DIFF
--- a/internal/controller/ebpf/agent_controller.go
+++ b/internal/controller/ebpf/agent_controller.go
@@ -64,7 +64,6 @@ const (
 	envMetricPrefix               = "METRICS_PREFIX"
 	envMetricsTLSCertPath         = "METRICS_TLS_CERT_PATH"
 	envMetricsTLSKeyPath          = "METRICS_TLS_KEY_PATH"
-	envEnableFlowFilter           = "ENABLE_FLOW_FILTER"
 	envFilterRules                = "FLOW_FILTER_RULES"
 	envEnablePacketTranslation    = "ENABLE_PKT_TRANSLATION"
 	envEnableEbpfMgr              = "EBPF_PROGRAM_MANAGER_MODE"
@@ -738,7 +737,6 @@ func getEnvConfig(coll *flowslatest.FlowCollector, cinfo *cluster.Info) []corev1
 	}
 
 	if helper.IsEBPFFlowFilterEnabled(&coll.Spec.Agent.EBPF) {
-		config = append(config, corev1.EnvVar{Name: envEnableFlowFilter, Value: "true"})
 		if len(coll.Spec.Agent.EBPF.FlowFilter.Rules) != 0 {
 			if filterRules := configureFlowFiltersRules(coll.Spec.Agent.EBPF.FlowFilter.Rules); filterRules != nil {
 				config = append(config, filterRules...)

--- a/internal/controller/ebpf/agent_controller_test.go
+++ b/internal/controller/ebpf/agent_controller_test.go
@@ -146,7 +146,6 @@ func TestGetEnvConfig_WithOverrides(t *testing.T) {
 	env := getEnvConfig(&fc, &cluster.Info{})
 	assert.Equal(t, []corev1.EnvVar{
 		{Name: "GOMEMLIMIT", Value: "0"},
-		{Name: "ENABLE_FLOW_FILTER", Value: "true"},
 		{Name: "FLOW_FILTER_RULES", Value: `[{"ip_cidr":"0.0.0.0/0","action":"Accept"}]`},
 		{Name: "AGENT_IP", Value: "",
 			ValueFrom: &corev1.EnvVarSource{

--- a/vendor/github.com/netobserv/netobserv-ebpf-agent/pkg/config/config.go
+++ b/vendor/github.com/netobserv/netobserv-ebpf-agent/pkg/config/config.go
@@ -231,8 +231,6 @@ type Agent struct {
 	MetricsTLSKeyPath string `env:"METRICS_TLS_KEY_PATH"`
 	// MetricsPrefix is the prefix of the metrics that are sent to the server.
 	MetricsPrefix string `env:"METRICS_PREFIX" envDefault:"ebpf_agent_"`
-	// EnableFlowFilter enables flow filter, default is false.
-	EnableFlowFilter bool `env:"ENABLE_FLOW_FILTER" envDefault:"false"`
 	// FlowFilterRules list of flow filter rules
 	FlowFilterRules string `env:"FLOW_FILTER_RULES"`
 	// EnableNetworkEventsMonitoring enables monitoring network plugin events, default is false.


### PR DESCRIPTION
## Description

ENABLE_FLOW_FILTER environment variable is not required anymore.

Ref: https://issues.redhat.com/browse/NETOBSERV-2274

## Dependencies

- https://github.com/netobserv/network-observability-cli/pull/366
- https://github.com/netobserv/netobserv-ebpf-agent/pull/779

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
