### PR TITLE
NETOBSERV-2434: fix default tolerations, and a few other issues

### DIFF
--- a/internal/controller/consoleplugin/consoleplugin_test.go
+++ b/internal/controller/consoleplugin/consoleplugin_test.go
@@ -191,6 +191,19 @@ func TestContainerUpdateCheck(t *testing.T) {
 	assert.Contains(report.String(), "Volumes changed")
 	old = nEw
 
+	// new toleration
+	spec.ConsolePlugin.Advanced = &flowslatest.AdvancedPluginConfig{
+		Scheduling: &flowslatest.SchedulingConfig{
+			Tolerations: []corev1.Toleration{{Key: "dummy-key", Operator: corev1.TolerationOpExists}},
+		},
+	}
+	builder = getBuilder(&spec, &loki)
+	nEw = builder.deployment(constants.PluginName, "digest")
+	report = helper.NewChangeReport("")
+	assert.True(helper.PodChanged(&old.Spec.Template, &nEw.Spec.Template, constants.PluginName, &report))
+	assert.Contains(report.String(), "Toleration changed")
+	old = nEw
+
 	// test again no change
 	loki.LokiManualParams.TLS.CACert.Name = "cm-name-2"
 	builder = getBuilder(&spec, &loki)

--- a/internal/controller/ebpf/agent_controller.go
+++ b/internal/controller/ebpf/agent_controller.go
@@ -460,7 +460,7 @@ func (c *AgentController) envConfig(ctx context.Context, coll *flowslatest.FlowC
 		}
 	} else {
 		config = append(config, corev1.EnvVar{Name: envExport, Value: exportGRPC})
-		advancedConfig := helper.GetAdvancedProcessorConfig(coll.Spec.Processor.Advanced)
+		advancedConfig := helper.GetAdvancedProcessorConfig(&coll.Spec)
 		// When flowlogs-pipeline is deployed as a daemonset, each agent must send
 		// data to the pod that is deployed in the same host
 		config = append(config, corev1.EnvVar{

--- a/internal/controller/flp/flp_common_objects.go
+++ b/internal/controller/flp/flp_common_objects.go
@@ -35,7 +35,7 @@ const (
 
 func newGRPCPipeline(desired *flowslatest.FlowCollectorSpec) config.PipelineBuilderStage {
 	return config.NewGRPCPipeline("grpc", api.IngestGRPCProto{
-		Port: int(*helper.GetAdvancedProcessorConfig(desired.Processor.Advanced).Port),
+		Port: int(*helper.GetAdvancedProcessorConfig(desired).Port),
 	})
 }
 
@@ -80,7 +80,7 @@ func podTemplate(
 	hasHostPort, hostNetwork bool,
 	annotations map[string]string,
 ) corev1.PodTemplateSpec {
-	advancedConfig := helper.GetAdvancedProcessorConfig(desired.Processor.Advanced)
+	advancedConfig := helper.GetAdvancedProcessorConfig(desired)
 	var ports []corev1.ContainerPort
 	if hasHostPort {
 		ports = []corev1.ContainerPort{{
@@ -231,7 +231,7 @@ func metricsSettings(desired *flowslatest.FlowCollectorSpec, vol *volumes.Builde
 
 func getStaticJSONConfig(desired *flowslatest.FlowCollectorSpec, vol *volumes.Builder, promTLS *flowslatest.CertificateReference, pipeline *PipelineBuilder, dynCMName string) (string, error) {
 	metricsSettings := metricsSettings(desired, vol, promTLS)
-	advancedConfig := helper.GetAdvancedProcessorConfig(desired.Processor.Advanced)
+	advancedConfig := helper.GetAdvancedProcessorConfig(desired)
 	config := map[string]interface{}{
 		"log-level": desired.Processor.LogLevel,
 		"health": map[string]interface{}{

--- a/internal/controller/flp/flp_pipeline_builder.go
+++ b/internal/controller/flp/flp_pipeline_builder.go
@@ -553,7 +553,7 @@ func (b *PipelineBuilder) addConnectionTracking(lastStage config.PipelineBuilder
 	// Connection tracking stage (only if LogTypes is not FLOWS)
 	if b.desired.Processor.HasConntrack() {
 		outputRecordTypes := helper.GetRecordTypes(&b.desired.Processor)
-		advancedConfig := helper.GetAdvancedProcessorConfig(b.desired.Processor.Advanced)
+		advancedConfig := helper.GetAdvancedProcessorConfig(b.desired)
 		lastStage = lastStage.ConnTrack("extract_conntrack", api.ConnTrack{
 			KeyDefinition: api.KeyDefinition{
 				FieldGroups: []api.FieldGroup{

--- a/internal/pkg/helper/comparators.go
+++ b/internal/pkg/helper/comparators.go
@@ -102,6 +102,12 @@ func assignationChanged(old, n *corev1.PodTemplateSpec, report *ChangeReport) bo
 		}
 		return true
 	}
+	if !deepEqual(n.Spec.Tolerations, old.Spec.Tolerations) {
+		if report != nil {
+			report.Add("Toleration changed")
+		}
+		return true
+	}
 	if !deepDerivative(n.Spec.Affinity, old.Spec.Affinity) {
 		if report != nil {
 			report.Add("Affinity changed")

--- a/internal/pkg/helper/flowcollector.go
+++ b/internal/pkg/helper/flowcollector.go
@@ -132,10 +132,10 @@ func GetAdvancedAgentConfig(specConfig *flowslatest.AdvancedAgentConfig) flowsla
 			cfg.Env = specConfig.Env
 		}
 		if specConfig.Scheduling != nil {
-			if len(specConfig.Scheduling.NodeSelector) > 0 {
+			if specConfig.Scheduling.NodeSelector != nil {
 				cfg.Scheduling.NodeSelector = specConfig.Scheduling.NodeSelector
 			}
-			if len(specConfig.Scheduling.Tolerations) > 0 {
+			if specConfig.Scheduling.Tolerations != nil {
 				cfg.Scheduling.Tolerations = specConfig.Scheduling.Tolerations
 			}
 			if specConfig.Scheduling.Affinity != nil {
@@ -150,7 +150,11 @@ func GetAdvancedAgentConfig(specConfig *flowslatest.AdvancedAgentConfig) flowsla
 	return cfg
 }
 
-func GetAdvancedProcessorConfig(specConfig *flowslatest.AdvancedProcessorConfig) flowslatest.AdvancedProcessorConfig {
+func GetAdvancedProcessorConfig(spec *flowslatest.FlowCollectorSpec) flowslatest.AdvancedProcessorConfig {
+	var defaultToleration []corev1.Toleration
+	if !UseKafka(spec) { // TODO: with coming-soon Service deploymentModel, this should be replaced with "UseHostNetwork" (conflict should pop up while rebasing).
+		defaultToleration = []corev1.Toleration{{Operator: corev1.TolerationOpExists}}
+	}
 	cfg := flowslatest.AdvancedProcessorConfig{
 		Env:                            map[string]string{},
 		Port:                           ptr.To(GetFieldDefaultInt32(ProcessorAdvancedPath, "port")),
@@ -162,12 +166,13 @@ func GetAdvancedProcessorConfig(specConfig *flowslatest.AdvancedProcessorConfig)
 		ConversationTerminatingTimeout: ptr.To(GetFieldDefaultDuration(ProcessorAdvancedPath, "conversationTerminatingTimeout")),
 		Scheduling: &flowslatest.SchedulingConfig{
 			NodeSelector:      map[string]string{},
-			Tolerations:       []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+			Tolerations:       defaultToleration,
 			Affinity:          nil,
 			PriorityClassName: "",
 		},
 	}
 
+	specConfig := spec.Processor.Advanced
 	if specConfig != nil {
 		if len(specConfig.Env) > 0 {
 			cfg.Env = specConfig.Env
@@ -197,10 +202,10 @@ func GetAdvancedProcessorConfig(specConfig *flowslatest.AdvancedProcessorConfig)
 			cfg.ConversationTerminatingTimeout = specConfig.ConversationTerminatingTimeout
 		}
 		if specConfig.Scheduling != nil {
-			if len(specConfig.Scheduling.NodeSelector) > 0 {
+			if specConfig.Scheduling.NodeSelector != nil {
 				cfg.Scheduling.NodeSelector = specConfig.Scheduling.NodeSelector
 			}
-			if len(specConfig.Scheduling.Tolerations) > 0 {
+			if specConfig.Scheduling.Tolerations != nil {
 				cfg.Scheduling.Tolerations = specConfig.Scheduling.Tolerations
 			}
 			if specConfig.Scheduling.Affinity != nil {
@@ -249,7 +254,7 @@ func GetAdvancedPluginConfig(specConfig *flowslatest.AdvancedPluginConfig) flows
 		Port:     ptr.To(GetFieldDefaultInt32(PluginAdvancedPath, "port")),
 		Scheduling: &flowslatest.SchedulingConfig{
 			NodeSelector:      map[string]string{},
-			Tolerations:       []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+			Tolerations:       nil,
 			Affinity:          nil,
 			PriorityClassName: "",
 		},
@@ -269,10 +274,10 @@ func GetAdvancedPluginConfig(specConfig *flowslatest.AdvancedPluginConfig) flows
 			cfg.Port = specConfig.Port
 		}
 		if specConfig.Scheduling != nil {
-			if len(specConfig.Scheduling.NodeSelector) > 0 {
+			if specConfig.Scheduling.NodeSelector != nil {
 				cfg.Scheduling.NodeSelector = specConfig.Scheduling.NodeSelector
 			}
-			if len(specConfig.Scheduling.Tolerations) > 0 {
+			if specConfig.Scheduling.Tolerations != nil {
 				cfg.Scheduling.Tolerations = specConfig.Scheduling.Tolerations
 			}
 			if specConfig.Scheduling.Affinity != nil {


### PR DESCRIPTION
## Description

- Do not set default toleration on console plugin and FLP transfo (keep for FLP monolith as they must have a scheduling config consistent with agent pods)
- Allow override Tolerations and NodeSelectors with empty values
- Check for Toleration changes for reconcile triggers
- Add tests
- Add validation webhook to warn about inconsistent scheduling between Agent and FLP in direct mode


## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
