### PR TITLE
NETOBSERV-2705: Filter disabled feature fields from OTEL exports

### DIFF
--- a/internal/controller/flp/flp_pipeline_builder.go
+++ b/internal/controller/flp/flp_pipeline_builder.go
@@ -728,12 +728,21 @@ func (b *PipelineBuilder) createOpenTelemetryStage(name string, spec *flowslates
 	metricsEnabled := spec.Metrics.Enable != nil && *spec.Metrics.Enable
 
 	if logsEnabled || metricsEnabled {
+		// Filter out fields for disabled features before transforming to OTEL format
+		filterRules := b.getOtelFieldFilterRules()
+		var currentStage config.PipelineBuilderStage
+		if len(filterRules) > 0 {
+			currentStage = fromStage.TransformFilter(fmt.Sprintf("%s-field-filter", name), api.TransformFilter{Rules: filterRules})
+		} else {
+			currentStage = *fromStage
+		}
+
 		// add transform stage
 		transformCfg, err := otelConfig.GetOtelTransformConfig(spec.FieldsMapping)
 		if err != nil {
 			return err
 		}
-		transformStage := fromStage.TransformGeneric(fmt.Sprintf("%s-transform", name), *transformCfg)
+		transformStage := currentStage.TransformGeneric(fmt.Sprintf("%s-transform", name), *transformCfg)
 
 		// otel logs config
 		if logsEnabled {
@@ -759,6 +768,73 @@ func (b *PipelineBuilder) createOpenTelemetryStage(name string, spec *flowslates
 		}
 	}
 	return nil
+}
+
+// getOtelFieldFilterRules generates filter rules to remove fields for disabled agent features
+// This prevents unused/null fields from appearing in OTEL exports
+func (b *PipelineBuilder) getOtelFieldFilterRules() []api.TransformFilterRule {
+	rules := []api.TransformFilterRule{}
+
+	// Remove DNS fields if DNSTracking is disabled
+	if !b.desired.Agent.EBPF.IsDNSTrackingEnabled() {
+		dnsFields := []string{"DnsErrno", "DnsFlags", "DnsFlagsResponseCode", "DnsId", "DnsLatencyMs", "DnsName"}
+		for _, field := range dnsFields {
+			rules = append(rules, api.TransformFilterRule{
+				Type: api.RemoveField,
+				RemoveField: &api.TransformFilterGenericRule{
+					Input: field,
+				},
+			})
+		}
+	}
+
+	// Remove PacketDrop fields if PacketDrop is disabled
+	if !b.desired.Agent.EBPF.IsPktDropEnabled() {
+		dropFields := []string{"PktDropBytes", "PktDropPackets", "PktDropLatestDropCause", "PktDropLatestFlags", "PktDropLatestState"}
+		for _, field := range dropFields {
+			rules = append(rules, api.TransformFilterRule{
+				Type: api.RemoveField,
+				RemoveField: &api.TransformFilterGenericRule{
+					Input: field,
+				},
+			})
+		}
+	}
+
+	// Remove FlowRTT field if FlowRTT is disabled
+	if !b.desired.Agent.EBPF.IsFlowRTTEnabled() {
+		rules = append(rules, api.TransformFilterRule{
+			Type: api.RemoveField,
+			RemoveField: &api.TransformFilterGenericRule{
+				Input: "TimeFlowRttNs",
+			},
+		})
+	}
+
+	// Remove IPSec field if IPSec is disabled
+	if !b.desired.Agent.EBPF.IsIPSecEnabled() {
+		rules = append(rules, api.TransformFilterRule{
+			Type: api.RemoveField,
+			RemoveField: &api.TransformFilterGenericRule{
+				Input: "IPSecStatus",
+			},
+		})
+	}
+
+	// Remove UDN network name fields if UDNMapping is disabled
+	if !b.desired.Agent.EBPF.IsUDNMappingEnabled() {
+		udnFields := []string{"SrcK8S_NetworkName", "DstK8S_NetworkName"}
+		for _, field := range udnFields {
+			rules = append(rules, api.TransformFilterRule{
+				Type: api.RemoveField,
+				RemoveField: &api.TransformFilterGenericRule{
+					Input: field,
+				},
+			})
+		}
+	}
+
+	return rules
 }
 
 func getOtelConnType(connType string) string {

--- a/internal/controller/flp/flp_pipeline_builder_test.go
+++ b/internal/controller/flp/flp_pipeline_builder_test.go
@@ -270,10 +270,10 @@ func TestMergeMetricsConfiguration_WithAdditionalList_Dedup(t *testing.T) {
 
 	cfg := getConfig()
 	cfg.Processor.Metrics.AdditionalIncludeList = &[]flowslatest.FLPMetric{
-		"node_ingress_bytes_total",        // Already in defaults
-		"namespace_egress_bytes_total",    // New metric
-		"namespace_egress_bytes_total",    // Duplicate in additional
-		"node_ingress_bytes_total",        // Duplicate overlap with default
+		"node_ingress_bytes_total",     // Already in defaults
+		"namespace_egress_bytes_total", // New metric
+		"namespace_egress_bytes_total", // Duplicate in additional
+		"node_ingress_bytes_total",     // Duplicate overlap with default
 	}
 
 	names, cfs := buildAndGetMetricNames(t, &cfg)


### PR DESCRIPTION
## Summary

Fixes [NETOBSERV-2705](https://redhat.atlassian.net/browse/NETOBSERV-2705): Filter out fields for disabled agent features from OpenTelemetry exports to prevent null values in exported logs.

## Changes

Added a `TransformFilter` stage before the OTEL `TransformGeneric` stage in the FLP pipeline to remove fields associated with disabled features.

### Modified Files
- `internal/controller/flp/flp_pipeline_builder.go`:
  - New method `getOtelFieldFilterRules()` generates filter rules based on enabled agent features
  - Updated `createOpenTelemetryStage()` to apply field filtering before OTEL transformation
- `internal/controller/flp/flp_pipeline_builder_test.go`: Minor formatting

### Fields Filtered (when features disabled)
- **DNSTracking** (6 fields): `DnsErrno`, `DnsFlags`, `DnsFlagsResponseCode`, `DnsId`, `DnsLatencyMs`, `DnsName`
- **PacketDrop** (5 fields): `PktDropBytes`, `PktDropPackets`, `PktDropLatestDropCause`, `PktDropLatestFlags`, `PktDropLatestState`
- **FlowRTT** (1 field): `TimeFlowRttNs`
- **IPSec** (1 field): `IPSecStatus`
- **UDNMapping** (2 fields): `SrcK8S_NetworkName`, `DstK8S_NetworkName`

## Test Plan

OTEL exporter test (test_exporters.go:74977) verifies that:
1. OTEL collector receives flow records with TLS encryption
2. Fields for disabled features are not present in exported logs (previously showed as null)

## Related Issues

- JIRA: [NETOBSERV-2705](https://redhat.atlassian.net/browse/NETOBSERV-2705)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized OpenTelemetry export field handling to conditionally remove unused fields when agent features are disabled.

* **Tests**
  * Minor formatting updates to test configuration verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->