### PR TITLE
New "part-of" label on all pods / resources

### DIFF
--- a/bundle/manifests/netobserv-manager-config_v1_configmap.yaml
+++ b/bundle/manifests/netobserv-manager-config_v1_configmap.yaml
@@ -16,4 +16,5 @@ kind: ConfigMap
 metadata:
   labels:
     app: netobserv-operator
+    part-of: netobserv-operator
   name: netobserv-manager-config

--- a/bundle/manifests/netobserv-metrics-service_v1_service.yaml
+++ b/bundle/manifests/netobserv-metrics-service_v1_service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: netobserv-operator
     control-plane: controller-manager
+    part-of: netobserv-operator
   name: netobserv-metrics-service
 spec:
   ports:
@@ -17,5 +18,6 @@ spec:
   selector:
     app: netobserv-operator
     control-plane: controller-manager
+    part-of: netobserv-operator
 status:
   loadBalancer: {}

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -253,7 +253,7 @@ metadata:
     categories: Monitoring, Networking, Observability
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: quay.io/netobserv/network-observability-operator:1.9.2-community
-    createdAt: "2025-10-01T10:32:51Z"
+    createdAt: "2025-10-06T09:16:35Z"
     description: Network flows collector and monitoring solution
     operatorframework.io/initialization-resource: '{"apiVersion":"flows.netobserv.io/v1beta2",
       "kind":"FlowCollector","metadata":{"name":"cluster"},"spec": {}}'
@@ -1034,6 +1034,7 @@ spec:
       - label:
           app: netobserv-operator
           control-plane: controller-manager
+          part-of: netobserv-operator
         name: netobserv-controller-manager
         spec:
           replicas: 1
@@ -1041,12 +1042,14 @@ spec:
             matchLabels:
               app: netobserv-operator
               control-plane: controller-manager
+              part-of: netobserv-operator
           strategy: {}
           template:
             metadata:
               labels:
                 app: netobserv-operator
                 control-plane: controller-manager
+                part-of: netobserv-operator
             spec:
               containers:
               - args:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -19,3 +19,4 @@ labels:
 - includeSelectors: true
   pairs:
     app: netobserv-operator
+    part-of: netobserv-operator

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: netobserv-controller-manager
   labels:
+    part-of: netobserv-operator
     app: netobserv-operator
     control-plane: controller-manager
 spec:
@@ -15,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        part-of: netobserv-operator
         app: netobserv-operator
         control-plane: controller-manager
     spec:

--- a/helm/templates/netobserv-manager-config_v1_configmap.yaml
+++ b/helm/templates/netobserv-manager-config_v1_configmap.yaml
@@ -16,4 +16,5 @@ kind: ConfigMap
 metadata:
   labels:
     app: netobserv-operator
+    part-of: netobserv-operator
   name: netobserv-manager-config

--- a/helm/templates/netobserv-metrics-service_v1_service.yaml
+++ b/helm/templates/netobserv-metrics-service_v1_service.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: netobserv-operator
     control-plane: controller-manager
+    part-of: netobserv-operator
   name: netobserv-metrics-service
 spec:
   ports:
@@ -15,5 +16,6 @@ spec:
   selector:
     app: netobserv-operator
     control-plane: controller-manager
+    part-of: netobserv-operator
 status:
   loadBalancer: {}

