### PR TITLE
NETOBSERV-2707: Fix invalid volume names in OpenTelemetry and IPFIX exporters

### DIFF
--- a/internal/controller/flp/flp_pipeline_builder.go
+++ b/internal/controller/flp/flp_pipeline_builder.go
@@ -671,10 +671,10 @@ func (b *PipelineBuilder) addCustomExportStages(previous config.PipelineBuilderS
 			b.createKafkaWriteStage(fmt.Sprintf("kafka-export-%d", i), &exporter.Kafka, &stage)
 		}
 		if exporter.Type == flowslatest.IpfixExporter {
-			createIPFIXWriteStage(fmt.Sprintf("IPFIX-export-%d", i), &exporter.IPFIX, &stage)
+			createIPFIXWriteStage(fmt.Sprintf("ipfix-export-%d", i), &exporter.IPFIX, &stage)
 		}
 		if exporter.Type == flowslatest.OpenTelemetryExporter {
-			err := b.createOpenTelemetryStage(fmt.Sprintf("Otel-export-%d", i), &exporter.OpenTelemetry, &stage, flpMetrics)
+			err := b.createOpenTelemetryStage(fmt.Sprintf("otel-export-%d", i), &exporter.OpenTelemetry, &stage, flpMetrics)
 			if err != nil {
 				return err
 			}

--- a/internal/controller/flp/flp_pipeline_builder_test.go
+++ b/internal/controller/flp/flp_pipeline_builder_test.go
@@ -240,7 +240,7 @@ func TestPipelineWithExporter(t *testing.T) {
 	assert.NoError(err)
 	cfs, pipeline := validatePipelineConfig(t, scm, dcm)
 	assert.Equal(
-		`[{"name":"grpc"},{"name":"extract_conntrack","follows":"grpc"},{"name":"enrich","follows":"extract_conntrack"},{"name":"loki","follows":"enrich"},{"name":"stdout","follows":"enrich"},{"name":"prometheus","follows":"enrich"},{"name":"kafka-export-0","follows":"enrich"},{"name":"IPFIX-export-1","follows":"enrich"}]`,
+		`[{"name":"grpc"},{"name":"extract_conntrack","follows":"grpc"},{"name":"enrich","follows":"extract_conntrack"},{"name":"loki","follows":"enrich"},{"name":"stdout","follows":"enrich"},{"name":"prometheus","follows":"enrich"},{"name":"kafka-export-0","follows":"enrich"},{"name":"ipfix-export-1","follows":"enrich"}]`,
 		pipeline,
 	)
 


### PR DESCRIPTION
## Description

When TLS is enabled on OpenTelemetry or IPFIX exporters, the operator generates volume names with uppercase letters (`Otel-export-0-ca`, `IPFIX-export-1-ca`) that violate Kubernetes RFC 1123 DNS naming standards. 

This causes the FLP deployment to be rejected by the apiserver with:                                                                                                                                   
                                                                                                                                                                                                                    
`Invalid value: "Otel-export-0-ca": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (regex: a-z0-9?)`

### How to Reproduce
                                                                                                                                                                              
  1. Deploy a FlowCollector with OpenTelemetry exporter and TLS enabled:                                                                                                                                            
  ```yaml                                                   
  apiVersion: flows.netobserv.io/v1beta2                                                                                                                                                                            
  kind: FlowCollector
  metadata:                                                                                                                                                                                                         
    name: cluster                                           
  spec:
    namespace: netobserv
    deploymentModel: Service
    agent:
      type: eBPF
    loki:
      enable: false                                                                                                                                                                                                 
    exporters:
      - type: OpenTelemetry                                                                                                                                                                                         
        openTelemetry:                                                                                                                                                                                              
          targetHost: "otel-collector.observability.svc.cluster.local"
          targetPort: 4317                                                                                                                                                                                          
          protocol: grpc                                    
          tls:                                                                                                                                                                                                      
            enable: true                                                                                                                                                                                            
            caCert:                                                                                                                                                                                                 
              type: configmap                                                                                                                                                                                       
              name: otel-ca-bundle                          
              certFile: ca.crt
          logs:
            enable: true
  ```                                          

2. Apply and check the operator logs:                                                                                                                                                                             

```bash 
kubectl apply -f flowcollector.yaml
kubectl logs -n netobserv deployment/netobserv-controller-manager                                                                                                                                                 
```                                                                    
3. Expected error in operator logs:
  
`Failed to create new *v1.Deployment {"Namespace": "netobserv", "Name": "flowlogs-pipeline", "error": "Deployment.apps \"flowlogs-pipeline\" is invalid:  spec.template.spec.volumes[X].name: Invalid value: \"Otel-export-0-ca\": ..."}                    `                                                                                                                
                                                                                                                                                                                                                    
4. Verify the FLP deployment was never created:                                                                                                                                                                   

```bash   
kubectl get deployment -n netobserv flowlogs-pipeline                        
```

5. Apply this fix, and the deployment should be created (although will fail because the proper configuration needs a configmap, but that is expected, normal behavior.

## Dependencies

n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [x] Does the changes in PR need specific configuration or environment set up for testing?
   * [x]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized exporter stage naming in pipeline identifiers to use lowercase formatting across IPFIX and OpenTelemetry exporters for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->