### PR TITLE
fix timeout issue

### DIFF
--- a/integration-tests/backend/flowcollector_utils.go
+++ b/integration-tests/backend/flowcollector_utils.go
@@ -360,12 +360,10 @@ func (lokilabels Lokilabels) getLokiFlowLogs(token, lokiRoute string, startTime 
 		res, qErr = lc.searchLogsInLoki(tenantID, lokiQuery)
 		if qErr != nil {
 			e2e.Logf("\ngot error %v when getting %s logs for query: %s\n", qErr, tenantID, lokiQuery)
-			return false, qErr
+			return false, nil
 		}
 
-		// return results if no error and result is empty
-		// caller should add assertions to ensure len([]FlowRecord) is as they expected for given loki query
-		return len(res.Data.Result) > 0, nil
+		return true, nil
 	})
 
 	if err != nil {


### PR DESCRIPTION
## Description

Fix for failing 73175, noticed during [this jenkins run](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/netobserv/job/noo-backend-tests/31/console):
```
05-20 17:02:54.761    << Timeline
05-20 17:02:54.761  
05-20 17:02:54.761    [FAILED] Unexpected error:
05-20 17:02:54.761        <context.deadlineExceededError>: 
05-20 17:02:54.761        context deadline exceeded
05-20 17:02:54.761        
05-20 17:02:54.761            {}
05-20 17:02:54.761    occurred
05-20 17:02:54.761    In [It] at: /home/jenkins/ws/workspace/netobserv/noo-backend-tests/network-observability-operator/integration-tests/backend/test_flowcollector.go:1315 @ 05/20/26 15:02:08.737
```

Now passing succesfully, sanity test passing as well:
```
[sig-netobserv] Network_Observability with Loki Author:aramesha-NonPreRelease-Longduration-High-73175-Verify eBPF agent filtering [Serial]
/home/osmakal/Repos/network-observability-operator/integration-tests/backend/test_flowcollector.go:1236
• PASSED [786.372 seconds]
[sig-netobserv] Network_Observability with Loki Author:memodi-Critical-53844-Sanity Test NetObserv [Serial]
/home/osmakal/Repos/network-observability-operator/integration-tests/backend/test_flowcollector.go:1389
• PASSED [418.069 seconds]
```

The problem was that in the testcase, 0 flows are actually expected which would previously returned false and force the timeout.

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test robustness by handling transient errors gracefully during polling operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netobserv/netobserv-operator/pull/2779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->