### PR TITLE
NETOBSERV-2329 health integration in topology

### DIFF
--- a/internal/pkg/metrics/alerts/builder.go
+++ b/internal/pkg/metrics/alerts/builder.go
@@ -381,8 +381,10 @@ func (rb *ruleBuilder) buildHealthAnnotation(override map[string]any) ([]byte, e
 	switch rb.healthRule.GroupBy {
 	case flowslatest.GroupByNode:
 		annotation["nodeLabels"] = []string{"node"}
-	case flowslatest.GroupByNamespace, flowslatest.GroupByWorkload:
+	case flowslatest.GroupByNamespace:
 		annotation["namespaceLabels"] = []string{"namespace"}
+	case flowslatest.GroupByWorkload:
+		annotation["ownerLabels"] = []string{"workload"}
 	}
 	for k, v := range override {
 		annotation[k] = v


### PR DESCRIPTION
## Description

- add missing annotations for owners

This allows https://github.com/netobserv/network-observability-console-plugin/pull/1200 to display owners alerts in both health and topology views

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
