### PR TITLE
NETOBSERV-2733: Remove kafka compression by default

### DIFF
--- a/api/flowcollector/v1beta2/flowcollector_types.go
+++ b/api/flowcollector/v1beta2/flowcollector_types.go
@@ -432,9 +432,9 @@ type FlowCollectorKafka struct {
 	Topic string `json:"topic"`
 
 	// +kubebuilder:validation:Enum:="none";"gzip";"snappy";"lz4";"zstd"
-	// +kubebuilder:default:="lz4"
+	// +kubebuilder:default:="none"
 	// Compression codec to use when producing messages to Kafka.
-	// Accepted values are: `none`, `gzip`, `snappy`, `lz4` (default), `zstd`.
+	// Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.
 	// +optional
 	Compression string `json:"compression,omitempty"`
 

--- a/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowcollectors.yaml
@@ -3318,10 +3318,10 @@ spec:
                           description: Address of the Kafka server
                           type: string
                         compression:
-                          default: lz4
+                          default: none
                           description: |-
                             Compression codec to use when producing messages to Kafka.
-                            Accepted values are: `none`, `gzip`, `snappy`, `lz4` (default), `zstd`.
+                            Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.
                           enum:
                           - none
                           - gzip
@@ -3652,10 +3652,10 @@ spec:
                     description: Address of the Kafka server
                     type: string
                   compression:
-                    default: lz4
+                    default: none
                     description: |-
                       Compression codec to use when producing messages to Kafka.
-                      Accepted values are: `none`, `gzip`, `snappy`, `lz4` (default), `zstd`.
+                      Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.
                     enum:
                     - none
                     - gzip

--- a/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowcollectors.yaml
@@ -3107,10 +3107,10 @@ spec:
                             description: Address of the Kafka server
                             type: string
                           compression:
-                            default: lz4
+                            default: none
                             description: |-
                               Compression codec to use when producing messages to Kafka.
-                              Accepted values are: `none`, `gzip`, `snappy`, `lz4` (default), `zstd`.
+                              Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.
                             enum:
                               - none
                               - gzip
@@ -3392,10 +3392,10 @@ spec:
                       description: Address of the Kafka server
                       type: string
                     compression:
-                      default: lz4
+                      default: none
                       description: |-
                         Compression codec to use when producing messages to Kafka.
-                        Accepted values are: `none`, `gzip`, `snappy`, `lz4` (default), `zstd`.
+                        Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.
                       enum:
                         - none
                         - gzip

--- a/docs/FlowCollector.md
+++ b/docs/FlowCollector.md
@@ -6201,10 +6201,10 @@ Kafka configuration, such as the address and topic, to send enriched flows to.
         <td>enum</td>
         <td>
           Compression codec to use when producing messages to Kafka.
-Accepted values are: `none`, `gzip`, `snappy`, `lz4` (default), `zstd`.<br/>
+Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.<br/>
           <br/>
             <i>Enum</i>: none, gzip, snappy, lz4, zstd<br/>
-            <i>Default</i>: lz4<br/>
+            <i>Default</i>: none<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6954,10 +6954,10 @@ Kafka configuration, allowing to use Kafka as a broker as part of the flow colle
         <td>enum</td>
         <td>
           Compression codec to use when producing messages to Kafka.
-Accepted values are: `none`, `gzip`, `snappy`, `lz4` (default), `zstd`.<br/>
+Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.<br/>
           <br/>
             <i>Enum</i>: none, gzip, snappy, lz4, zstd<br/>
-            <i>Default</i>: lz4<br/>
+            <i>Default</i>: none<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/helm/crds/flows.netobserv.io_flowcollectors.yaml
+++ b/helm/crds/flows.netobserv.io_flowcollectors.yaml
@@ -3111,10 +3111,10 @@ spec:
                             description: Address of the Kafka server
                             type: string
                           compression:
-                            default: lz4
+                            default: none
                             description: |-
                               Compression codec to use when producing messages to Kafka.
-                              Accepted values are: `none`, `gzip`, `snappy`, `lz4` (default), `zstd`.
+                              Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.
                             enum:
                               - none
                               - gzip
@@ -3396,10 +3396,10 @@ spec:
                       description: Address of the Kafka server
                       type: string
                     compression:
-                      default: lz4
+                      default: none
                       description: |-
                         Compression codec to use when producing messages to Kafka.
-                        Accepted values are: `none`, `gzip`, `snappy`, `lz4` (default), `zstd`.
+                        Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.
                       enum:
                         - none
                         - gzip

--- a/internal/controller/flp/flp_pipeline_builder_test.go
+++ b/internal/controller/flp/flp_pipeline_builder_test.go
@@ -270,10 +270,10 @@ func TestMergeMetricsConfiguration_WithAdditionalList_Dedup(t *testing.T) {
 
 	cfg := getConfig()
 	cfg.Processor.Metrics.AdditionalIncludeList = &[]flowslatest.FLPMetric{
-		"node_ingress_bytes_total",        // Already in defaults
-		"namespace_egress_bytes_total",    // New metric
-		"namespace_egress_bytes_total",    // Duplicate in additional
-		"node_ingress_bytes_total",        // Duplicate overlap with default
+		"node_ingress_bytes_total",     // Already in defaults
+		"namespace_egress_bytes_total", // New metric
+		"namespace_egress_bytes_total", // Duplicate in additional
+		"node_ingress_bytes_total",     // Duplicate overlap with default
 	}
 
 	names, cfs := buildAndGetMetricNames(t, &cfg)


### PR DESCRIPTION
## Description

Enabling Kafka compression by default results in performance regressions, at least visible in the NDH tests. Moreover, those tests don't show a counterpart improvement, such as on Kafka brokers cpu or memory.

Hence, this PR restores the previous default state; Kafka compression is still possible as an opt-in.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Updated default Kafka message compression from `lz4` to `none` for both exporter and processor configurations.

* **Documentation**
  * Updated configuration documentation to reflect the new Kafka compression default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->