### PR TITLE
NETOBSERV-2189 check LokiStack status

### DIFF
--- a/internal/pkg/manager/status/status_manager.go
+++ b/internal/pkg/manager/status/status_manager.go
@@ -30,6 +30,7 @@ const (
 	NetworkPolicy               ComponentName = "NetworkPolicy"
 	ConditionConfigurationIssue               = "ConfigurationIssue"
 	LokiIssue                                 = "LokiIssue"
+	LokiWarning                               = "LokiWarning"
 )
 
 var allNames = []ComponentName{FlowCollectorLegacy, Monitoring, StaticController}
@@ -139,6 +140,7 @@ func updateStatus(ctx context.Context, c client.Client, conditions ...metav1.Con
 		}
 		conditions = append(conditions, checkValidation(ctx, &fc))
 		conditions = append(conditions, checkLoki(ctx, c, &fc))
+		conditions = append(conditions, checkLokiWarnings(ctx, c, &fc))
 		for _, c := range conditions {
 			meta.SetStatusCondition(&fc.Status.Conditions, c)
 		}


### PR DESCRIPTION
## Description

- check LokiStack status conditions
- also check components status

Examples:

<img width="1644" height="1148" alt="image" src="https://github.com/user-attachments/assets/141b3e86-856a-4387-bd3f-5f5826162a36" />

```
    - lastTransitionTime: '2026-01-15T15:23:10Z'
      message: 'LokiStack components have issues [name: loki, namespace: netobserv]: Ingester has 1 pending pod(s): loki-ingester-1; Gateway has 2 pending pod(s): loki-gateway-bdc57846c-7b45v, loki-gateway-bdc57846c-jqqrc'
      reason: LokiStackComponentIssues
      status: 'True'
      type: LokiIssue
```

<img width="1644" height="1148" alt="image" src="https://github.com/user-attachments/assets/1aa1f326-2b36-46eb-8cb3-a58a0e60f773" />

```
    - lastTransitionTime: '2026-01-15T15:44:51Z'
      message: 'LokiStack has issues [name: loki, namespace: netobserv]: Warning: The schema configuration does not contain the most recent schema version and needs an update; Degraded: Missing object storage secret'
      reason: LokiStackIssues
      status: 'True'
      type: LokiIssue
```

<img width="1644" height="1148" alt="image" src="https://github.com/user-attachments/assets/df3bb766-ada4-4725-b9c8-9f449671f301" />

```
    - lastTransitionTime: '2026-01-15T16:05:26Z'
      message: ''
      reason: NoIssue
      status: 'False'
      type: LokiIssue
    - lastTransitionTime: '2026-01-15T16:05:26Z'
      message: 'LokiStack has warnings [name: loki, namespace: netobserv]: Warning: The schema configuration does not contain the most recent schema version and needs an update'
      reason: LokiStackWarnings
      status: 'True'
      type: LokiWarning
```

<img width="1644" height="1148" alt="image" src="https://github.com/user-attachments/assets/594146e7-beae-4e06-9625-5640c2dcaa43" />

## Dependencies

https://github.com/netobserv/network-observability-console-plugin/pull/1194

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
