### PR TITLE
Fix due to change in FLP

### DIFF
--- a/internal/controller/flp/flp_pipeline_builder_test.go
+++ b/internal/controller/flp/flp_pipeline_builder_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 // This function validate that each stage has its matching parameter
-func validatePipelineConfig(t *testing.T, staticCm *corev1.ConfigMap, dynamicCm *corev1.ConfigMap) (*config.ConfigFileStruct, string) {
-	var cfs config.ConfigFileStruct
+func validatePipelineConfig(t *testing.T, staticCm *corev1.ConfigMap, dynamicCm *corev1.ConfigMap) (*config.Root, string) {
+	var cfs config.Root
 	err := json.Unmarshal([]byte(staticCm.Data[configFile]), &cfs)
 	assert.NoError(t, err)
 

--- a/internal/controller/flp/flp_test.go
+++ b/internal/controller/flp/flp_test.go
@@ -633,7 +633,7 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiManual(t *testing.T) {
 	data, ok := cm.Data[configFile]
 	assert.True(ok)
 
-	var decoded config.ConfigFileStruct
+	var decoded config.Root
 	err = json.Unmarshal([]byte(data), &decoded)
 
 	assert.Nil(err)
@@ -681,7 +681,7 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiStack(t *testing.T) {
 	data, ok := cm.Data[configFile]
 	assert.True(ok)
 
-	var decoded config.ConfigFileStruct
+	var decoded config.Root
 	err = json.Unmarshal([]byte(data), &decoded)
 
 	assert.Nil(err)

--- a/internal/controller/flp/metrics_api_test.go
+++ b/internal/controller/flp/metrics_api_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func getConfiguredMetrics(cm *corev1.ConfigMap) (api.MetricsItems, error) {
-	var cfs config.ConfigFileStruct
+	var cfs config.Root
 	err := json.Unmarshal([]byte(cm.Data[configFile]), &cfs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

Fix to address an error in compilation and testing related to a past change in flp (https://github.com/netobserv/flowlogs-pipeline/commit/9957abe07ef631076eb9934b2452840653ee20f9#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R38)

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
