### PR TITLE
NETOBSERV-2531: use narrowcache for endpoints and endpointslices

### DIFF
--- a/internal/controller/flowcollector_controller_iso_test.go
+++ b/internal/controller/flowcollector_controller_iso_test.go
@@ -244,6 +244,8 @@ func flowCollectorIsoSpecs() {
 			Expect(cr.Spec.Loki).Should(Equal(specInput.Loki))
 			Expect(cr.Spec.Kafka).Should(Equal(specInput.Kafka))
 			Expect(cr.Spec.Exporters).Should(Equal(specInput.Exporters))
+			Expect(cr.Spec.NetworkPolicy).Should(Equal(specInput.NetworkPolicy))
+			Expect(cr.Spec.Prometheus).Should(Equal(specInput.Prometheus))
 
 			// Catch-all in case we missed something
 			Expect(cr.Spec).Should(Equal(specInput))

--- a/internal/pkg/manager/manager.go
+++ b/internal/pkg/manager/manager.go
@@ -81,6 +81,8 @@ func NewManager(
 		narrowcache.Secrets,
 		narrowcache.Services,
 		narrowcache.ServiceAccounts,
+		narrowcache.Endpoints,
+		narrowcache.EndpointSlices,
 	)
 	opts.Client = client.Options{Cache: narrowCache.ControllerRuntimeClientCacheOptions()}
 


### PR DESCRIPTION
## Description

Use narrowcache for endpoints and endpointslices, to avoid caching unnecessary data cluster-wide

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
