### PR TITLE
NETOBSERV-2489: configure agent reconnect timer

### DIFF
--- a/internal/controller/ebpf/agent_controller.go
+++ b/internal/controller/ebpf/agent_controller.go
@@ -38,6 +38,8 @@ const (
 	envFlowsTargetHost            = "TARGET_HOST"
 	envFlowsTargetPort            = "TARGET_PORT"
 	envTargetTLSCACertPath        = "TARGET_TLS_CA_CERT_PATH"
+	envGRPCReconnect              = "GRPC_RECONNECT_TIMER"
+	envGRPCReconnectRnd           = "GRPC_RECONNECT_TIMER_RANDOMIZATION"
 	envSampling                   = "SAMPLING"
 	envExport                     = "EXPORT"
 	envKafkaBrokers               = "KAFKA_BROKERS"
@@ -496,14 +498,19 @@ func (c *AgentController) envConfig(ctx context.Context, coll *flowslatest.FlowC
 				caPath := c.volumes.AddCACertificate(&tlsCfg, "svc-certs")
 				config = append(config, corev1.EnvVar{Name: envTargetTLSCACertPath, Value: caPath})
 			}
-			config = append(config, corev1.EnvVar{
-				Name: envFlowsTargetHost,
-				// NB: trailing dot (...local.) is a DNS optimization for exact name match without extra search
-				Value: fmt.Sprintf("%s.%s.svc.cluster.local.", constants.FLPName, c.Namespace),
-			}, corev1.EnvVar{
-				Name:  envFlowsTargetPort,
-				Value: strconv.Itoa(int(*advancedConfig.Port)),
-			})
+			config = append(config,
+				corev1.EnvVar{
+					Name: envFlowsTargetHost,
+					// NB: trailing dot (...local.) is a DNS optimization for exact name match without extra search
+					Value: fmt.Sprintf("%s.%s.svc.cluster.local.", constants.FLPName, c.Namespace),
+				},
+				corev1.EnvVar{
+					Name:  envFlowsTargetPort,
+					Value: strconv.Itoa(int(*advancedConfig.Port)),
+				},
+				corev1.EnvVar{Name: envGRPCReconnect, Value: "5m"},
+				corev1.EnvVar{Name: envGRPCReconnectRnd, Value: "30s"},
+			)
 		}
 	}
 


### PR DESCRIPTION
## Description

Nothing to configure explicitly, the operator automatically configures the agents with a 5min period for reconnects, when in Service mode

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
Agent: https://github.com/netobserv/netobserv-ebpf-agent/pull/854

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
