### PR TITLE
Fix upstream deploy/bundle issues with PF4 image

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -1072,7 +1072,7 @@ spec:
                 - name: RELATED_IMAGE_CONSOLE_PLUGIN
                   value: quay.io/netobserv/network-observability-console-plugin:v1.9.2-community
                 - name: RELATED_IMAGE_CONSOLE_PLUGIN_COMPAT
-                  value: quay.io/netobserv/network-observability-console-plugin-pf4:v1.8.2-community
+                  value: quay.io/netobserv/network-observability-console-plugin:v1.9.2-community-pf4
                 - name: DOWNSTREAM_DEPLOYMENT
                   value: "false"
                 - name: PROFILING_BIND_ADDRESS
@@ -1218,7 +1218,7 @@ spec:
     name: flowlogs-pipeline
   - image: quay.io/netobserv/network-observability-console-plugin:v1.9.2-community
     name: console-plugin
-  - image: quay.io/netobserv/network-observability-console-plugin-pf4:v1.8.2-community
+  - image: quay.io/netobserv/network-observability-console-plugin:v1.9.2-community-pf4
     name: console-plugin-compat
   version: 1.9.2-community
   webhookdefinitions:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,7 +39,7 @@ spec:
           - name: RELATED_IMAGE_CONSOLE_PLUGIN
             value: quay.io/netobserv/network-observability-console-plugin:v1.9.2-community
           - name: RELATED_IMAGE_CONSOLE_PLUGIN_COMPAT
-            value: quay.io/netobserv/network-observability-console-plugin-pf4:v1.8.2-community
+            value: quay.io/netobserv/network-observability-console-plugin:v1.9.2-community-pf4
           - name: DOWNSTREAM_DEPLOYMENT
             value: "false"
           - name: PROFILING_BIND_ADDRESS


### PR DESCRIPTION
The Makefile was screwing up the bundle when running first `make deploy` then `make update-bundle` (we had to manually discard changes from `make deploy` before running  `make update-bundle`  to avoid that)

This change updates all `sed` commands when updating manager.yaml so that it substitute next lines based on RELATED_IMAGE_X.

Note that we actually don't provide a plugin compat image in the community releases, so the tag `v1.9.2-community-pf4` is essentially a placeholder here. But we do support creating upstream OLM bundle/catalog for testing purpose, and this must work as well with compat images.