### PR TITLE
NETOBSERV-631: show subnet labels in topology

### DIFF
--- a/internal/controller/consoleplugin/config/static-frontend-config.yaml
+++ b/internal/controller/consoleplugin/config/static-frontend-config.yaml
@@ -1159,6 +1159,8 @@ scopes:
       - DstK8S_OwnerType
       - SrcK8S_Namespace
       - DstK8S_Namespace
+      - SrcSubnetLabel
+      - DstSubnetLabel
     groups:
       - clusters
       - clusters+zones
@@ -1190,6 +1192,7 @@ scopes:
       - SrcK8S_Namespace
       - SrcAddr
       - SrcK8S_HostName
+      - SrcSubnetLabel
       - DstK8S_Name
       - DstK8S_Type
       - DstK8S_OwnerName
@@ -1197,6 +1200,7 @@ scopes:
       - DstK8S_Namespace
       - DstAddr
       - DstK8S_HostName
+      - DstSubnetLabel
     groups:
       - clusters
       - clusters+zones


### PR DESCRIPTION
## Description

Add Src/DstSubnetLabel to data fetched for resource and owner topo scopes

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
- Console plugin: https://github.com/netobserv/network-observability-console-plugin/pull/1048

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
