### PR TITLE
Prevent nil pointer / panic with InstallDemoLoki

### DIFF
--- a/api/flowcollector/v1beta2/helper.go
+++ b/api/flowcollector/v1beta2/helper.go
@@ -43,7 +43,7 @@ func (spec *FlowCollectorSpec) UseLoki() bool {
 }
 
 func (spec *FlowCollectorSpec) UseLokiDev() bool {
-	return spec.UseLoki() && spec.Loki.Mode == LokiModeMonolithic && *spec.Loki.Monolithic.InstallDemoLoki
+	return spec.UseLoki() && spec.Loki.Mode == LokiModeMonolithic && spec.Loki.Monolithic.InstallDemoLoki != nil && *spec.Loki.Monolithic.InstallDemoLoki
 }
 
 func (spec *FlowCollectorSpec) UsePrometheus() bool {

--- a/internal/pkg/helper/loki_config.go
+++ b/internal/pkg/helper/loki_config.go
@@ -53,7 +53,7 @@ func NewLokiConfig(spec *flowslatest.FlowCollectorLoki, namespace string) LokiCo
 			},
 		}
 	case flowslatest.LokiModeMonolithic:
-		if *spec.Monolithic.InstallDemoLoki {
+		if spec.Monolithic.InstallDemoLoki != nil && *spec.Monolithic.InstallDemoLoki {
 			loki.LokiManualParams = flowslatest.LokiManualParams{
 				QuerierURL:  "http://loki:3100/",
 				IngesterURL: "http://loki:3100/",


### PR DESCRIPTION
## Description

panic may occur when upgrading from an old CR; we shouldn't assume InstallDemoLoki is set even if a kubebuilder default is provided.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
