### PR TITLE
Fixes to backend tests

### DIFF
--- a/integration-tests/backend/flowcollector.go
+++ b/integration-tests/backend/flowcollector.go
@@ -145,7 +145,7 @@ type Flowlog struct {
 	// TLS
 	TLSVersion     string   `json:"TLSVersion,omitempty"`
 	TLSTypes       []string `json:"TLSTypes,omitempty"`
-	TLSCurve       string   `json:"TLSCurve,omitempty"`
+	TLSGroup       string   `json:"TLSGroup,omitempty"`
 	TLSCipherSuite string   `json:"TLSCipherSuite,omitempty"`
 }
 

--- a/integration-tests/backend/flowcollector_utils.go
+++ b/integration-tests/backend/flowcollector_utils.go
@@ -113,11 +113,11 @@ func getIPFIXFlowRecordsFromAPI(oc *exutil.CLI, namespace, podName string) ([]Fl
 }
 
 // Parse IPFIX data string format: "    key: value \n    key2: value2 \n ..."
-func parseIPFIXDataString(data string) map[string]interface{} {
-	fields := make(map[string]interface{})
-	lines := strings.Split(data, "\n")
+func parseIPFIXDataString(data string) map[string]any {
+	fields := make(map[string]any)
+	lines := strings.SplitSeq(data, "\n")
 
-	for _, line := range lines {
+	for line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -236,8 +236,8 @@ func (flowlog *Flowlog) verifyIPFIXFields() {
 	// Verify IPFIX standard fields are present and valid
 	o.Expect(flowlog.SrcAddr).NotTo(o.BeEmpty(), flow)
 	o.Expect(flowlog.DstAddr).NotTo(o.BeEmpty(), flow)
-	o.Expect(flowlog.SrcPort).Should(o.BeNumerically(">", 0), flow)
-	o.Expect(flowlog.DstPort).Should(o.BeNumerically(">", 0), flow)
+	o.Expect(flowlog.SrcPort).Should(o.BeNumerically(">=", 0), flow)
+	o.Expect(flowlog.DstPort).Should(o.BeNumerically(">=", 0), flow)
 	o.Expect(flowlog.Proto).Should(o.BeNumerically(">", 0), flow)
 	o.Expect(flowlog.Packets).Should(o.BeNumerically(">", 0), flow)
 	o.Expect(flowlog.Sampling).Should(o.BeNumerically(">=", 0), flow)

--- a/integration-tests/backend/loki_storage.go
+++ b/integration-tests/backend/loki_storage.go
@@ -89,13 +89,6 @@ func generateS3Config(cred s3Credential) aws.Config {
 	var err error
 	var cfg aws.Config
 	if len(cred.Endpoint) > 0 {
-		customResolver := aws.EndpointResolverWithOptionsFunc(func(_, _ string, _ ...interface{}) (aws.Endpoint, error) {
-			return aws.Endpoint{
-				URL:               cred.Endpoint,
-				HostnameImmutable: true,
-				Source:            aws.EndpointSourceCustom,
-			}, nil
-		})
 		// For ODF and Minio, they're deployed in OCP clusters
 		// In some clusters, we can't connect it without proxy, here add proxy settings to s3 client when there has http_proxy or https_proxy in the env var
 		httpClient := awshttp.NewBuildableClient().WithTransportOptions(func(tr *http.Transport) {
@@ -109,7 +102,7 @@ func generateS3Config(cred s3Credential) aws.Config {
 		})
 		cfg, err = config.LoadDefaultConfig(context.TODO(),
 			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(cred.AccessKeyID, cred.SecretAccessKey, "")),
-			config.WithEndpointResolverWithOptions(customResolver),
+			config.WithBaseEndpoint(cred.Endpoint),
 			config.WithHTTPClient(httpClient),
 			config.WithRegion("auto"))
 	} else {

--- a/integration-tests/backend/metrics.go
+++ b/integration-tests/backend/metrics.go
@@ -165,6 +165,13 @@ func verifyEBPFFeatureMetrics(oc *exutil.CLI, feature string) {
 	o.Expect(metrics).Should(o.BeNumerically(">", 0), fmt.Sprintf("%s metrics is 0", feature))
 }
 
+// verify TLS metrics with specified label
+func verifyTLSMetrics(oc *exutil.CLI, field string) {
+	query := fmt.Sprintf(`sum(netobserv_namespace_tls_flows_total{%s!=""})`, field)
+	metrics := pollMetrics(oc, query)
+	o.Expect(metrics).Should(o.BeNumerically(">", 0), fmt.Sprintf("TLS metrics with %s label should be > 0", field))
+}
+
 func getMetricsScheme(oc *exutil.CLI, servicemonitor string, namespace string) (string, error) {
 	out, err := oc.AsAdmin().Run("get").Args("servicemonitor", servicemonitor, "-n", namespace, "-o", "jsonpath='{.spec.endpoints[].scheme}'").Output()
 	return out, err

--- a/integration-tests/backend/test_exporters.go
+++ b/integration-tests/backend/test_exporters.go
@@ -126,7 +126,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			Sampling:                          strconv.Itoa(samplingValue),
 		}
 
-		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		defer flow.DeleteFlowcollector(oc)
 		flow.CreateFlowcollector(oc)
 
 		g.By("Verify flowcollector is deployed with IPFIX exporter")

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -326,7 +326,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 	g.Context("with Loki", func() {
 		var (
 			lokiDir, _ = filePath.Abs("testdata/loki")
-                      	// Loki Operator variables
+			// Loki Operator variables
 			lokiPackageName = "loki-operator"
 			lokiSource      CatalogSourceObjects
 			lokiCatalog     = "redhat-operators"
@@ -341,7 +341,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
 				CatalogSource: &lokiSource,
 			}
-                       	// LokiStack variables
+			// LokiStack variables
 			ipStackType       string
 			lokiStackTemplate = filePath.Join(lokiDir, "lokistack-simple.yaml")
 			lokiTenant        = "openshift-network"
@@ -2683,7 +2683,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				Template:      flowFixturePath,
 			}
 
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
+			defer flow.DeleteFlowcollector(oc)
 			flow.CreateFlowcollector(oc)
 
 			g.By("Wait for a min before logs gets collected and written to loki")
@@ -2717,8 +2717,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			for _, r := range flowRecords {
 				o.Expect(r.Flowlog.TLSTypes).Should(o.ContainElement("ServerHello"), "expected TLS Types to contain ServerHello")
 				o.Expect(r.Flowlog.TLSCipherSuite).NotTo(o.BeEmpty())
-				// Will be fixed in follow-up
-				// o.Expect(r.Flowlog.TLSCurve).NotTo(o.BeEmpty())
 			}
 
 			g.By("Verify HTTPS flows with TLSVersion 1.3")
@@ -2729,9 +2727,14 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			// Verify TLS 1.3 fields
 			for _, r := range flowRecords {
 				o.Expect(r.Flowlog.TLSTypes).Should(o.ContainElement("ServerHello"), "expected TLS Types to contain ServerHello")
-				o.Expect(r.Flowlog.TLSCurve).Should(o.ContainSubstring("X25519"))
+				o.Expect(r.Flowlog.TLSGroup).NotTo(o.BeEmpty())
 				o.Expect(r.Flowlog.TLSCipherSuite).NotTo(o.BeEmpty())
 			}
+
+			g.By("Verify TLS metrics")
+			verifyTLSMetrics(oc, "TLSVersion")
+			verifyTLSMetrics(oc, "TLSCipherSuite")
+			verifyTLSMetrics(oc, "TLSGroup")
 		})
 
 		g.It("Author:kapjain-Medium-88683-Secure communications between Agent and FLP [Serial]", func() {
@@ -2943,8 +2946,8 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				g.By("Deploy Kafka with TLS")
 				oc.CreateSpecifiedNamespaceAsAdmin(kafkaNs)
 				kafkaMetrics.deployKafkaMetrics(oc)
-				kafka.deployKafka(oc)
 				kafkaNodePool.deployKafkaNodePool(oc)
+				kafka.deployKafka(oc)
 				kafkaTopic.deployKafkaTopic(oc)
 				kafkaUser.deployKafkaUser(oc)
 

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -434,15 +434,16 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				g.Skip("Skipping test since LokiStack is not ready")
 			}
 			ls.Route = "https://" + getRouteAddress(oc, ls.Namespace, ls.Name)
-		})
 
-		g.AfterEach(func() {
-			ls.removeLokiStack(oc)
-			ls.removeObjectStorage(oc)
-			if !Lokiexisting {
-				LO.uninstallOperator(oc)
-			}
-			oc.DeleteSpecifiedNamespaceAsAdmin(lokiStackNS)
+			// Defer cleanup - runs even if test fails or panics
+			g.DeferCleanup(func() {
+				ls.removeLokiStack(oc)
+				ls.removeObjectStorage(oc)
+				if !Lokiexisting {
+					LO.uninstallOperator(oc)
+				}
+				oc.DeleteSpecifiedNamespaceAsAdmin(lokiStackNS)
+			})
 		})
 
 		g.Context("FLP, eBPF and Console metrics:", func() {
@@ -2956,17 +2957,18 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				WaitForPodsReadyWithLabel(oc, kafka.Namespace, "strimzi.io/pool-name=kafka-pool")
 				waitForKafkaReady(oc, kafka.Name, kafka.Namespace)
 				waitForKafkaTopicReady(oc, kafkaTopic.TopicName, kafkaTopic.Namespace)
-			})
 
-			g.AfterEach(func() {
-				kafkaUser.deleteKafkaUser(oc)
-				kafkaTopic.deleteKafkaTopic(oc)
-				kafkaNodePool.deleteKafkaNodePool(oc)
-				kafka.deleteKafka(oc)
-				if !AMQexisting {
-					amq.uninstallOperator(oc)
-				}
-				oc.DeleteSpecifiedNamespaceAsAdmin(kafkaNs)
+				// Defer cleanup - runs even if test fails or panics
+				g.DeferCleanup(func() {
+					kafkaUser.deleteKafkaUser(oc)
+					kafkaTopic.deleteKafkaTopic(oc)
+					kafkaNodePool.deleteKafkaNodePool(oc)
+					kafka.deleteKafka(oc)
+					if !AMQexisting {
+						amq.uninstallOperator(oc)
+					}
+					oc.DeleteSpecifiedNamespaceAsAdmin(kafkaNs)
+				})
 			})
 
 			g.It("Author:aramesha-NonPreRelease-Longduration-Critical-56362-High-53597-High-56326-High-64880-High-75340-Verify network flows are captured with Kafka with TLS [Serial][Slow]", func() {
@@ -3198,13 +3200,14 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				o.Expect(err).ToNot(o.HaveOccurred())
 				waitUntilHyperConvergedReady(oc, "kubevirt-hyperconverged", virtOperatorNS)
 				WaitForPodsReadyWithLabel(oc, virtOperatorNS, "app.kubernetes.io/managed-by=virt-operator")
-			})
 
-			g.AfterEach(func() {
-				deleteResource(oc, "hyperconverged", "kubevirt-hyperconverged", virtOperatorNS)
-				if !VOexisting {
-					VO.uninstallOperator(oc)
-				}
+				// Defer cleanup - runs even if test fails or panics
+				g.DeferCleanup(func() {
+					deleteResource(oc, "hyperconverged", "kubevirt-hyperconverged", virtOperatorNS)
+					if !VOexisting {
+						VO.uninstallOperator(oc)
+					}
+				})
 			})
 
 			g.It("Author:aramesha-NonPreRelease-Longduration-High-76537-Verify flow enrichment for VM's secondary interfaces [Disruptive][Slow]", func() {

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -371,6 +371,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			// If Loki Operator was installed by NetObserv tests,
 			//  it will install and uninstall after each spec/test.
 			if !Lokiexisting {
+				g.DeferCleanup(LO.uninstallOperator, oc)
 				ensureOperatorDeployed(oc, LO, lokiSource, "name="+LO.OperatorName)
 			} else {
 				channelName, err := checkOperatorChannel(oc, LO.Namespace, LO.PackageName)
@@ -378,6 +379,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				if channelName != lokiChannel {
 					e2e.Logf("found %s channel for loki operator, removing and reinstalling with %s channel instead", channelName, lokiSource.Channel)
 					LO.uninstallOperator(oc)
+					g.DeferCleanup(LO.uninstallOperator, oc)
 					ensureOperatorDeployed(oc, LO, lokiSource, "name="+LO.OperatorName)
 					Lokiexisting = false
 				}
@@ -394,6 +396,8 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			if len(objectStorageType) == 0 && ipStackType != "ipv6single" {
 				g.Skip("Current cluster doesn't have a proper object storage for this test!")
 			}
+
+			g.DeferCleanup(oc.DeleteSpecifiedNamespaceAsAdmin, lokiStackNS)
 			oc.CreateSpecifiedNamespaceAsAdmin(lokiStackNS)
 
 			ls = &lokiStack{
@@ -413,11 +417,13 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				ls.EnableIPV6 = "true"
 			}
 
+			g.DeferCleanup(ls.removeObjectStorage, oc)
 			err = ls.prepareResourcesForLokiStack(oc)
 			if err != nil {
 				g.Skip("Skipping test since LokiStack resources were not deployed")
 			}
 
+			g.DeferCleanup(ls.removeLokiStack, oc)
 			err = ls.deployLokiStack(oc)
 			if err != nil {
 				g.Skip("Skipping test since LokiStack was not deployed")
@@ -434,16 +440,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				g.Skip("Skipping test since LokiStack is not ready")
 			}
 			ls.Route = "https://" + getRouteAddress(oc, ls.Namespace, ls.Name)
-
-			// Defer cleanup - runs even if test fails or panics
-			g.DeferCleanup(func() {
-				ls.removeLokiStack(oc)
-				ls.removeObjectStorage(oc)
-				if !Lokiexisting {
-					LO.uninstallOperator(oc)
-				}
-				oc.DeleteSpecifiedNamespaceAsAdmin(lokiStackNS)
-			})
 		})
 
 		g.Context("FLP, eBPF and Console metrics:", func() {
@@ -852,6 +848,13 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 
 		g.It("Author:aramesha-NonPreRelease-Critical-59746-NetObserv upgrade testing [Serial]", func() {
 			SkipIfOCPBelow("v4.10")
+
+			// Defer cleanup - ensures operator is uninstalled if test fails/passes
+			g.DeferCleanup(func() {
+				NO.uninstallOperator(oc)
+				oc.DeleteSpecifiedNamespaceAsAdmin(netobservNS)
+			})
+
 			g.By("Uninstall operator deployed by BeforeEach and delete operator NS")
 			NO.uninstallOperator(oc)
 			oc.DeleteSpecifiedNamespaceAsAdmin(netobservNS)
@@ -885,7 +888,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				LokiNamespace: lokiStackNS,
 			}
 
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
+			defer flow.DeleteFlowcollector(oc)
 			flow.CreateFlowcollector(oc)
 
 			g.By("Get NetObserv and components versions")
@@ -2907,6 +2910,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				AMQexisting, err = CheckOperatorStatus(oc, amq.Namespace, amq.PackageName)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				if !AMQexisting {
+					g.DeferCleanup(amq.uninstallOperator, oc)
 					ensureOperatorDeployed(oc, amq, kafkaSource, "name="+amq.OperatorName)
 					// before creating kafka, check the existence of crd kafkas.kafka.strimzi.io
 					checkResource(oc, true, true, "kafka.strimzi.io", []string{"crd", "kafkas.kafka.strimzi.io", "-ojsonpath={.spec.group}"})
@@ -2945,11 +2949,16 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				}
 
 				g.By("Deploy Kafka with TLS")
+				g.DeferCleanup(oc.DeleteSpecifiedNamespaceAsAdmin, kafkaNs)
 				oc.CreateSpecifiedNamespaceAsAdmin(kafkaNs)
 				kafkaMetrics.deployKafkaMetrics(oc)
+				g.DeferCleanup(kafkaNodePool.deleteKafkaNodePool, oc)
 				kafkaNodePool.deployKafkaNodePool(oc)
+				g.DeferCleanup(kafka.deleteKafka, oc)
 				kafka.deployKafka(oc)
+				g.DeferCleanup(kafkaTopic.deleteKafkaTopic, oc)
 				kafkaTopic.deployKafkaTopic(oc)
+				g.DeferCleanup(kafkaUser.deleteKafkaUser, oc)
 				kafkaUser.deployKafkaUser(oc)
 
 				g.By("Check if Kafka and Kafka topic are ready")
@@ -2957,18 +2966,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				WaitForPodsReadyWithLabel(oc, kafka.Namespace, "strimzi.io/pool-name=kafka-pool")
 				waitForKafkaReady(oc, kafka.Name, kafka.Namespace)
 				waitForKafkaTopicReady(oc, kafkaTopic.TopicName, kafkaTopic.Namespace)
-
-				// Defer cleanup - runs even if test fails or panics
-				g.DeferCleanup(func() {
-					kafkaUser.deleteKafkaUser(oc)
-					kafkaTopic.deleteKafkaTopic(oc)
-					kafkaNodePool.deleteKafkaNodePool(oc)
-					kafka.deleteKafka(oc)
-					if !AMQexisting {
-						amq.uninstallOperator(oc)
-					}
-					oc.DeleteSpecifiedNamespaceAsAdmin(kafkaNs)
-				})
 			})
 
 			g.It("Author:aramesha-NonPreRelease-Longduration-Critical-56362-High-53597-High-56326-High-64880-High-75340-Verify network flows are captured with Kafka with TLS [Serial][Slow]", func() {
@@ -3192,22 +3189,16 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				VOexisting, err = CheckOperatorStatus(oc, VO.Namespace, VO.PackageName)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				if !VOexisting {
+					g.DeferCleanup(VO.uninstallOperator, oc)
 					ensureOperatorDeployed(oc, VO, virtSource, "name=virt-operator")
 				}
 
 				g.By("Deploy OpenShift Virtualization Deployment CR")
+				g.DeferCleanup(deleteResource, oc, "hyperconverged", "kubevirt-hyperconverged", virtOperatorNS)
 				_, err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", kubevirtHyperconvergedPath).Output()
 				o.Expect(err).ToNot(o.HaveOccurred())
 				waitUntilHyperConvergedReady(oc, "kubevirt-hyperconverged", virtOperatorNS)
 				WaitForPodsReadyWithLabel(oc, virtOperatorNS, "app.kubernetes.io/managed-by=virt-operator")
-
-				// Defer cleanup - runs even if test fails or panics
-				g.DeferCleanup(func() {
-					deleteResource(oc, "hyperconverged", "kubevirt-hyperconverged", virtOperatorNS)
-					if !VOexisting {
-						VO.uninstallOperator(oc)
-					}
-				})
 			})
 
 			g.It("Author:aramesha-NonPreRelease-Longduration-High-76537-Verify flow enrichment for VM's secondary interfaces [Disruptive][Slow]", func() {

--- a/integration-tests/backend/test_flowcollectorslice.go
+++ b/integration-tests/backend/test_flowcollectorslice.go
@@ -126,6 +126,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		// If Loki Operator was installed by NetObserv tests,
 		//  it will install and uninstall after each spec/test.
 		if !Lokiexisting {
+			g.DeferCleanup(LO.uninstallOperator, oc)
 			ensureOperatorDeployed(oc, LO, lokiSource, "name="+LO.OperatorName)
 		} else {
 			channelName, err := checkOperatorChannel(oc, LO.Namespace, LO.PackageName)
@@ -133,6 +134,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			if channelName != lokiChannel {
 				e2e.Logf("found %s channel for loki operator, removing and reinstalling with %s channel instead", channelName, lokiSource.Channel)
 				LO.uninstallOperator(oc)
+				g.DeferCleanup(LO.uninstallOperator, oc)
 				ensureOperatorDeployed(oc, LO, lokiSource, "name="+LO.OperatorName)
 				Lokiexisting = false
 			}
@@ -149,6 +151,8 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		if len(objectStorageType) == 0 && ipStackType != "ipv6single" {
 			g.Skip("Current cluster doesn't have a proper object storage for this test!")
 		}
+
+		g.DeferCleanup(oc.DeleteSpecifiedNamespaceAsAdmin, lokiStackNS)
 		oc.CreateSpecifiedNamespaceAsAdmin(lokiStackNS)
 
 		ls = &lokiStack{
@@ -168,11 +172,13 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			ls.EnableIPV6 = "true"
 		}
 
+		g.DeferCleanup(ls.removeObjectStorage, oc)
 		err = ls.prepareResourcesForLokiStack(oc)
 		if err != nil {
 			g.Skip("Skipping test since LokiStack resources were not deployed")
 		}
 
+		g.DeferCleanup(ls.removeLokiStack, oc)
 		err = ls.deployLokiStack(oc)
 		if err != nil {
 			g.Skip("Skipping test since LokiStack was not deployed")
@@ -189,16 +195,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			g.Skip("Skipping test since LokiStack is not ready")
 		}
 		ls.Route = "https://" + getRouteAddress(oc, ls.Namespace, ls.Name)
-
-		// Defer cleanup - runs even if test fails or panics
-		g.DeferCleanup(func() {
-			ls.removeLokiStack(oc)
-			ls.removeObjectStorage(oc)
-			if !Lokiexisting {
-				LO.uninstallOperator(oc)
-			}
-			oc.DeleteSpecifiedNamespaceAsAdmin(lokiStackNS)
-		})
 	})
 
 	g.It("Author:aramesha-Critical-86388-Verify flowCollectorSlice collectionMode: AlwaysCollect [Serial]", func() {
@@ -404,7 +400,8 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		serverPodIP, _ := getPodIP(oc, testPingPodsTemplate.ServerNS, "ping-server", ipStackType)
 
 		// Continuously ping server for 300 seconds to generate sustained traffic
-		_, _ = e2eoutput.RunHostCmd(testPingPodsTemplate.ClientNS, "ping-client", "timeout 300 ping "+serverPodIP)
+		_, err = e2eoutput.RunHostCmd(testPingPodsTemplate.ClientNS, "ping-client", "ping -w 300 "+serverPodIP)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		time.Sleep(60 * time.Second)
 
 		lokilabels = Lokilabels{

--- a/integration-tests/backend/test_flowcollectorslice.go
+++ b/integration-tests/backend/test_flowcollectorslice.go
@@ -189,15 +189,16 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			g.Skip("Skipping test since LokiStack is not ready")
 		}
 		ls.Route = "https://" + getRouteAddress(oc, ls.Namespace, ls.Name)
-	})
 
-	g.AfterEach(func() {
-		ls.removeLokiStack(oc)
-		ls.removeObjectStorage(oc)
-		if !Lokiexisting {
-			LO.uninstallOperator(oc)
-		}
-		oc.DeleteSpecifiedNamespaceAsAdmin(lokiStackNS)
+		// Defer cleanup - runs even if test fails or panics
+		g.DeferCleanup(func() {
+			ls.removeLokiStack(oc)
+			ls.removeObjectStorage(oc)
+			if !Lokiexisting {
+				LO.uninstallOperator(oc)
+			}
+			oc.DeleteSpecifiedNamespaceAsAdmin(lokiStackNS)
+		})
 	})
 
 	g.It("Author:aramesha-Critical-86388-Verify flowCollectorSlice collectionMode: AlwaysCollect [Serial]", func() {

--- a/integration-tests/backend/test_flowcollectorslice.go
+++ b/integration-tests/backend/test_flowcollectorslice.go
@@ -402,9 +402,9 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		// Get server pod IP
 		serverPodIP, _ := getPodIP(oc, testPingPodsTemplate.ServerNS, "ping-server", ipStackType)
 
-		// Ping server pod from client pod
-		_, _ = e2eoutput.RunHostCmd(testPingPodsTemplate.ClientNS, "ping-client", "ping -c 100 "+serverPodIP)
-		time.Sleep(120 * time.Second)
+		// Continuously ping server for 300 seconds to generate sustained traffic
+		_, _ = e2eoutput.RunHostCmd(testPingPodsTemplate.ClientNS, "ping-client", "timeout 300 ping "+serverPodIP)
+		time.Sleep(60 * time.Second)
 
 		lokilabels = Lokilabels{
 			App:             "netobserv-flowcollector",

--- a/integration-tests/backend/testdata/kafka/kafka-default.yaml
+++ b/integration-tests/backend/testdata/kafka/kafka-default.yaml
@@ -3,7 +3,7 @@ apiVersion: template.openshift.io/v1
 metadata:
   name: kafka-template
 objects:
-- apiVersion: kafka.strimzi.io/v1beta2
+- apiVersion: kafka.strimzi.io/v1
   kind: Kafka
   metadata:
     name: "${NAME}"
@@ -45,8 +45,7 @@ objects:
         log.retention.ms: 1680000
         log.roll.ms: 7200000
         log.segment.bytes: 1073741824
-      metadataVersion: 4.0-IV3
-      version: 4.0.0
+      version: 4.1.0
       metricsConfig:
         type: jmxPrometheusExporter
         valueFrom:

--- a/integration-tests/backend/testdata/kafka/kafka-node-pool.yaml
+++ b/integration-tests/backend/testdata/kafka/kafka-node-pool.yaml
@@ -3,7 +3,7 @@ apiVersion: template.openshift.io/v1
 metadata:
   name: kafka-node-pool-template
 objects:
-- apiVersion: kafka.strimzi.io/v1beta2
+- apiVersion: kafka.strimzi.io/v1
   kind: KafkaNodePool
   metadata:
     name: "${NODEPOOL}"

--- a/integration-tests/backend/testdata/kafka/kafka-tls.yaml
+++ b/integration-tests/backend/testdata/kafka/kafka-tls.yaml
@@ -3,7 +3,7 @@ apiVersion: template.openshift.io/v1
 metadata:
   name: kafka-TLS-template
 objects:
-- apiVersion: kafka.strimzi.io/v1beta2
+- apiVersion: kafka.strimzi.io/v1
   kind: Kafka
   metadata:
     name: "${NAME}"
@@ -49,8 +49,7 @@ objects:
         log.retention.ms: 1680000
         log.roll.ms: 7200000
         log.segment.bytes: 1073741824
-      metadataVersion: 4.0-IV3
-      version: 4.0.0
+      version: 4.1.0
       metricsConfig:
         type: jmxPrometheusExporter
         valueFrom:

--- a/integration-tests/backend/testdata/kafka/kafka-topic.yaml
+++ b/integration-tests/backend/testdata/kafka/kafka-topic.yaml
@@ -3,7 +3,7 @@ apiVersion: template.openshift.io/v1
 metadata:
   name: kafka-topic-template
 objects:
-- apiVersion: kafka.strimzi.io/v1beta2
+- apiVersion: kafka.strimzi.io/v1
   kind: KafkaTopic
   metadata:
     name: "${TOPIC}"

--- a/integration-tests/backend/testdata/kafka/kafka-user.yaml
+++ b/integration-tests/backend/testdata/kafka/kafka-user.yaml
@@ -3,7 +3,7 @@ apiVersion: template.openshift.io/v1
 metadata:
   name: kafka-user-template
 objects:
-- apiVersion: kafka.strimzi.io/v1beta2
+- apiVersion: kafka.strimzi.io/v1
   kind: KafkaUser
   metadata:
     labels:

--- a/integration-tests/backend/testdata/subscription/image-digest-mirror-set.yaml
+++ b/integration-tests/backend/testdata/subscription/image-digest-mirror-set.yaml
@@ -29,5 +29,10 @@ spec:
       - quay.io/redhat-user-workloads/ocp-network-observab-tenant/network-observability-operator-bundle-zstream
       source: registry.redhat.io/network-observability/network-observability-operator-bundle
     - mirrors:
+      - quay.io/redhat-user-workloads/ocp-network-observab-tenant/network-observability-console-plugin-pf5-ystream
+      - quay.io/redhat-user-workloads/ocp-network-observab-tenant/network-observability-console-plugin-pf5-zstream
+      source: registry.redhat.io/network-observability/network-observability-console-plugin-pf5-rhel9
+    - mirrors:
       - quay.io/redhat-user-workloads/ocp-network-observab-tenant/network-observability-console-plugin-pf4-ystream
-      source: registry.redhat.io/network-observability/network-observability-console-plugin-compat-rhel9
+      - quay.io/redhat-user-workloads/ocp-network-observab-tenant/network-observability-console-plugin-pf4-zstream
+      source: registry.redhat.io/network-observability/network-observability-console-plugin-pf4-rhel9


### PR DESCRIPTION
## Description

PR changes:
- Update IDMS due to new PF5 builds
- [NETOBSERV-2680](https://redhat.atlassian.net/browse/NETOBSERV-2680): Fix Kafka tests by updating API to v1
- [NETOBSERV-2681](https://redhat.atlassian.net/browse/NETOBSERV-2681): Fix flowcollectorSlice flake by adding continous ping
- Update TLS test to add metrics test and also rename TLSCurve to TLSGroup
- [NETOBSERV-2734](https://redhat.atlassian.net/browse/NETOBSERV-2734): cleanup `netobserv-loki`, `netobserv-kafka` NS if tests fail. Using deferCleanup instead of AferEach
- [NETOBSERV-2756](https://redhat.atlassian.net/browse/NETOBSERV-2756): Added defer UninstallOperator to upgrade test such that the operator is uninstalled if test passes/fails. The next test in the suite will do a fresh install so we wont be stuck with latest released version if upgrade fails
- [NETOBSERV-2737](https://redhat.atlassian.net/browse/NETOBSERV-2737): IPFIX exporter test fails since some flows dont have src, dstPort and we set it to 0 then. So fixing the test by relaxing the verify func

## Dependencies

n/a

## Test Results

  [sig-netobserv] Network_Observability with Loki with Kafka Author:aramesha-NonPreRelease-Longduration-Critical-56362-High-53597-High-56326-High-64880-High-75340-Verify network flows are captured with Kafka
  with TLS [Serial][Slow]
  • PASSED [967.493 seconds]

  [sig-netobserv] Network_Observability with Loki with Kafka Author:aramesha-NonPreRelease-Longduration-High-57397-High-65116-Verify network-flows export with Kafka and netobserv installation without
  Loki[Serial]
  • PASSED [867.917 seconds]

[sig-netobserv] Network_Observability Author:aramesha-Critical-86388-Verify flowCollectorSlice collectionMode: AlwaysCollect [Serial]
  • PASSED [663.264 seconds]

  [sig-netobserv] Network_Observability Author:aramesha-Critical-86388-Verify flowCollectorSlice collectionMode: AllowList [Serial]
  • PASSED [1047.535 seconds]

[sig-netobserv] Network_Observability with Loki Author:aramesha-NonPreRelease-High-88455-Verify TLS Tracking feature [Serial]
  • PASSED [821.818 seconds]

  [sig-netobserv] Network_Observability with Loki Author:aramesha-NonPreRelease-Critical-59746-NetObserv upgrade testing [Serial]
  • PASSED [725.090 seconds] -> Operator got uninstalled even though test passed

[sig-netobserv] Network_Observability Author:aramesha-High-64156-Verify IPFIX-exporter [Serial]
• PASSED [194.861 seconds]

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flow logs and metrics now report TLS group information (replacing the prior curve attribute).

* **Tests**
  * Strengthened TLS validations and added metrics checks for TLS group.
  * Improved test reliability: many teardowns moved to deferred cleanup, deployment ordering refined, and timing adjustments.

* **Chores**
  * Upgraded Strimzi Kafka templates to API v1 and bumped broker version to 4.1.0.
  * Updated console-plugin image mirrors and refined custom S3 endpoint client config.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netobserv/netobserv-operator/pull/2778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->