### PR TITLE
Fix test timeout often reached

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ lint: prereqs ## Run linter (golangci-lint).
 	./bin/golangci-lint-${GOLANGCI_LINT_VERSION} run --timeout 5m ./...
 
 test: envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT="120s" go test ./... -coverpkg=./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT="60s" go test ./... -coverpkg=./... -coverprofile cover.out
 
 coverage-report: ## Generate coverage report
 	go tool cover --func=./cover.out


### PR DESCRIPTION
The tests occasionally fail in the CI, such as here https://github.com/netobserv/network-observability-operator/actions/runs/17466842398/job/49612262446 , due to a timeout reached during envtest teardown.
This should give us a more comfortable margin. (default is 20s, using here 60s)