### PR TITLE
Add validation hook for network policies when Loki in same namespace

### DIFF
--- a/api/flowcollector/v1beta2/helper.go
+++ b/api/flowcollector/v1beta2/helper.go
@@ -192,3 +192,7 @@ func (spec *FlowCollectorSpec) HasExperimentalAlertsHealth() bool {
 	}
 	return false
 }
+
+func (spec *FlowCollectorSpec) DeployNetworkPolicy() bool {
+	return spec.NetworkPolicy.Enable != nil && *spec.NetworkPolicy.Enable
+}

--- a/internal/controller/networkpolicy/np_objects.go
+++ b/internal/controller/networkpolicy/np_objects.go
@@ -27,7 +27,7 @@ func buildMainNetworkPolicy(desired *flowslatest.FlowCollector, mgr *manager.Man
 	ns := desired.Spec.GetNamespace()
 
 	name := types.NamespacedName{Name: netpolName, Namespace: ns}
-	if !helper.DeployNetworkPolicy(&desired.Spec) {
+	if !desired.Spec.DeployNetworkPolicy() {
 		return name, nil
 	}
 
@@ -191,7 +191,7 @@ func buildPrivilegedNetworkPolicy(desired *flowslatest.FlowCollector, mgr *manag
 	privNs := mainNs + constants.EBPFPrivilegedNSSuffix
 
 	name := types.NamespacedName{Name: netpolName, Namespace: privNs}
-	if !helper.DeployNetworkPolicy(&desired.Spec) {
+	if !desired.Spec.DeployNetworkPolicy() {
 		return name, nil
 	}
 

--- a/internal/pkg/helper/flowcollector.go
+++ b/internal/pkg/helper/flowcollector.go
@@ -25,10 +25,6 @@ func UseKafka(spec *flowslatest.FlowCollectorSpec) bool {
 	return spec.DeploymentModel == flowslatest.DeploymentModelKafka
 }
 
-func DeployNetworkPolicy(spec *flowslatest.FlowCollectorSpec) bool {
-	return spec.NetworkPolicy.Enable != nil && *spec.NetworkPolicy.Enable
-}
-
 func HasKafkaExporter(spec *flowslatest.FlowCollectorSpec) bool {
 	for _, ex := range spec.Exporters {
 		if ex.Type == flowslatest.KafkaExporter {


### PR DESCRIPTION
## Description

We recommend to install Loki in a different namespace; if users still want to use the same ns, they need to disable the network policy and possibly create their own.

This webhook deals with these restrictions by rejecting invalid config.


## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
