### PR TITLE
NETOBSERV-2562: make alertmanager url optional

### DIFF
--- a/api/flowcollector/v1beta2/flowcollector_types.go
+++ b/api/flowcollector/v1beta2/flowcollector_types.go
@@ -1021,7 +1021,7 @@ type PrometheusQuerierManual struct {
 // `AlertManagerQuerierManual` defines the full connection parameters to Prometheus AlertManager.
 type AlertManagerQuerierManual struct {
 	// `url` is the address of an existing Prometheus AlertManager service to use for querying alerts.
-	// +required
+	// +optional
 	URL string `json:"url,omitempty"`
 
 	// TLS client configuration for Prometheus AlertManager URL.

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -6299,8 +6299,6 @@ spec:
                                   Prometheus AlertManager service to use for querying
                                   alerts.'
                                 type: string
-                            required:
-                            - url
                             type: object
                           forwardUserToken:
                             description: Set `true` to forward logged in user token

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -5807,8 +5807,6 @@ spec:
                                 url:
                                   description: '`url` is the address of an existing Prometheus AlertManager service to use for querying alerts.'
                                   type: string
-                              required:
-                                - url
                               type: object
                             forwardUserToken:
                               description: Set `true` to forward logged in user token in queries to Prometheus

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -12279,17 +12279,17 @@ When used in OpenShift it can be left empty to use the Console API instead.
         </tr>
     </thead>
     <tbody><tr>
-        <td><b>url</b></td>
-        <td>string</td>
-        <td>
-          `url` is the address of an existing Prometheus AlertManager service to use for querying alerts.<br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b><a href="#flowcollectorspecprometheusqueriermanualalertmanagertls">tls</a></b></td>
         <td>object</td>
         <td>
           TLS client configuration for Prometheus AlertManager URL.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>url</b></td>
+        <td>string</td>
+        <td>
+          `url` is the address of an existing Prometheus AlertManager service to use for querying alerts.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/helm/crds/flows.netobserv.io_flowcollectors.yaml
+++ b/helm/crds/flows.netobserv.io_flowcollectors.yaml
@@ -5811,8 +5811,6 @@ spec:
                                 url:
                                   description: '`url` is the address of an existing Prometheus AlertManager service to use for querying alerts.'
                                   type: string
-                              required:
-                                - url
                               type: object
                             forwardUserToken:
                               description: Set `true` to forward logged in user token in queries to Prometheus


### PR DESCRIPTION
## Description

Additionally to the change [here](https://github.com/netobserv/network-observability-console-plugin/pull/1193), also make the alertmanager url field optional, just to be safe (although I think it's not absolutely necessary)

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
