### PR TITLE
NETOBSERV-2610 restore prometheus enable as default

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -78,6 +78,11 @@ metadata:
               "slicesConfig": {
                 "enable": false
               }
+            },
+            "prometheus": {
+              "querier": {
+                "enable": true
+              }
             }
           }
         }

--- a/config/samples/flows_v1beta2_flowcollector.yaml
+++ b/config/samples/flows_v1beta2_flowcollector.yaml
@@ -175,9 +175,9 @@ spec:
     # writeTimeout: 10s
     # writeBatchWait: 1s
     # writeBatchSize: 10485760
-  # prometheus:
-  #   querier:
-  #     enable: true
+  prometheus:
+    querier:
+      enable: true
   #     mode: Auto
   #     timeout: 30s
   consolePlugin:


### PR DESCRIPTION
## Description

Ensure prometheus is enabled by default since the plugin rely on CSV example in the setup.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
