### PR TITLE
NETOBSERV-2376 fix statuses

### DIFF
--- a/internal/controller/flp/flp_controller.go
+++ b/internal/controller/flp/flp_controller.go
@@ -119,7 +119,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		return ctrl.Result{}, err
 	}
 
-	r.status.SetReady()
+	if fc.Spec.OnHold() {
+		r.status.SetUnused("FlowCollector is on hold")
+	} else {
+		r.status.SetReady()
+	}
 	if r.mgr.Status.NeedsRequeue() {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}

--- a/internal/pkg/manager/status/status_manager.go
+++ b/internal/pkg/manager/status/status_manager.go
@@ -158,8 +158,12 @@ func (s *Manager) getConditions() []metav1.Condition {
 }
 
 // populateComponentStatuses maps internal ComponentStatus instances to the CRD status fields.
-// Always start fresh to avoid stale data from a previous API server fetch influencing the merge.
-func (s *Manager) populateComponentStatuses(fc *flowslatest.FlowCollector) {
+// Integrations are always rebuilt from the in-memory map. Component fields are rebuilt from the map,
+// then agent/plugin may be merged from prevComponents (see preserveAgentOrPluginSnapshot).
+// prevComponents is the FlowCollector's status.components from the API before this update; when
+// another controller commits while the legacy reconciler is between ForComponent (placeholder Unknown)
+// and the real status, we keep agent/plugin from prev so users do not see transient Unknown.
+func (s *Manager) populateComponentStatuses(fc *flowslatest.FlowCollector, prevComponents *flowslatest.FlowCollectorComponentsStatus) {
 	fc.Status.Components = &flowslatest.FlowCollectorComponentsStatus{}
 	fc.Status.Integrations = &flowslatest.FlowCollectorIntegrationsStatus{}
 
@@ -194,6 +198,26 @@ func (s *Manager) populateComponentStatuses(fc *flowslatest.FlowCollector) {
 		return true
 	})
 	fc.Status.Integrations.Exporters = exporters
+
+	if prevComponents != nil {
+		fc.Status.Components.Agent = preserveAgentOrPluginSnapshot(fc.Status.Components.Agent, prevComponents.Agent)
+		fc.Status.Components.Plugin = preserveAgentOrPluginSnapshot(fc.Status.Components.Plugin, prevComponents.Plugin)
+	}
+}
+
+// preserveAgentOrPluginSnapshot avoids publishing a transient Unknown written by ForComponent before
+// the owning controller finishes, or losing agent/plugin when their keys are absent from the map.
+func preserveAgentOrPluginSnapshot(cur, prev *flowslatest.FlowCollectorComponentStatus) *flowslatest.FlowCollectorComponentStatus {
+	if prev == nil {
+		return cur
+	}
+	if cur == nil {
+		return prev
+	}
+	if cur.State == string(StatusUnknown) && cur.Reason == "" && cur.Message == "" {
+		return prev
+	}
+	return cur
 }
 
 // mergeProcessorStatus handles FLP processor status aggregation from parent, monolith, and transformer.
@@ -288,11 +312,18 @@ func (s *Manager) updateStatus(ctx context.Context, c client.Client) {
 		conditions = append(conditions, checkValidation(ctx, &fc))
 		if kafkaCond := s.GetKafkaCondition(); kafkaCond != nil {
 			conditions = append(conditions, *kafkaCond)
+		} else if ts := s.getStatus(FLPTransformer); ts == nil || ts.Status != StatusUnknown {
+			// Skip removal while FLPTransformer is placeholder Unknown (GetKafkaCondition is nil then too).
+			meta.RemoveStatusCondition(&fc.Status.Conditions, "KafkaReady")
 		}
 		for _, cond := range conditions {
 			meta.SetStatusCondition(&fc.Status.Conditions, cond)
 		}
-		s.populateComponentStatuses(&fc)
+		var prevComponents *flowslatest.FlowCollectorComponentsStatus
+		if fc.Status.Components != nil {
+			prevComponents = fc.Status.Components.DeepCopy()
+		}
+		s.populateComponentStatuses(&fc, prevComponents)
 		if err := c.Status().Update(ctx, &fc); err != nil {
 			return err
 		}
@@ -395,8 +426,9 @@ func (s *Manager) GetKafkaCondition() *metav1.Condition {
 				Message: "Kafka transformer is rolling out",
 			}
 		case StatusUnknown, StatusUnused, StatusFailure, StatusDegraded:
-			// Failure/Degraded already handled above via hasKafkaIssue;
-			// Unknown/Unused mean Kafka mode is not active.
+			// Failure/Degraded already handled above via hasKafkaIssue.
+			// Unused means transformer not used (e.g. direct mode). Unknown is either not yet
+			// reconciled (ForComponent placeholder) or indeterminate — no KafkaReady row in either case.
 		}
 	}
 