--- a/internal/controller/consoleplugin/consoleplugin_objects.go
+++ b/internal/controller/consoleplugin/consoleplugin_objects.go
@@ -64,6 +64,7 @@ func newBuilder(info *reconcilers.Instance, desired *flowslatest.FlowCollectorSp
 		info:     info,
 		imageRef: imageToUse,
 		labels: map[string]string{
+			"part-of": constants.OperatorName,
 			"app":     name,
 			"version": helper.MaxLabelLength(version),
 		},

--- a/internal/controller/consoleplugin/consoleplugin_test.go
+++ b/internal/controller/consoleplugin/consoleplugin_test.go
@@ -404,13 +404,16 @@ func TestLabels(t *testing.T) {
 	// Deployment
 	depl := builder.deployment(constants.PluginName, "digest")
 	assert.Equal("netobserv-plugin", depl.Labels["app"])
+	assert.Equal(constants.OperatorName, depl.Labels["part-of"])
 	assert.Equal("netobserv-plugin", depl.Spec.Template.Labels["app"])
+	assert.Equal(constants.OperatorName, depl.Spec.Template.Labels["part-of"])
 	assert.Equal("dev", depl.Labels["version"])
 	assert.Equal("dev", depl.Spec.Template.Labels["version"])
 
 	// Service
 	svc := builder.mainService(constants.PluginName)
 	assert.Equal("netobserv-plugin", svc.Labels["app"])
+	assert.Equal(constants.OperatorName, svc.Labels["part-of"])
 	assert.Equal("netobserv-plugin", svc.Spec.Selector["app"])
 	assert.Equal("dev", svc.Labels["version"])
 	assert.Empty(svc.Spec.Selector["version"])

--- a/internal/controller/ebpf/agent_controller.go
+++ b/internal/controller/ebpf/agent_controller.go
@@ -366,6 +366,7 @@ func (c *AgentController) desired(ctx context.Context, coll *flowslatest.FlowCol
 			Name:      constants.EBPFAgentName,
 			Namespace: c.PrivilegedNamespace(),
 			Labels: map[string]string{
+				"part-of": constants.OperatorName,
 				"app":     constants.EBPFAgentName,
 				"version": helper.MaxLabelLength(version),
 			},
@@ -376,7 +377,10 @@ func (c *AgentController) desired(ctx context.Context, coll *flowslatest.FlowCol
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{"app": constants.EBPFAgentName},
+					Labels: map[string]string{
+						"part-of": constants.OperatorName,
+						"app":     constants.EBPFAgentName,
+					},
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{

--- a/internal/controller/ebpf/agent_metrics.go
+++ b/internal/controller/ebpf/agent_metrics.go
@@ -57,7 +57,8 @@ func (c *AgentController) promService(target *flowslatest.FlowCollectorEBPF) *co
 			Name:      constants.EBPFAgentMetricsSvcName,
 			Namespace: c.PrivilegedNamespace(),
 			Labels: map[string]string{
-				"app": constants.EBPFAgentName,
+				"part-of": constants.OperatorName,
+				"app":     constants.EBPFAgentName,
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -88,7 +89,8 @@ func (c *AgentController) promServiceMonitoring(target *flowslatest.FlowCollecto
 			Name:      constants.EBPFAgentMetricsSvcMonitoringName,
 			Namespace: c.PrivilegedNamespace(),
 			Labels: map[string]string{
-				"app": constants.EBPFAgentName,
+				"part-of": constants.OperatorName,
+				"app":     constants.EBPFAgentName,
 			},
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
@@ -140,7 +142,8 @@ func (c *AgentController) agentPrometheusRule(target *flowslatest.FlowCollectorE
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.EBPFAgentPromAlertRule,
 			Labels: map[string]string{
-				"app": constants.EBPFAgentName,
+				"part-of": constants.OperatorName,
+				"app":     constants.EBPFAgentName,
 			},
 			Namespace: c.PrivilegedNamespace(),
 		},

--- a/internal/controller/flp/flp_common_objects.go
+++ b/internal/controller/flp/flp_common_objects.go
@@ -173,7 +173,11 @@ func podTemplate(
 	annotations["prometheus.io/scrape_port"] = fmt.Sprint(desired.Processor.GetMetricsPort())
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      map[string]string{"app": appName, "version": version},
+			Labels: map[string]string{
+				"part-of": constants.OperatorName,
+				"app":     appName,
+				"version": version,
+			},
 			Annotations: annotations,
 		},
 		Spec: corev1.PodSpec{
@@ -197,7 +201,10 @@ func configMap(name, namespace, data, appName string) (*corev1.ConfigMap, string
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    map[string]string{"app": appName},
+			Labels: map[string]string{
+				"part-of": constants.OperatorName,
+				"app":     appName,
+			},
 		},
 		Data: map[string]string{
 			configFile: data,
@@ -275,7 +282,10 @@ func promService(desired *flowslatest.FlowCollectorSpec, svcName, namespace, app
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      svcName,
 			Namespace: namespace,
-			Labels:    map[string]string{"app": appLabel},
+			Labels: map[string]string{
+				"part-of": constants.OperatorName,
+				"app":     appLabel,
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{"app": appLabel},
@@ -305,7 +315,11 @@ func serviceMonitor(desired *flowslatest.FlowCollectorSpec, smName, svcName, nam
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      smName,
 			Namespace: namespace,
-			Labels:    map[string]string{"app": appLabel, "version": version},
+			Labels: map[string]string{
+				"part-of": constants.OperatorName,
+				"app":     appLabel,
+				"version": version,
+			},
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{
@@ -349,8 +363,12 @@ func serviceMonitor(desired *flowslatest.FlowCollectorSpec, smName, svcName, nam
 func prometheusRule(rules []monitoringv1.Rule, ruleName, namespace, appLabel, version string) *monitoringv1.PrometheusRule {
 	flpPrometheusRuleObject := monitoringv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ruleName,
-			Labels:    map[string]string{"app": appLabel, "version": version},
+			Name: ruleName,
+			Labels: map[string]string{
+				"part-of": constants.OperatorName,
+				"app":     appLabel,
+				"version": version,
+			},
 			Namespace: namespace,
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{

--- a/internal/controller/flp/flp_monolith_objects.go
+++ b/internal/controller/flp/flp_monolith_objects.go
@@ -49,19 +49,6 @@ func newMonolithBuilder(info *reconcilers.Instance, desired *flowslatest.FlowCol
 	}, nil
 }
 
-func (b *monolithBuilder) appLabel() map[string]string {
-	return map[string]string{
-		"app": monoName,
-	}
-}
-
-func (b *monolithBuilder) appVersionLabels() map[string]string {
-	return map[string]string{
-		"app":     monoName,
-		"version": b.version,
-	}
-}
-
 func (b *monolithBuilder) daemonSet(annotations map[string]string) *appsv1.DaemonSet {
 	pod := podTemplate(
 		monoName,
@@ -78,11 +65,15 @@ func (b *monolithBuilder) daemonSet(annotations map[string]string) *appsv1.Daemo
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      monoName,
 			Namespace: b.info.Namespace,
-			Labels:    b.appVersionLabels(),
+			Labels: map[string]string{
+				"part-of": constants.OperatorName,
+				"app":     monoName,
+				"version": b.version,
+			},
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: b.appLabel(),
+				MatchLabels: map[string]string{"app": monoName},
 			},
 			Template: pod,
 		},
@@ -142,7 +133,10 @@ func (b *monolithBuilder) serviceAccount() *corev1.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      monoName,
 			Namespace: b.info.Namespace,
-			Labels:    b.appLabel(),
+			Labels: map[string]string{
+				"part-of": constants.OperatorName,
+				"app":     monoName,
+			},
 		},
 	}
 }

--- a/internal/controller/flp/flp_test.go
+++ b/internal/controller/flp/flp_test.go
@@ -635,6 +635,7 @@ func TestConfigMapShouldDeserializeAsJSONWithLokiManual(t *testing.T) {
 	assert.NotEmpty(t, digest)
 
 	assert.Equal("flowlogs-pipeline", cm.Labels["app"])
+	assert.Equal(constants.OperatorName, cm.Labels["part-of"])
 
 	data, ok := cm.Data[configFile]
 	assert.True(ok)
@@ -769,6 +770,8 @@ func TestLabels(t *testing.T) {
 	depl := tBuilder.deployment(annotate("digest"))
 	assert.Equal("flowlogs-pipeline-transformer", depl.Labels["app"])
 	assert.Equal("flowlogs-pipeline-transformer", depl.Spec.Template.Labels["app"])
+	assert.Equal(constants.OperatorName, depl.Labels["part-of"])
+	assert.Equal(constants.OperatorName, depl.Spec.Template.Labels["part-of"])
 	assert.Equal("dev", depl.Labels["version"])
 	assert.Equal("dev", depl.Spec.Template.Labels["version"])
 
@@ -776,6 +779,8 @@ func TestLabels(t *testing.T) {
 	ds := builder.daemonSet(annotate("digest"))
 	assert.Equal("flowlogs-pipeline", ds.Labels["app"])
 	assert.Equal("flowlogs-pipeline", ds.Spec.Template.Labels["app"])
+	assert.Equal(constants.OperatorName, ds.Labels["part-of"])
+	assert.Equal(constants.OperatorName, ds.Spec.Template.Labels["part-of"])
 	assert.Equal("dev", ds.Labels["version"])
 	assert.Equal("dev", ds.Spec.Template.Labels["version"])
 
@@ -783,6 +788,7 @@ func TestLabels(t *testing.T) {
 	svc := builder.promService()
 	assert.Equal("flowlogs-pipeline", svc.Labels["app"])
 	assert.Equal("flowlogs-pipeline", svc.Spec.Selector["app"])
+	assert.Equal(constants.OperatorName, svc.Labels["part-of"])
 	assert.Empty(svc.Labels["version"])
 	assert.Empty(svc.Spec.Selector["version"])
 
@@ -790,9 +796,11 @@ func TestLabels(t *testing.T) {
 	smMono := builder.serviceMonitor()
 	assert.Equal("flowlogs-pipeline-monitor", smMono.Name)
 	assert.Equal("flowlogs-pipeline", smMono.Spec.Selector.MatchLabels["app"])
+	assert.Equal(constants.OperatorName, smMono.Labels["part-of"])
 	smTrans := tBuilder.serviceMonitor()
 	assert.Equal("flowlogs-pipeline-transformer-monitor", smTrans.Name)
 	assert.Equal("flowlogs-pipeline-transformer", smTrans.Spec.Selector.MatchLabels["app"])
+	assert.Equal(constants.OperatorName, smMono.Labels["part-of"])
 }
 
 func TestToleration(t *testing.T) {

--- a/internal/controller/flp/flp_transfo_objects.go
+++ b/internal/controller/flp/flp_transfo_objects.go
@@ -50,19 +50,6 @@ func newTransfoBuilder(info *reconcilers.Instance, desired *flowslatest.FlowColl
 	}, nil
 }
 
-func (b *transfoBuilder) appLabel() map[string]string {
-	return map[string]string{
-		"app": transfoName,
-	}
-}
-
-func (b *transfoBuilder) appVersionLabels() map[string]string {
-	return map[string]string{
-		"app":     transfoName,
-		"version": b.version,
-	}
-}
-
 func (b *transfoBuilder) deployment(annotations map[string]string) *appsv1.Deployment {
 	pod := podTemplate(
 		transfoName,
@@ -79,12 +66,16 @@ func (b *transfoBuilder) deployment(annotations map[string]string) *appsv1.Deplo
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      transfoName,
 			Namespace: b.info.Namespace,
-			Labels:    b.appVersionLabels(),
+			Labels: map[string]string{
+				"part-of": constants.OperatorName,
+				"app":     transfoName,
+				"version": b.version,
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: b.desired.Processor.KafkaConsumerReplicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: b.appLabel(),
+				MatchLabels: map[string]string{"app": transfoName},
 			},
 			Template: pod,
 		},
@@ -144,7 +135,10 @@ func (b *transfoBuilder) autoScaler() *ascv2.HorizontalPodAutoscaler {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      transfoName,
 			Namespace: b.info.Namespace,
-			Labels:    b.appLabel(),
+			Labels: map[string]string{
+				"part-of": constants.OperatorName,
+				"app":     transfoName,
+			},
 		},
 		Spec: ascv2.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: ascv2.CrossVersionObjectReference{
@@ -164,7 +158,10 @@ func (b *transfoBuilder) serviceAccount() *corev1.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      transfoName,
 			Namespace: b.info.Namespace,
-			Labels:    b.appLabel(),
+			Labels: map[string]string{
+				"part-of": constants.OperatorName,
+				"app":     transfoName,
+			},
 		},
 	}
 }

--- a/internal/pkg/resources/roles.go
+++ b/internal/pkg/resources/roles.go
@@ -23,7 +23,10 @@ func GetRoleBinding(namespace, shortName, app, sa string, ref constants.RoleName
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      string(ref) + "-" + shortName,
 			Namespace: namespace,
-			Labels:    map[string]string{"app": app},
+			Labels: map[string]string{
+				"part-of": constants.OperatorName,
+				"app":     app,
+			},
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",


### PR DESCRIPTION
## Description

Introduce the "part-of" label to designate by labels all resources part of the netobserv operator installation & operation.

This aims to simplify user workflow if they need to do something related to all netobserv resources; such as configuring a network policy that only target netobserv pods, for instance. Or simply it can help them better understand what's part of netobserv without prior knowledge.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
