### PR TITLE
NETOBSERV-2438: enforce validation on subnet names

### DIFF
--- a/api/flowcollector/v1beta2/flowcollector_types.go
+++ b/api/flowcollector/v1beta2/flowcollector_types.go
@@ -1418,7 +1418,9 @@ type SubnetLabel struct {
 	// List of CIDRs, such as `["1.2.3.4/32"]`.
 	//+required
 	CIDRs []string `json:"cidrs,omitempty"` // Note, starting with k8s 1.31 / ocp 4.16 there's a new way to validate CIDR such as `+kubebuilder:validation:XValidation:rule="isCIDR(self)",message="field should be in CIDR notation format"`. But older versions would reject the CRD so we cannot implement it now to maintain compatibility.
+
 	// Label name, used to flag matching flows.
+	// +kubebuilder:validation:Pattern:="^[a-zA-Z_:-][a-zA-Z0-9_:-]*$"
 	//+required
 	Name string `json:"name,omitempty"`
 }

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -6113,6 +6113,7 @@ spec:
                               type: array
                             name:
                               description: Label name, used to flag matching flows.
+                              pattern: ^[a-zA-Z_:-][a-zA-Z0-9_:-]*$
                               type: string
                           required:
                           - cidrs

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -5648,6 +5648,7 @@ spec:
                                 type: array
                               name:
                                 description: Label name, used to flag matching flows.
+                                pattern: ^[a-zA-Z_:-][a-zA-Z0-9_:-]*$
                                 type: string
                             required:
                               - cidrs

--- a/config/samples/flowmetrics/cluster_external_egress_traffic.yaml
+++ b/config/samples/flowmetrics/cluster_external_egress_traffic.yaml
@@ -9,10 +9,13 @@ spec:
   type: Counter
   valueField: Bytes
   direction: Egress
-  labels: [SrcK8S_HostName,SrcK8S_Namespace,SrcK8S_OwnerName,SrcK8S_OwnerType]
+  labels: [SrcK8S_HostName,SrcK8S_Namespace,SrcK8S_OwnerName,SrcK8S_OwnerType,DstSubnetLabel]
   filters:
   - field: DstSubnetLabel
     matchType: Absence
+  - field: DstSubnetLabel
+    matchType: MatchRegex
+    value: "^EXT:.*"
   charts:
   - dashboardName: Main
     title: External egress traffic

--- a/config/samples/flowmetrics/cluster_external_ingress_traffic.yaml
+++ b/config/samples/flowmetrics/cluster_external_ingress_traffic.yaml
@@ -9,10 +9,13 @@ spec:
   type: Counter
   valueField: Bytes
   direction: Ingress
-  labels: [DstK8S_HostName,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType]
+  labels: [DstK8S_HostName,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType,SrcSubnetLabel]
   filters:
   - field: SrcSubnetLabel
     matchType: Absence
+  - field: SrcSubnetLabel
+    matchType: MatchRegex
+    value: "^EXT:.*"
   charts:
   - dashboardName: Main
     title: External ingress traffic

--- a/helm/crds/flows.netobserv.io_flowcollectors.yaml
+++ b/helm/crds/flows.netobserv.io_flowcollectors.yaml
@@ -5652,6 +5652,7 @@ spec:
                                 type: array
                               name:
                                 description: Label name, used to flag matching flows.
+                                pattern: ^[a-zA-Z_:-][a-zA-Z0-9_:-]*$
                                 type: string
                             required:
                               - cidrs


### PR DESCRIPTION
## Description

Enforce validation on subnet names, using regex `^[a-zA-Z_:-][a-zA-Z0-9_:-]*$`
Also standardize using EXT: for external subnet names in sample metrics

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
