### PR TITLE
Add GitHub workflows for automatic PR labeling for needs-review and needs-changes

### DIFF
--- a/.github/workflows/needs-changes.yaml
+++ b/.github/workflows/needs-changes.yaml
@@ -15,8 +15,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Handle review submission
-        if: github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'pull_request_review'
         run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "PR number: ${{ github.event.pull_request.number }}"
+          echo "Review state: ${{ github.event.review.state }}"
+          echo "Repository: ${{ github.repository }}"
+          
           PR_NUMBER=${{ github.event.pull_request.number }}
           REVIEW_STATE="${{ github.event.review.state }}"
           
@@ -28,6 +33,8 @@ jobs:
           if [[ "$REVIEW_STATE" == "changes_requested" ]] || [[ "$REVIEW_STATE" == "commented" ]]; then
             echo "Adding needs-changes label for $REVIEW_STATE review"
             gh pr edit $PR_NUMBER --add-label needs-changes || echo "Failed to add needs-changes label or label already exists"
+          else
+            echo "Review state $REVIEW_STATE does not trigger needs-changes label"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/needs-review.yaml
+++ b/.github/workflows/needs-review.yaml
@@ -28,16 +28,23 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+    if: github.event_name == 'issue_comment' && github.event.issue.pull_request != null
     steps:
       - name: Add needs-review label via comment
         run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Issue number: ${{ github.event.issue.number }}"
+          echo "Comment body: ${{ github.event.comment.body }}"
+          echo "Is PR: ${{ github.event.issue.pull_request != null }}"
+          
           COMMENT_BODY="${{ github.event.comment.body }}"
           COMMENT_LOWER=$(echo "$COMMENT_BODY" | tr '[:upper:]' '[:lower:]')
           
           if [[ "$COMMENT_LOWER" == *"needs-review"* ]] || [[ "$COMMENT_LOWER" == *"/needs-review"* ]]; then
             echo "Adding needs-review label via comment"
             gh pr edit ${{ github.event.issue.number }} --add-label needs-review || echo "Failed to add label or label already exists"
+          else
+            echo "Comment does not contain needs-review trigger"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add automatic "needs-review" labeling for non-draft PRs without WIP in title
- Add automatic "needs-changes" labeling based on review status
- Support manual label management via comments

## Changes
- **needs-review.yaml**: Automatically adds "needs-review" label to non-draft PRs (excludes red-hat-konflux author and WIP titles)
- **needs-changes.yaml**: Manages review status labels:
  - Removes "needs-review" when any review is submitted
  - Adds "needs-changes" for non-approved reviews
  - Removes "needs-changes" when "lgtm" label is added
  - Allows manual "needs-changes" labeling via comments

- [x] I performed self-review of the code changes - Mehul Modi

## Test plan
- [ ] Verify workflows trigger correctly on PR events
- [ ] Test label addition/removal based on review states
- [ ] Test manual labeling via comments

🤖 Generated with [Claude Code](https://claude.ai/code)