### PR TITLE
Fix upstream builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,11 @@ OCI_BIN_PATH := $(shell which docker 2>/dev/null || which podman)
 OCI_BIN ?= $(shell basename ${OCI_BIN_PATH})
 OCI_BUILD_OPTS ?=
 
+ifeq ("$(OCI_BIN)","docker")
+# https://stackoverflow.com/questions/75521775/buildx-docker-image-claims-to-be-a-manifest-list
+EXTRA_BUILD_FLAGS ?= --provenance=false
+endif
+
 ifneq ($(CLEAN_BUILD),)
 	BUILD_DATE := $(shell date +%Y-%m-%d\ %H:%M)
 	BUILD_SHA := $(shell git rev-parse --short HEAD)
@@ -119,7 +124,7 @@ all: help
 # build a single arch target provided as argument
 define build_target
 	echo 'building image for arch $(1)'; \
-	DOCKER_BUILDKIT=1 $(OCI_BIN) buildx build --load --build-arg LDFLAGS="${LDFLAGS}" --build-arg TARGETARCH=$(1) ${OCI_BUILD_OPTS} -t ${IMAGE}-$(1) -f Dockerfile .;
+	DOCKER_BUILDKIT=1 $(OCI_BIN) buildx build --load --build-arg LDFLAGS="${LDFLAGS}" --build-arg TARGETARCH=$(1) ${OCI_BUILD_OPTS} ${EXTRA_BUILD_FLAGS} -t ${IMAGE}-$(1) -f Dockerfile .;
 endef
 
 # push a single arch target image


### PR DESCRIPTION
See https://stackoverflow.com/questions/75521775/buildx-docker-image-claims-to-be-a-manifest-list

Fixes errors like:

```
Error response from daemon: No such image: quay.io/netobserv/flowlogs-pipeline:8751bd4
DOCKER_BUILDKIT=1 docker manifest create quay.io/netobserv/flowlogs-pipeline:8751bd4  --amend quay.io/netobserv/flowlogs-pipeline:8751bd4-amd64;
quay.io/netobserv/flowlogs-pipeline:8751bd4-amd64 is a manifest list
```