--- a/internal/pkg/manager/status/status_manager_test.go
+++ b/internal/pkg/manager/status/status_manager_test.go
@@ -95,12 +95,39 @@ func TestUnusedStatusInCRD(t *testing.T) {
 	assert.Equal(t, StatusUnused, cs.Status)
 
 	fc := &flowslatest.FlowCollector{}
-	s.populateComponentStatuses(fc)
+	s.populateComponentStatuses(fc, nil)
 	require.NotNil(t, fc.Status.Components)
 	require.NotNil(t, fc.Status.Components.Agent)
 	assert.Equal(t, "Unused", fc.Status.Components.Agent.State)
 	assert.Equal(t, "ComponentUnused", fc.Status.Components.Agent.Reason)
 	assert.Equal(t, "FlowCollector is on hold", fc.Status.Components.Agent.Message)
+}
+
+func TestPopulatePreservesAgentPluginAgainstPlaceholderUnknown(t *testing.T) {
+	s := NewManager()
+	_ = s.ForComponent(EBPFAgents)
+	_ = s.ForComponent(WebConsole)
+
+	prev := &flowslatest.FlowCollectorComponentsStatus{
+		Agent: &flowslatest.FlowCollectorComponentStatus{
+			State:   "Unused",
+			Reason:  "ComponentUnused",
+			Message: "FlowCollector is on hold",
+		},
+		Plugin: &flowslatest.FlowCollectorComponentStatus{
+			State:   "Unused",
+			Reason:  "ComponentUnused",
+			Message: "FlowCollector is on hold",
+		},
+	}
+
+	fc := &flowslatest.FlowCollector{}
+	s.populateComponentStatuses(fc, prev)
+
+	require.NotNil(t, fc.Status.Components.Agent)
+	assert.Equal(t, "Unused", fc.Status.Components.Agent.State)
+	require.NotNil(t, fc.Status.Components.Plugin)
+	assert.Equal(t, "Unused", fc.Status.Components.Plugin.State)
 }
 
 func TestReplicaCounts(t *testing.T) {
@@ -366,7 +393,7 @@ func TestPopulateComponentStatuses(t *testing.T) {
 	monitoring.SetFailure("DashboardError", "dashboard CM missing")
 
 	fc := &flowslatest.FlowCollector{}
-	s.populateComponentStatuses(fc)
+	s.populateComponentStatuses(fc, nil)
 
 	require.NotNil(t, fc.Status.Components)
 	require.NotNil(t, fc.Status.Components.Agent)
@@ -405,7 +432,7 @@ func TestPopulateProcessorAggregation(t *testing.T) {
 		})
 
 		fc := &flowslatest.FlowCollector{}
-		s.populateComponentStatuses(fc)
+		s.populateComponentStatuses(fc, nil)
 
 		require.NotNil(t, fc.Status.Components)
 		require.NotNil(t, fc.Status.Components.Processor)
@@ -424,7 +451,7 @@ func TestPopulateProcessorAggregation(t *testing.T) {
 		transformer.SetFailure("KafkaConnectionError", "cannot connect to broker")
 
 		fc := &flowslatest.FlowCollector{}
-		s.populateComponentStatuses(fc)
+		s.populateComponentStatuses(fc, nil)
 
 		require.NotNil(t, fc.Status.Components)
 		require.NotNil(t, fc.Status.Components.Processor)
@@ -443,11 +470,29 @@ func TestPopulateProcessorAggregation(t *testing.T) {
 		trans.SetUnused("direct mode")
 
 		fc := &flowslatest.FlowCollector{}
-		s.populateComponentStatuses(fc)
+		s.populateComponentStatuses(fc, nil)
 
 		require.NotNil(t, fc.Status.Components)
 		require.NotNil(t, fc.Status.Components.Processor)
 		assert.Equal(t, "Ready", fc.Status.Components.Processor.State)
+	})
+
+	t.Run("on hold parent unused with unused subs yields processor unused", func(t *testing.T) {
+		s := NewManager()
+		parent := s.ForComponent(FLPParent)
+		mono := s.ForComponent(FLPMonolith)
+		trans := s.ForComponent(FLPTransformer)
+
+		parent.SetUnused("FlowCollector is on hold")
+		mono.SetUnused("FlowCollector is on hold")
+		trans.SetUnused("FlowCollector is on hold")
+
+		fc := &flowslatest.FlowCollector{}
+		s.populateComponentStatuses(fc, nil)
+
+		require.NotNil(t, fc.Status.Components)
+		require.NotNil(t, fc.Status.Components.Processor)
+		assert.Equal(t, "Unused", fc.Status.Components.Processor.State)
 	})
 }
 
