### PR TITLE
Fixing np default deployment after upgrade

### DIFF
--- a/api/flowcollector/v1beta2/flowcollector_types.go
+++ b/api/flowcollector/v1beta2/flowcollector_types.go
@@ -93,7 +93,7 @@ type FlowCollectorSpec struct {
 }
 
 type NetworkPolicy struct {
-	// Set `enable` to `true` to deploy network policies on the namespaces used by NetObserv (main and privileged). It is disabled by default.
+	// Deploys network policies on the namespaces used by NetObserv (main and privileged).
 	// These network policies better isolate the NetObserv components to prevent undesired connections to them.
 	// This option is enabled by default, disable it to manually manage network policies
 	// +optional

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -4261,7 +4261,7 @@ spec:
                     type: array
                   enable:
                     description: |-
-                      Set `enable` to `true` to deploy network policies on the namespaces used by NetObserv (main and privileged). It is disabled by default.
+                      Deploys network policies on the namespaces used by NetObserv (main and privileged).
                       These network policies better isolate the NetObserv components to prevent undesired connections to them.
                       This option is enabled by default, disable it to manually manage network policies
                     type: boolean

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -253,7 +253,7 @@ metadata:
     categories: Monitoring, Networking, Observability
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: quay.io/netobserv/network-observability-operator:1.9.2-community
-    createdAt: "2025-09-29T15:00:44Z"
+    createdAt: "2025-09-30T17:05:14Z"
     description: Network flows collector and monitoring solution
     operatorframework.io/initialization-resource: '{"apiVersion":"flows.netobserv.io/v1beta2",
       "kind":"FlowCollector","metadata":{"name":"cluster"},"spec": {}}'

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -3909,7 +3909,7 @@ spec:
                       type: array
                     enable:
                       description: |-
-                        Set `enable` to `true` to deploy network policies on the namespaces used by NetObserv (main and privileged). It is disabled by default.
+                        Deploys network policies on the namespaces used by NetObserv (main and privileged).
                         These network policies better isolate the NetObserv components to prevent undesired connections to them.
                         This option is enabled by default, disable it to manually manage network policies
                       type: boolean

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -8351,7 +8351,7 @@ configuration, you can disable it and install your own instead.<br/>
         <td><b>enable</b></td>
         <td>boolean</td>
         <td>
-          Set `enable` to `true` to deploy network policies on the namespaces used by NetObserv (main and privileged). It is disabled by default.
+          Deploys network policies on the namespaces used by NetObserv (main and privileged).
 These network policies better isolate the NetObserv components to prevent undesired connections to them.
 This option is enabled by default, disable it to manually manage network policies<br/>
         </td>

--- a/helm/crds/flows.netobserv.io_flowcollectors.yaml
+++ b/helm/crds/flows.netobserv.io_flowcollectors.yaml
@@ -3913,7 +3913,7 @@ spec:
                       type: array
                     enable:
                       description: |-
-                        Set `enable` to `true` to deploy network policies on the namespaces used by NetObserv (main and privileged). It is disabled by default.
+                        Deploys network policies on the namespaces used by NetObserv (main and privileged).
                         These network policies better isolate the NetObserv components to prevent undesired connections to them.
                         This option is enabled by default, disable it to manually manage network policies
                       type: boolean


### PR DESCRIPTION
## Description

The default value is now set at the section level.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
