### PR TITLE
NETOBSERV-2446: service monitors use EndpointSlice when available

### DIFF
--- a/bundle/manifests/netobserv-expose-metrics_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/netobserv-expose-metrics_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -14,3 +14,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/kind/deployment-prometheus.yaml
+++ b/config/kind/deployment-prometheus.yaml
@@ -12,6 +12,14 @@ rules:
   - list
   - get
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/config/rbac/component_roles.yaml
+++ b/config/rbac/component_roles.yaml
@@ -54,6 +54,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm/templates/netobserv-expose-metrics_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/helm/templates/netobserv-expose-metrics_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -14,3 +14,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/internal/controller/flowcollector_controller.go
+++ b/internal/controller/flowcollector_controller.go
@@ -61,11 +61,6 @@ func Start(ctx context.Context, mgr *manager.Manager) (manager.PostCreateHook, e
 	}
 	if mgr.ClusterInfo.HasConsolePlugin() {
 		builder.Owns(&osv1.ConsolePlugin{}, reconcilers.UpdateOrDeleteOnlyPred)
-	} else {
-		log.Info("Console not detected: the console plugin is not available")
-	}
-	if !mgr.ClusterInfo.HasCNO() {
-		log.Info("CNO not detected: using ovnKubernetes config and reconciler")
 	}
 
 	ctrl, err := builder.Build(&r)

--- a/internal/controller/flp/flp_common_objects.go
+++ b/internal/controller/flp/flp_common_objects.go
@@ -325,9 +325,13 @@ func promService(desired *flowslatest.FlowCollectorSpec, svcName, namespace, app
 	return &svc
 }
 
-func serviceMonitor(desired *flowslatest.FlowCollectorSpec, smName, svcName, namespace, appLabel, version string, isDownstream bool) *monitoringv1.ServiceMonitor {
+func serviceMonitor(desired *flowslatest.FlowCollectorSpec, smName, svcName, namespace, appLabel, version string, isDownstream, useEndpointSlices bool) *monitoringv1.ServiceMonitor {
 	serverName := fmt.Sprintf("%s.%s.svc", svcName, namespace)
 	scheme, smTLS := helper.GetServiceMonitorTLSConfig(&desired.Processor.Metrics.Server.TLS, serverName, isDownstream)
+	var sdRole *monitoringv1.ServiceDiscoveryRole
+	if useEndpointSlices {
+		sdRole = ptr.To(monitoringv1.EndpointSliceRole)
+	}
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      smName,
@@ -339,6 +343,7 @@ func serviceMonitor(desired *flowslatest.FlowCollectorSpec, smName, svcName, nam
 			},
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
+			ServiceDiscoveryRole: sdRole,
 			Endpoints: []monitoringv1.Endpoint{
 				{
 					Port:        prometheusPortName,

--- a/internal/controller/flp/flp_monolith_objects.go
+++ b/internal/controller/flp/flp_monolith_objects.go
@@ -215,6 +215,7 @@ func (b *monolithBuilder) serviceMonitor() *monitoringv1.ServiceMonitor {
 		monoName,
 		b.version,
 		b.info.IsDownstream,
+		b.info.ClusterInfo.HasPromServiceDiscoveryRole(),
 	)
 }
 

--- a/internal/controller/flp/flp_transfo_objects.go
+++ b/internal/controller/flp/flp_transfo_objects.go
@@ -179,6 +179,7 @@ func (b *transfoBuilder) serviceMonitor() *monitoringv1.ServiceMonitor {
 		transfoName,
 		b.version,
 		b.info.IsDownstream,
+		b.info.ClusterInfo.HasPromServiceDiscoveryRole(),
 	)
 }
 

--- a/internal/pkg/cluster/cluster_test.go
+++ b/internal/pkg/cluster/cluster_test.go
@@ -1,10 +1,12 @@
 package cluster
 
 import (
+	"context"
 	"testing"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/assert"
+	apix "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 func TestIsOpenShiftVersionLessThan(t *testing.T) {
@@ -34,4 +36,47 @@ func TestIsOpenShiftVersionAtLeast(t *testing.T) {
 	b, _, err = info.IsOpenShiftVersionAtLeast("4.14.0")
 	assert.NoError(t, err)
 	assert.False(t, b)
+}
+
+func TestGetCRDProperty(t *testing.T) {
+	crd := apix.CustomResourceDefinition{
+		Spec: apix.CustomResourceDefinitionSpec{
+			Versions: []apix.CustomResourceDefinitionVersion{
+				{
+					Name: "v1alpha1",
+					Schema: &apix.CustomResourceValidation{
+						OpenAPIV3Schema: &apix.JSONSchemaProps{
+							Properties: map[string]apix.JSONSchemaProps{
+								"spec": {},
+							},
+						},
+					},
+				},
+				{
+					Name: "v1",
+					Schema: &apix.CustomResourceValidation{
+						OpenAPIV3Schema: &apix.JSONSchemaProps{
+							Properties: map[string]apix.JSONSchemaProps{
+								"spec": {
+									Properties: map[string]apix.JSONSchemaProps{
+										"foo": {
+											Properties: map[string]apix.JSONSchemaProps{
+												"bar": {},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.True(t, hasCRDProperty(context.Background(), &crd, "", "spec.foo.bar"))
+	assert.False(t, hasCRDProperty(context.Background(), &crd, "v1alpha1", "spec.foo.bar"))
+	assert.True(t, hasCRDProperty(context.Background(), &crd, "v1", "spec.foo.bar"))
+	assert.False(t, hasCRDProperty(context.Background(), &crd, "", "spec.foo.bar.baz"))
+	assert.False(t, hasCRDProperty(context.Background(), &crd, "v2", "spec"))
 }


### PR DESCRIPTION
## Description

When ServiceMonitor CRD has `ServiceDiscoveryRole`, set it to EndpointSlices. Allow prometheus to fetch EndpointSlices.
In OpenShift, this should be used on 4.21 and later. On previous versions ServiceMonitor should stay unchanged.

Note: I haven't been able to test on 4.21 yet

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