@@ -458,7 +503,7 @@ func TestPopulateLokiStatus(t *testing.T) {
 		ls.SetReady()
 
 		fc := &flowslatest.FlowCollector{}
-		s.populateComponentStatuses(fc)
+		s.populateComponentStatuses(fc, nil)
 
 		require.NotNil(t, fc.Status.Integrations)
 		require.NotNil(t, fc.Status.Integrations.Loki)
@@ -471,7 +516,7 @@ func TestPopulateLokiStatus(t *testing.T) {
 		demo.SetFailure("DeployFailed", "cannot create PVC")
 
 		fc := &flowslatest.FlowCollector{}
-		s.populateComponentStatuses(fc)
+		s.populateComponentStatuses(fc, nil)
 
 		require.NotNil(t, fc.Status.Integrations)
 		require.NotNil(t, fc.Status.Integrations.Loki)
@@ -485,7 +530,7 @@ func TestPopulateLokiStatus(t *testing.T) {
 		ls.SetUnused("Loki is disabled")
 
 		fc := &flowslatest.FlowCollector{}
-		s.populateComponentStatuses(fc)
+		s.populateComponentStatuses(fc, nil)
 
 		require.NotNil(t, fc.Status.Integrations)
 		require.NotNil(t, fc.Status.Integrations.Loki)
@@ -504,7 +549,7 @@ func TestControllerComponentsNotInCRDStatus(t *testing.T) {
 	np.SetReady()
 
 	fc := &flowslatest.FlowCollector{}
-	s.populateComponentStatuses(fc)
+	s.populateComponentStatuses(fc, nil)
 
 	assert.Nil(t, fc.Status.Components.Agent)
 	assert.Nil(t, fc.Status.Components.Plugin)
@@ -519,7 +564,7 @@ func TestExporterStatus(t *testing.T) {
 	s.SetExporterStatus("ipfix-export-0", "IPFIX", "Failure", "ConnectionRefused", "cannot connect")
 
 	fc := &flowslatest.FlowCollector{}
-	s.populateComponentStatuses(fc)
+	s.populateComponentStatuses(fc, nil)
 
 	require.NotNil(t, fc.Status.Integrations)
 	assert.Len(t, fc.Status.Integrations.Exporters, 2)
@@ -539,7 +584,7 @@ func TestExporterStatus(t *testing.T) {
 
 	s.ClearExporters()
 	fc2 := &flowslatest.FlowCollector{}
-	s.populateComponentStatuses(fc2)
+	s.populateComponentStatuses(fc2, nil)
 	assert.Empty(t, fc2.Status.Integrations.Exporters)
 }
 
@@ -552,6 +597,20 @@ func TestKafkaCondition(t *testing.T) {
 		mono.SetReady()
 
 		assert.Nil(t, s.GetKafkaCondition())
+	})
+
+	t.Run("transformer placeholder unknown implies do not strip kafka ready from API", func(t *testing.T) {
+		s := NewManager()
+		tr := s.ForComponent(FLPTransformer)
+		ts := s.getStatus(FLPTransformer)
+		require.NotNil(t, ts)
+		assert.Equal(t, StatusUnknown, ts.Status)
+		assert.Nil(t, s.GetKafkaCondition())
+
+		tr.SetUnused("direct mode")
+		ts = s.getStatus(FLPTransformer)
+		require.NotNil(t, ts)
+		assert.NotEqual(t, StatusUnknown, ts.Status)
 	})
 
 	t.Run("healthy transformer returns KafkaReady=True", func(t *testing.T) {


### PR DESCRIPTION
## Description

- onHold component statuses forced to unused
- kafka condition removed when disabling it

<img width="1712" height="1285" alt="image" src="https://github.com/user-attachments/assets/ac366756-c32d-4e78-a721-d3d9dab86b6c" />

Also see https://github.com/netobserv/netobserv-web-console/pull/1445 for colors and icons in plugin

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status reporting for on-hold components; they now correctly display as "unused" instead of "ready."
  * Removed stale Kafka-related status conditions when Kafka is not in use, preventing outdated status information.
  * Enhanced state preservation during concurrent operations to maintain accurate agent and plugin status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->