### PR TITLE
NETOBSERV-2441: fix netpol for upstream deployment

### DIFF
--- a/internal/controller/networkpolicy/np_objects.go
+++ b/internal/controller/networkpolicy/np_objects.go
@@ -95,26 +95,21 @@ func buildMainNetworkPolicy(desired *flowslatest.FlowCollector, mgr *manager.Man
 				}},
 			})
 		}
+		np.Spec.Egress = append(np.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
+			// Console plugin pod needs access to cluster monitoring, see its configured URL, even with upstream deployment
+			To: []networkingv1.NetworkPolicyPeer{
+				peerInNamespace(constants.MonitoringNamespace),
+			},
+		})
 		if mgr.Config.DownstreamDeployment {
 			np.Spec.Ingress = append(np.Spec.Ingress, networkingv1.NetworkPolicyIngressRule{
 				From: []networkingv1.NetworkPolicyPeer{
 					peerInNamespace(constants.MonitoringNamespace),
 				},
 			})
-			np.Spec.Egress = append(np.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
-				To: []networkingv1.NetworkPolicyPeer{
-					peerInNamespace(constants.MonitoringNamespace),
-				},
-			})
-
 		} else {
 			np.Spec.Ingress = append(np.Spec.Ingress, networkingv1.NetworkPolicyIngressRule{
 				From: []networkingv1.NetworkPolicyPeer{
-					peerInNamespace(constants.UWMonitoringNamespace),
-				},
-			})
-			np.Spec.Egress = append(np.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
-				To: []networkingv1.NetworkPolicyPeer{
 					peerInNamespace(constants.UWMonitoringNamespace),
 				},
 			})


### PR DESCRIPTION
## Description

Upstream openshift deployment needs egress connection to openshift-monitoring (from the console plugin pods), not user-workload-monitoring, which is only used for ingestion but not for queries.

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
