### PR TITLE
NETOBSERV-2674: report Degraded when eBPF DaemonSet has no pods scheduled

### DIFF
--- a/internal/controller/flp/flp_pipeline_builder_test.go
+++ b/internal/controller/flp/flp_pipeline_builder_test.go
@@ -270,10 +270,10 @@ func TestMergeMetricsConfiguration_WithAdditionalList_Dedup(t *testing.T) {
 
 	cfg := getConfig()
 	cfg.Processor.Metrics.AdditionalIncludeList = &[]flowslatest.FLPMetric{
-		"node_ingress_bytes_total",        // Already in defaults
-		"namespace_egress_bytes_total",    // New metric
-		"namespace_egress_bytes_total",    // Duplicate in additional
-		"node_ingress_bytes_total",        // Duplicate overlap with default
+		"node_ingress_bytes_total",     // Already in defaults
+		"namespace_egress_bytes_total", // New metric
+		"namespace_egress_bytes_total", // Duplicate in additional
+		"node_ingress_bytes_total",     // Duplicate overlap with default
 	}
 
 	names, cfs := buildAndGetMetricNames(t, &cfg)

--- a/internal/pkg/manager/status/status_manager.go
+++ b/internal/pkg/manager/status/status_manager.go
@@ -539,7 +539,7 @@ func (i *Instance) setDeploymentReplicas(d *appsv1.Deployment) {
 	}
 }
 
-// CheckDaemonSetProgress sets the status either as In Progress, or Ready,
+// CheckDaemonSetProgress sets the status either as In Progress, Ready, or Degraded,
 // and populates replica counts from the DaemonSet status.
 func (i *Instance) CheckDaemonSetProgress(ds *appsv1.DaemonSet) {
 	if ds == nil {
@@ -547,7 +547,9 @@ func (i *Instance) CheckDaemonSetProgress(ds *appsv1.DaemonSet) {
 		return
 	}
 	defer i.setDaemonSetReplicas(ds)
-	if ds.Status.NumberReady < ds.Status.DesiredNumberScheduled {
+	if ds.Status.DesiredNumberScheduled == 0 {
+		i.s.setDegraded(i.cpnt, "NoPodsScheduled", fmt.Sprintf("DaemonSet %s has no pods scheduled; check nodeSelector or node availability", ds.Name))
+	} else if ds.Status.NumberReady < ds.Status.DesiredNumberScheduled {
 		i.s.setInProgress(i.cpnt, "DaemonSetNotReady", fmt.Sprintf("DaemonSet %s not ready: %d/%d", ds.Name, ds.Status.NumberReady, ds.Status.DesiredNumberScheduled))
 	} else {
 		i.s.setReady(i.cpnt)

--- a/internal/pkg/manager/status/status_manager_test.go
+++ b/internal/pkg/manager/status/status_manager_test.go
@@ -268,6 +268,45 @@ func TestDaemonSetNilSetsInProgress(t *testing.T) {
 	assert.Equal(t, "DaemonSetNotCreated", cs.Reason)
 }
 
+func TestDaemonSetZeroDesiredScheduled(t *testing.T) {
+	s := NewManager()
+	agent := s.ForComponent(EBPFAgents)
+
+	// DesiredNumberScheduled == 0 means no nodes matched the nodeSelector
+	agent.CheckDaemonSetProgress(&appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "netobserv-ebpf-agent"},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: 0,
+			NumberReady:            0,
+		},
+	})
+
+	cs := agent.Get()
+	assert.Equal(t, StatusDegraded, cs.Status)
+	assert.Equal(t, "NoPodsScheduled", cs.Reason)
+	assert.Contains(t, cs.Message, "netobserv-ebpf-agent")
+	assert.Contains(t, cs.Message, "nodeSelector")
+}
+
+func TestDaemonSetZeroDesiredScheduledHealth(t *testing.T) {
+	s := NewManager()
+	agent := s.ForComponent(EBPFAgents)
+
+	// CheckDaemonSetHealth should also report Degraded when no pods are scheduled
+	agent.CheckDaemonSetHealth(context.Background(), nil, &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "netobserv-ebpf-agent"},
+		Spec:       appsv1.DaemonSetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "agent"}}},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: 0,
+			NumberReady:            0,
+		},
+	})
+
+	cs := agent.Get()
+	assert.Equal(t, StatusDegraded, cs.Status)
+	assert.Equal(t, "NoPodsScheduled", cs.Reason)
+}
+
 func TestDeploymentMissingConditionFallback(t *testing.T) {
 	s := NewManager()
 	plugin := s.ForComponent(WebConsole)


### PR DESCRIPTION
## Description

FlowCollector was incorrectly showing as `Ready` even when no eBPF pods were deployed due to a non-matching `nodeSelector`. The root cause was in `CheckDaemonSetProgress()`: when `DesiredNumberScheduled == 0`, the check `NumberReady < DesiredNumberScheduled` (0 < 0) is false, causing the component to be reported as Ready.

This fix adds an explicit guard: if `DesiredNumberScheduled == 0`, the eBPF agent component is reported as `Degraded` with reason `NoPodsScheduled` and a message pointing users toward checking their `nodeSelector` or node availability.

The same fix also covers the case where eBPF pods are in CrashLoopBackOff and `DesiredNumberScheduled` happens to be 0, as `CheckDaemonSetHealth` delegates to `CheckDaemonSetProgress`.

**Changed files:**
- `internal/pkg/manager/status/status_manager.go` — add zero-scheduled guard in `CheckDaemonSetProgress`
- `internal/pkg/manager/status/status_manager_test.go` — add tests for zero-scheduled DaemonSet scenario

## Dependencies

n/a

## Checklist

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * To reproduce: patch FlowCollector with a non-matching `nodeSelector` for eBPF pods and observe the `Status.Components.Agent` field on the FlowCollector CR.
* [x] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code) via `/jira:solve [NETOBSERV-2674](https://redhat.atlassian.net/browse/NETOBSERV-2674)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DaemonSet status reporting now correctly identifies components with zero scheduled pods as degraded instead of in-progress, improving status accuracy and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->