### PR TITLE
NETOBSERV-2760: configure console k8s client token access

### DIFF
--- a/.mk/development.mk
+++ b/.mk/development.mk
@@ -167,7 +167,7 @@ set-plugin-image:
 ifeq ("", "$(CSV)")
 	kubectl set env -n $(NAMESPACE) deployment netobserv-controller-manager -c "manager" RELATED_IMAGE_CONSOLE_PLUGIN=$(IMAGE_REGISTRY)/$(USER)/network-observability-console-plugin:$(VERSION)
 	kubectl set env -n $(NAMESPACE) deployment netobserv-controller-manager -c "manager" RELATED_IMAGE_CONSOLE_PLUGIN_PF5=$(IMAGE_REGISTRY)/$(USER)/network-observability-console-plugin:$(VERSION)
-	kubectl set image deployment/netobserv-plugin-static netobserv-plugin-static=$(IMAGE_REGISTRY)/$(USER)/network-observability-console-plugin:$(VERSION)
+	kubectl set image deployment/netobserv-plugin-static netobserv-plugin-static=$(IMAGE_REGISTRY)/$(USER)/network-observability-console-plugin:$(VERSION) -n $(NAMESPACE)
 else
 	./hack/swap-image-csv.sh $(CSV) $(OPERATOR_NS) console-plugin RELATED_IMAGE_CONSOLE_PLUGIN $(IMAGE_REGISTRY)/$(USER)/network-observability-console-plugin:$(VERSION)
 	./hack/swap-image-csv.sh $(CSV) $(OPERATOR_NS) console-plugin-pf5 RELATED_IMAGE_CONSOLE_PLUGIN_PF5 $(IMAGE_REGISTRY)/$(USER)/network-observability-console-plugin:$(VERSION)

--- a/bundle/manifests/netobserv-flowcollector-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/netobserv-flowcollector-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: netobserv-flowcollector-viewer-role
+rules:
+- apiGroups:
+  - flows.netobserv.io
+  resources:
+  - flowcollectors
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - flows.netobserv.io
+  resources:
+  - flowcollectors/status
+  verbs:
+  - get

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
 - metrics_role.yaml
 - metrics_role_binding.yaml
 - component_roles.yaml
+- flowcollector_viewer_role.yaml

--- a/helm/templates/netobserv-flowcollector-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/helm/templates/netobserv-flowcollector-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: netobserv-flowcollector-viewer-role
+rules:
+- apiGroups:
+  - flows.netobserv.io
+  resources:
+  - flowcollectors
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - flows.netobserv.io
+  resources:
+  - flowcollectors/status
+  verbs:
+  - get

--- a/internal/controller/consoleplugin/config/config.go
+++ b/internal/controller/consoleplugin/config/config.go
@@ -35,7 +35,6 @@ type LokiConfig struct {
 	StatusCAPath       string       `yaml:"statusCaPath,omitempty" json:"statusCaPath,omitempty"`
 	StatusUserCertPath string       `yaml:"statusUserCertPath,omitempty" json:"statusUserCertPath,omitempty"`
 	StatusUserKeyPath  string       `yaml:"statusUserKeyPath,omitempty" json:"statusUserKeyPath,omitempty"`
-	UseMocks           bool         `yaml:"useMocks,omitempty" json:"useMocks,omitempty"`
 	ForwardUserToken   bool         `yaml:"forwardUserToken,omitempty" json:"forwardUserToken,omitempty"`
 }
 
@@ -64,6 +63,11 @@ type MetricInfo struct {
 	ValueField string   `yaml:"valueField,omitempty" json:"valueField,omitempty"`
 	Direction  string   `yaml:"direction,omitempty" json:"direction,omitempty"`
 	Labels     []string `yaml:"labels,omitempty" json:"labels,omitempty"`
+}
+
+type K8SConfig struct {
+	TokenPath        string `yaml:"tokenPath,omitempty" json:"tokenPath,omitempty"`
+	ForwardUserToken bool   `yaml:"forwardUserToken" json:"forwardUserToken"` // do not omit empty, so "false" can override the default "true" in plugin
 }
 
 type ColumnConfig struct {
@@ -131,11 +135,21 @@ type FrontendConfig struct {
 	RecordingAnnotations map[string]map[string]string        `yaml:"recordingAnnotations,omitempty" json:"recordingAnnotations,omitempty"`
 }
 
+type ConsoleMode string
+
+const (
+	Standalone      ConsoleMode = "Standalone"
+	OpenShiftPlugin ConsoleMode = "OpenShiftPlugin"
+	Mock            ConsoleMode = "Mock"
+)
+
 type PluginConfig struct {
-	Server     ServerConfig     `yaml:"server" json:"server"`
-	Loki       LokiConfig       `yaml:"loki" json:"loki"`
-	Prometheus PrometheusConfig `yaml:"prometheus" json:"prometheus"`
-	Frontend   FrontendConfig   `yaml:"frontend" json:"frontend"`
+	ConsoleMode ConsoleMode      `yaml:"consoleMode" json:"consoleMode"`
+	Server      ServerConfig     `yaml:"server" json:"server"`
+	Loki        LokiConfig       `yaml:"loki" json:"loki"`
+	Prometheus  PrometheusConfig `yaml:"prometheus" json:"prometheus"`
+	Kubernetes  K8SConfig        `yaml:"kubernetes" json:"kubernetes"`
+	Frontend    FrontendConfig   `yaml:"frontend" json:"frontend"`
 }
 
 //go:embed static-frontend-config.yaml

--- a/internal/controller/consoleplugin/consoleplugin_objects.go
+++ b/internal/controller/consoleplugin/consoleplugin_objects.go
@@ -631,10 +631,17 @@ func (b *builder) configMap(ctx context.Context, externalRecordingAnnotations ma
 		Server: cfg.ServerConfig{
 			Port: int(*b.advanced.Port),
 		},
+		Kubernetes: cfg.K8SConfig{
+			ForwardUserToken: true,
+		},
 	}
 	if b.useStandalone {
-		config.Server.AuthCheck = "none"
+		config.ConsoleMode = cfg.Standalone
+		// No access management yet in the standalone console
+		config.Kubernetes.ForwardUserToken = false
+		config.Kubernetes.TokenPath = b.volumes.AddToken(constants.PluginName)
 	} else {
+		config.ConsoleMode = cfg.OpenShiftPlugin
 		config.Server.CertPath = "/var/serving-cert/tls.crt"
 		config.Server.KeyPath = "/var/serving-cert/tls.key"
 	}

--- a/internal/controller/consoleplugin/consoleplugin_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_reconciler.go
@@ -124,10 +124,10 @@ func (r *CPReconciler) reconcile(ctx context.Context, desired *flowslatest.FlowC
 			// Watch for Loki certificates if necessary; we'll ignore in that case the returned digest, as we don't need to restart pods on cert rotation
 			// because certificate is always reloaded from file
 			if _, err = r.Watcher.ProcessCACert(ctx, r.Client, &r.Loki.TLS, r.Namespace); err != nil {
-				return err
+				r.Status.SetDegraded("LokiCACertMissing", err.Error())
 			}
 			if _, _, err = r.Watcher.ProcessMTLSCerts(ctx, r.Client, &r.Loki.StatusTLS, r.Namespace); err != nil {
-				return err
+				r.Status.SetDegraded("LokiMTLSCertMissing", err.Error())
 			}
 		}
 	} else {

--- a/internal/controller/consoleplugin/consoleplugin_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_reconciler.go
@@ -17,6 +17,7 @@ import (
 
 	flowslatest "github.com/netobserv/netobserv-operator/api/flowcollector/v1beta2"
 	"github.com/netobserv/netobserv-operator/internal/controller/constants"
+	"github.com/netobserv/netobserv-operator/internal/controller/lokistack"
 	"github.com/netobserv/netobserv-operator/internal/controller/reconcilers"
 	"github.com/netobserv/netobserv-operator/internal/pkg/helper"
 	"github.com/netobserv/netobserv-operator/internal/pkg/manager/status"
@@ -90,6 +91,17 @@ func (r *CPReconciler) reconcile(ctx context.Context, desired *flowslatest.FlowC
 	}
 
 	if desired.Spec.NeedsConsolePluginDeployment(hasPluginAPI) {
+		if lokiStatus != nil && lokiStatus.Status == status.StatusFailure &&
+			(lokiStatus.Reason == lokistack.LokiStackAPIMissing || lokiStatus.Reason == lokistack.LokiCantFetchLokiStack) {
+			// If LokiStack is missing, turn off TLS config; queries will fail anyway, but we don't want to try mounting
+			// the missing certificates, as it prevents the console plugin pod to start.
+			lokiCopy := *r.Loki
+			lokiCopy.LokiManualParams.TLS.Enable = false
+			lokiCopy.LokiManualParams.StatusTLS.Enable = false
+			r.Loki = &lokiCopy
+			r.Status.SetDegraded("LokiStackMissing", "LokiStack is missing, can't mount certificates")
+		}
+
 		// Create object builder
 		builder := newBuilder(r.Instance, &desired.Spec, constants.PluginName)
 

--- a/internal/controller/consoleplugin/consoleplugin_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_reconciler.go
@@ -61,7 +61,8 @@ func (r *CPReconciler) Reconcile(ctx context.Context, desired *flowslatest.FlowC
 	l := log.FromContext(ctx).WithName("web-console")
 	ctx = log.IntoContext(ctx, l)
 
-	defer r.Status.Commit(ctx, r.Client)
+	commit := r.Status.Reset()
+	defer commit(ctx, r.Client)
 
 	err := r.reconcile(ctx, desired, lokiStatus)
 	if err != nil {

--- a/internal/controller/consoleplugin/consoleplugin_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_reconciler.go
@@ -174,7 +174,24 @@ func (r *CPReconciler) reconcilePermissions(ctx context.Context, builder *builde
 		name,
 		constants.ConsoleTokenReviewRole,
 	)
-	return r.ReconcileClusterRoleBinding(ctx, binding)
+	if err := r.ReconcileClusterRoleBinding(ctx, binding); err != nil {
+		return err
+	}
+	if builder.useStandalone {
+		// Currently, standalone mode uses service account token, not user token, for permissions.
+		// Add FlowCollector viewer role so that it can display the FC status icon.
+		binding := resources.GetClusterRoleBinding(
+			r.Namespace,
+			constants.PluginShortName,
+			name,
+			name,
+			constants.FlowCollectorViewerRole,
+		)
+		if err := r.ReconcileClusterRoleBinding(ctx, binding); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *CPReconciler) reconcilePlugin(ctx context.Context, builder *builder, desired *flowslatest.FlowCollectorSpec, name, displayName string) error {

--- a/internal/controller/consoleplugin/consoleplugin_test.go
+++ b/internal/controller/consoleplugin/consoleplugin_test.go
@@ -274,10 +274,6 @@ func TestConfigMapUpdateCheck(t *testing.T) {
 	assert.NotEqual(old.Data, nEw.Data)
 }
 
-func newLokiConfig(spec *flowslatest.FlowCollectorLoki) helper.LokiConfig {
-	return helper.NewLokiConfig(spec, "any", nil)
-}
-
 func TestConfigMapUpdateWithLokistackMode(t *testing.T) {
 	assert := assert.New(t)
 
@@ -287,7 +283,7 @@ func TestConfigMapUpdateWithLokistackMode(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "lokistack", Namespace: "ls-namespace"},
 	}
-	loki := newLokiConfig(&lokiSpec)
+	loki := helper.NewLokiConfig(&lokiSpec, "any")
 	spec := flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: lokiSpec}
 	builder := getBuilder(&spec, &loki)
 	old, _, _ := builder.configMap(context.Background(), nil, &lokiStatusUnused)
@@ -296,7 +292,7 @@ func TestConfigMapUpdateWithLokistackMode(t *testing.T) {
 
 	// update lokistack name
 	lokiSpec.LokiStack.Name = "lokistack-updated"
-	loki = newLokiConfig(&lokiSpec)
+	loki = helper.NewLokiConfig(&lokiSpec, "any")
 
 	spec = flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: lokiSpec}
 	builder = getBuilder(&spec, &loki)
@@ -306,7 +302,7 @@ func TestConfigMapUpdateWithLokistackMode(t *testing.T) {
 
 	// update lokistack namespace
 	lokiSpec.LokiStack.Namespace = "ls-namespace-updated"
-	loki = newLokiConfig(&lokiSpec)
+	loki = helper.NewLokiConfig(&lokiSpec, "any")
 
 	spec = flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: lokiSpec}
 	builder = getBuilder(&spec, &loki)
@@ -327,7 +323,7 @@ func TestConfigMapContent(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "lokistack", Namespace: "ls-namespace"},
 	}
-	loki := newLokiConfig(&lokiSpec)
+	loki := helper.NewLokiConfig(&lokiSpec, "any")
 	spec := flowslatest.FlowCollectorSpec{
 		Agent:         agentSpec,
 		ConsolePlugin: getPluginConfig(),
@@ -363,7 +359,7 @@ func TestConfigMapExternalRecordingAnnotations(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "lokistack", Namespace: "ls-namespace"},
 	}
-	loki := newLokiConfig(&lokiSpec)
+	loki := helper.NewLokiConfig(&lokiSpec, "any")
 	spec := flowslatest.FlowCollectorSpec{
 		ConsolePlugin: getPluginConfig(),
 		Loki:          lokiSpec,
@@ -525,7 +521,7 @@ func TestLokiStackStatusEmbedding(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "lokistack", Namespace: "ls-namespace"},
 	}
-	loki := newLokiConfig(&lokiSpec)
+	loki := helper.NewLokiConfig(&lokiSpec, "any")
 	spec := flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: lokiSpec}
 	builder := getBuilder(&spec, &loki)
 
@@ -581,7 +577,7 @@ func TestLokiStackNamespaceDefaulting(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "my-lokistack", Namespace: "custom-namespace"},
 	}
-	loki := helper.NewLokiConfig(&lokiSpec, "default-namespace", nil)
+	loki := helper.NewLokiConfig(&lokiSpec, "default-namespace")
 
 	// Verify URLs use the explicitly set namespace
 	assert.Contains(loki.QuerierURL, "custom-namespace")
@@ -593,7 +589,7 @@ func TestLokiStackNamespaceDefaulting(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "my-lokistack", Namespace: ""},
 	}
-	lokiDefault := helper.NewLokiConfig(&lokiSpecDefault, "flowcollector-namespace", nil)
+	lokiDefault := helper.NewLokiConfig(&lokiSpecDefault, "flowcollector-namespace")
 
 	// Verify URLs use the defaulted namespace
 	assert.Contains(lokiDefault.QuerierURL, "flowcollector-namespace")
@@ -615,7 +611,7 @@ func TestLokiStackNotFoundBehavior(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "missing-lokistack", Namespace: "test-namespace"},
 	}
-	loki := newLokiConfig(&lokiSpec)
+	loki := helper.NewLokiConfig(&lokiSpec, "any")
 	spec := flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: lokiSpec}
 	builder := getBuilder(&spec, &loki)
 
@@ -660,7 +656,7 @@ func TestScopeFilteringWithLoki(t *testing.T) {
 	lokiSpec := flowslatest.FlowCollectorLoki{
 		Enable: ptr.To(true),
 	}
-	loki := newLokiConfig(&lokiSpec)
+	loki := helper.NewLokiConfig(&lokiSpec, "any")
 	spec := flowslatest.FlowCollectorSpec{
 		Agent: flowslatest.FlowCollectorAgent{
 			EBPF: flowslatest.FlowCollectorEBPF{
@@ -700,7 +696,7 @@ func TestScopeFilteringNoLoki(t *testing.T) {
 	lokiSpec := flowslatest.FlowCollectorLoki{
 		Enable: ptr.To(false),
 	}
-	loki := newLokiConfig(&lokiSpec)
+	loki := helper.NewLokiConfig(&lokiSpec, "any")
 	spec := flowslatest.FlowCollectorSpec{
 		Agent: flowslatest.FlowCollectorAgent{
 			EBPF: flowslatest.FlowCollectorEBPF{

--- a/internal/controller/consoleplugin/consoleplugin_test.go
+++ b/internal/controller/consoleplugin/consoleplugin_test.go
@@ -274,6 +274,10 @@ func TestConfigMapUpdateCheck(t *testing.T) {
 	assert.NotEqual(old.Data, nEw.Data)
 }
 
+func newLokiConfig(spec *flowslatest.FlowCollectorLoki) helper.LokiConfig {
+	return helper.NewLokiConfig(spec, "any", nil)
+}
+
 func TestConfigMapUpdateWithLokistackMode(t *testing.T) {
 	assert := assert.New(t)
 
@@ -283,7 +287,7 @@ func TestConfigMapUpdateWithLokistackMode(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "lokistack", Namespace: "ls-namespace"},
 	}
-	loki := helper.NewLokiConfig(&lokiSpec, "any")
+	loki := newLokiConfig(&lokiSpec)
 	spec := flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: lokiSpec}
 	builder := getBuilder(&spec, &loki)
 	old, _, _ := builder.configMap(context.Background(), nil, &lokiStatusUnused)
@@ -292,7 +296,7 @@ func TestConfigMapUpdateWithLokistackMode(t *testing.T) {
 
 	// update lokistack name
 	lokiSpec.LokiStack.Name = "lokistack-updated"
-	loki = helper.NewLokiConfig(&lokiSpec, "any")
+	loki = newLokiConfig(&lokiSpec)
 
 	spec = flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: lokiSpec}
 	builder = getBuilder(&spec, &loki)
@@ -302,7 +306,7 @@ func TestConfigMapUpdateWithLokistackMode(t *testing.T) {
 
 	// update lokistack namespace
 	lokiSpec.LokiStack.Namespace = "ls-namespace-updated"
-	loki = helper.NewLokiConfig(&lokiSpec, "any")
+	loki = newLokiConfig(&lokiSpec)
 
 	spec = flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: lokiSpec}
 	builder = getBuilder(&spec, &loki)
@@ -323,7 +327,7 @@ func TestConfigMapContent(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "lokistack", Namespace: "ls-namespace"},
 	}
-	loki := helper.NewLokiConfig(&lokiSpec, "any")
+	loki := newLokiConfig(&lokiSpec)
 	spec := flowslatest.FlowCollectorSpec{
 		Agent:         agentSpec,
 		ConsolePlugin: getPluginConfig(),
@@ -359,7 +363,7 @@ func TestConfigMapExternalRecordingAnnotations(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "lokistack", Namespace: "ls-namespace"},
 	}
-	loki := helper.NewLokiConfig(&lokiSpec, "any")
+	loki := newLokiConfig(&lokiSpec)
 	spec := flowslatest.FlowCollectorSpec{
 		ConsolePlugin: getPluginConfig(),
 		Loki:          lokiSpec,
@@ -521,7 +525,7 @@ func TestLokiStackStatusEmbedding(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "lokistack", Namespace: "ls-namespace"},
 	}
-	loki := helper.NewLokiConfig(&lokiSpec, "any")
+	loki := newLokiConfig(&lokiSpec)
 	spec := flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: lokiSpec}
 	builder := getBuilder(&spec, &loki)
 
@@ -577,7 +581,7 @@ func TestLokiStackNamespaceDefaulting(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "my-lokistack", Namespace: "custom-namespace"},
 	}
-	loki := helper.NewLokiConfig(&lokiSpec, "default-namespace")
+	loki := helper.NewLokiConfig(&lokiSpec, "default-namespace", nil)
 
 	// Verify URLs use the explicitly set namespace
 	assert.Contains(loki.QuerierURL, "custom-namespace")
@@ -589,7 +593,7 @@ func TestLokiStackNamespaceDefaulting(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "my-lokistack", Namespace: ""},
 	}
-	lokiDefault := helper.NewLokiConfig(&lokiSpecDefault, "flowcollector-namespace")
+	lokiDefault := helper.NewLokiConfig(&lokiSpecDefault, "flowcollector-namespace", nil)
 
 	// Verify URLs use the defaulted namespace
 	assert.Contains(lokiDefault.QuerierURL, "flowcollector-namespace")
@@ -611,7 +615,7 @@ func TestLokiStackNotFoundBehavior(t *testing.T) {
 		Mode:      flowslatest.LokiModeLokiStack,
 		LokiStack: flowslatest.LokiStackRef{Name: "missing-lokistack", Namespace: "test-namespace"},
 	}
-	loki := helper.NewLokiConfig(&lokiSpec, "any")
+	loki := newLokiConfig(&lokiSpec)
 	spec := flowslatest.FlowCollectorSpec{ConsolePlugin: plugin, Loki: lokiSpec}
 	builder := getBuilder(&spec, &loki)
 
@@ -656,7 +660,7 @@ func TestScopeFilteringWithLoki(t *testing.T) {
 	lokiSpec := flowslatest.FlowCollectorLoki{
 		Enable: ptr.To(true),
 	}
-	loki := helper.NewLokiConfig(&lokiSpec, "any")
+	loki := newLokiConfig(&lokiSpec)
 	spec := flowslatest.FlowCollectorSpec{
 		Agent: flowslatest.FlowCollectorAgent{
 			EBPF: flowslatest.FlowCollectorEBPF{
@@ -696,7 +700,7 @@ func TestScopeFilteringNoLoki(t *testing.T) {
 	lokiSpec := flowslatest.FlowCollectorLoki{
 		Enable: ptr.To(false),
 	}
-	loki := helper.NewLokiConfig(&lokiSpec, "any")
+	loki := newLokiConfig(&lokiSpec)
 	spec := flowslatest.FlowCollectorSpec{
 		Agent: flowslatest.FlowCollectorAgent{
 			EBPF: flowslatest.FlowCollectorEBPF{

--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -61,14 +61,15 @@ const (
 	DNSNamespace                    = "openshift-dns"
 
 	// [Cluster]Roles, must match names in config/rbac/component_roles.yaml (without netobserv- prefix)
-	LokiWriterRole         ClusterRoleName = "netobserv-loki-writer"
-	LokiReaderRole         ClusterRoleName = "netobserv-loki-reader"
-	PromReaderRole         ClusterRoleName = "netobserv-metrics-reader"
-	ExposeMetricsRole      RoleName        = "netobserv-expose-metrics"
-	FLPInformersRole       ClusterRoleName = "netobserv-informers"
-	HostNetworkRole        ClusterRoleName = "netobserv-hostnetwork"
-	ConsoleTokenReviewRole ClusterRoleName = "netobserv-token-review"
-	ConfigWatcherRole      RoleName        = "netobserv-config-watcher"
+	LokiWriterRole          ClusterRoleName = "netobserv-loki-writer"
+	LokiReaderRole          ClusterRoleName = "netobserv-loki-reader"
+	PromReaderRole          ClusterRoleName = "netobserv-metrics-reader"
+	ExposeMetricsRole       RoleName        = "netobserv-expose-metrics"
+	FLPInformersRole        ClusterRoleName = "netobserv-informers"
+	HostNetworkRole         ClusterRoleName = "netobserv-hostnetwork"
+	ConsoleTokenReviewRole  ClusterRoleName = "netobserv-token-review"
+	FlowCollectorViewerRole ClusterRoleName = "netobserv-flowcollector-viewer-role"
+	ConfigWatcherRole       RoleName        = "netobserv-config-watcher"
 )
 
 var FlowCollectorName = types.NamespacedName{Name: "cluster"}

--- a/internal/controller/demoloki/demoloki_reconciler.go
+++ b/internal/controller/demoloki/demoloki_reconciler.go
@@ -40,7 +40,8 @@ func (r *LReconciler) Reconcile(ctx context.Context, desired *flowslatest.FlowCo
 	l := log.FromContext(ctx).WithName("demo-loki")
 	ctx = log.IntoContext(ctx, l)
 
-	defer r.Status.Commit(ctx, r.Client)
+	commit := r.Status.Reset()
+	defer commit(ctx, r.Client)
 
 	err := r.reconcile(ctx, desired)
 	if err != nil {

--- a/internal/controller/ebpf/agent_controller.go
+++ b/internal/controller/ebpf/agent_controller.go
@@ -140,7 +140,8 @@ func (c *AgentController) Reconcile(ctx context.Context, target *flowslatest.Flo
 	rlog := log.FromContext(ctx).WithName("ebpf")
 	ctx = log.IntoContext(ctx, rlog)
 
-	defer c.Status.Commit(ctx, c.Client)
+	commit := c.Status.Reset()
+	defer commit(ctx, c.Client)
 
 	err := c.reconcile(ctx, target)
 	if err != nil {

--- a/internal/controller/flowcollector_controller.go
+++ b/internal/controller/flowcollector_controller.go
@@ -123,7 +123,8 @@ func (r *FlowCollectorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	defer r.status.Commit(ctx, r.Client)
+	commit := r.status.Reset()
+	defer commit(ctx, r.Client)
 
 	err = r.reconcile(ctx, clh, desired)
 	if err != nil {

--- a/internal/controller/flowcollector_controller.go
+++ b/internal/controller/flowcollector_controller.go
@@ -145,8 +145,6 @@ func (r *FlowCollectorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 func (r *FlowCollectorReconciler) reconcile(ctx context.Context, clh *helper.Client, desired *flowslatest.FlowCollector) error {
 	ns := desired.Spec.GetNamespace()
 	previousNamespace := r.status.GetDeployedNamespace(desired)
-	lokiConfig := helper.NewLokiConfig(&desired.Spec.Loki, ns)
-	reconcilersInfo := r.newCommonInfo(clh, ns, &lokiConfig)
 
 	if err := r.checkFinalizer(ctx, desired); err != nil {
 		return err
@@ -158,6 +156,8 @@ func (r *FlowCollectorReconciler) reconcile(ctx context.Context, clh *helper.Cli
 	r.watcher.Reset(ns)
 
 	lokiStatus := r.lokistackWatcher.Reconcile(ctx, desired)
+	lokiConfig := helper.NewLokiConfig(&desired.Spec.Loki, ns, &lokiStatus)
+	reconcilersInfo := r.newCommonInfo(clh, ns, &lokiConfig)
 
 	var cpImage string
 	if desired.Spec.NeedsConsolePluginDeployment(r.mgr.ClusterInfo.HasConsolePlugin()) {

--- a/internal/controller/flowcollector_controller.go
+++ b/internal/controller/flowcollector_controller.go
@@ -145,6 +145,8 @@ func (r *FlowCollectorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 func (r *FlowCollectorReconciler) reconcile(ctx context.Context, clh *helper.Client, desired *flowslatest.FlowCollector) error {
 	ns := desired.Spec.GetNamespace()
 	previousNamespace := r.status.GetDeployedNamespace(desired)
+	lokiConfig := helper.NewLokiConfig(&desired.Spec.Loki, ns)
+	reconcilersInfo := r.newCommonInfo(clh, ns, &lokiConfig)
 
 	if err := r.checkFinalizer(ctx, desired); err != nil {
 		return err
@@ -156,8 +158,6 @@ func (r *FlowCollectorReconciler) reconcile(ctx context.Context, clh *helper.Cli
 	r.watcher.Reset(ns)
 
 	lokiStatus := r.lokistackWatcher.Reconcile(ctx, desired)
-	lokiConfig := helper.NewLokiConfig(&desired.Spec.Loki, ns, &lokiStatus)
-	reconcilersInfo := r.newCommonInfo(clh, ns, &lokiConfig)
 
 	var cpImage string
 	if desired.Spec.NeedsConsolePluginDeployment(r.mgr.ClusterInfo.HasConsolePlugin()) {

--- a/internal/controller/flowcollector_controller_certificates_test.go
+++ b/internal/controller/flowcollector_controller_certificates_test.go
@@ -4,6 +4,7 @@ package controllers
 import (
 	"time"
 
+	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -138,6 +139,17 @@ func flowCollectorCertificatesSpecs() {
 			Eventually(func() interface{} { return k8sClient.Create(ctx, &kafka2Cert) }, timeout, interval).Should(Succeed())
 			By("Creating Kafka-export SASL key")
 			Eventually(func() interface{} { return k8sClient.Create(ctx, &kafka2Sasl) }, timeout, interval).Should(Succeed())
+		})
+
+		It("Should create LokiStack", func() {
+			Eventually(func() interface{} {
+				return k8sClient.Create(ctx, &lokiv1.LokiStack{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "loki",
+						Namespace: "loki-namespace",
+					},
+				})
+			}, timeout, interval).Should(Succeed())
 		})
 
 		flowSpec := flowslatest.FlowCollectorSpec{

--- a/internal/controller/flowcollector_controller_console_test.go
+++ b/internal/controller/flowcollector_controller_console_test.go
@@ -56,10 +56,6 @@ func flowCollectorConsolePluginSpecs() {
 	})
 
 	Context("Console plugin test init", func() {
-		It("Should create controller pod owner", func() {
-			createFakeController()
-		})
-
 		It("Should create Console CR", func() {
 			created := &operatorsv1.Console{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/flowcollector_controller_console_test.go
+++ b/internal/controller/flowcollector_controller_console_test.go
@@ -423,7 +423,7 @@ func flowCollectorConsolePluginSpecs() {
 
 		It("Should delete fake controller", func() {
 			dp := appsv1.Deployment{}
-			By("Retreive controller deployment")
+			By("Retrieve controller deployment")
 			Eventually(func() interface{} {
 				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      "netobserv-controller-manager",

--- a/internal/controller/flowcollector_controller_test.go
+++ b/internal/controller/flowcollector_controller_test.go
@@ -13,9 +13,6 @@ const (
 )
 
 var (
-	createFakeController = func() {
-		test.CreateFakeController(ctx, k8sClient)
-	}
 	updateCR = func(key types.NamespacedName, updater func(*flowslatest.FlowCollector)) {
 		test.UpdateCR(ctx, k8sClient, key, updater)
 	}

--- a/internal/controller/flp/flp_controller.go
+++ b/internal/controller/flp/flp_controller.go
@@ -136,7 +136,7 @@ func (r *Reconciler) reconcile(ctx context.Context, clh *helper.Client, fc *flow
 	ns := fc.Spec.GetNamespace()
 	r.currentNamespace = ns
 	previousNamespace := r.status.GetDeployedNamespace(fc)
-	loki := helper.NewLokiConfig(&fc.Spec.Loki, ns)
+	loki := helper.NewLokiConfig(&fc.Spec.Loki, ns, nil)
 	cmn := r.newCommonInfo(clh, ns, &loki)
 
 	r.watcher.Reset(ns)

--- a/internal/controller/flp/flp_controller.go
+++ b/internal/controller/flp/flp_controller.go
@@ -102,7 +102,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		return ctrl.Result{}, nil
 	}
 
-	r.status.SetUnknown()
+	r.status.Reset()
 	defer r.status.Commit(ctx, r.Client)
 
 	err = r.reconcile(ctx, clh, fc)
@@ -136,7 +136,7 @@ func (r *Reconciler) reconcile(ctx context.Context, clh *helper.Client, fc *flow
 	ns := fc.Spec.GetNamespace()
 	r.currentNamespace = ns
 	previousNamespace := r.status.GetDeployedNamespace(fc)
-	loki := helper.NewLokiConfig(&fc.Spec.Loki, ns, nil)
+	loki := helper.NewLokiConfig(&fc.Spec.Loki, ns)
 	cmn := r.newCommonInfo(clh, ns, &loki)
 
 	r.watcher.Reset(ns)

--- a/internal/controller/flp/flp_controller.go
+++ b/internal/controller/flp/flp_controller.go
@@ -102,8 +102,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		return ctrl.Result{}, nil
 	}
 
-	r.status.Reset()
-	defer r.status.Commit(ctx, r.Client)
+	commit := r.status.Reset()
+	defer commit(ctx, r.Client)
 
 	err = r.reconcile(ctx, clh, fc)
 	if err != nil {

--- a/internal/controller/flp/flp_test.go
+++ b/internal/controller/flp/flp_test.go
@@ -159,14 +159,14 @@ func monoBuilder(ns string, cfg *flowslatest.FlowCollectorSpec) monolithBuilder 
 }
 
 func monoBuilderWithMetrics(ns string, cfg *flowslatest.FlowCollectorSpec, metrics *metricslatest.FlowMetricList) monolithBuilder {
-	loki := helper.NewLokiConfig(&cfg.Loki, "any", nil)
+	loki := helper.NewLokiConfig(&cfg.Loki, "any")
 	info := reconcilers.Common{Namespace: ns, Loki: &loki, ClusterInfo: &cluster.Info{}}
 	b, _ := newMonolithBuilder(info.NewInstance(image, status.Instance{}), cfg, metrics, nil, nil)
 	return b
 }
 
 func transfBuilder(ns string, cfg *flowslatest.FlowCollectorSpec) transfoBuilder {
-	loki := helper.NewLokiConfig(&cfg.Loki, "any", nil)
+	loki := helper.NewLokiConfig(&cfg.Loki, "any")
 	info := reconcilers.Common{Namespace: ns, Loki: &loki, ClusterInfo: &cluster.Info{}}
 	b, _ := newTransfoBuilder(info.NewInstance(image, status.Instance{}), cfg, &metricslatest.FlowMetricList{}, nil, nil)
 	return b

--- a/internal/controller/flp/flp_test.go
+++ b/internal/controller/flp/flp_test.go
@@ -159,14 +159,14 @@ func monoBuilder(ns string, cfg *flowslatest.FlowCollectorSpec) monolithBuilder 
 }
 
 func monoBuilderWithMetrics(ns string, cfg *flowslatest.FlowCollectorSpec, metrics *metricslatest.FlowMetricList) monolithBuilder {
-	loki := helper.NewLokiConfig(&cfg.Loki, "any")
+	loki := helper.NewLokiConfig(&cfg.Loki, "any", nil)
 	info := reconcilers.Common{Namespace: ns, Loki: &loki, ClusterInfo: &cluster.Info{}}
 	b, _ := newMonolithBuilder(info.NewInstance(image, status.Instance{}), cfg, metrics, nil, nil)
 	return b
 }
 
 func transfBuilder(ns string, cfg *flowslatest.FlowCollectorSpec) transfoBuilder {
-	loki := helper.NewLokiConfig(&cfg.Loki, "any")
+	loki := helper.NewLokiConfig(&cfg.Loki, "any", nil)
 	info := reconcilers.Common{Namespace: ns, Loki: &loki, ClusterInfo: &cluster.Info{}}
 	b, _ := newTransfoBuilder(info.NewInstance(image, status.Instance{}), cfg, &metricslatest.FlowMetricList{}, nil, nil)
 	return b

--- a/internal/controller/flp/metrics_api_test.go
+++ b/internal/controller/flp/metrics_api_test.go
@@ -34,7 +34,7 @@ func getConfiguredMetrics(cm *corev1.ConfigMap) (api.MetricsItems, error) {
 
 func defaultBuilderWithMetrics(metrics *metricslatest.FlowMetricList) (monolithBuilder, error) {
 	cfg := getConfig()
-	loki := helper.NewLokiConfig(&cfg.Loki, "any", nil)
+	loki := helper.NewLokiConfig(&cfg.Loki, "any")
 	info := reconcilers.Common{Namespace: "namespace", Loki: &loki, ClusterInfo: &cluster.Info{}}
 	return newMonolithBuilder(info.NewInstance(image, status.Instance{}), &cfg, metrics, nil, nil)
 }

--- a/internal/controller/flp/metrics_api_test.go
+++ b/internal/controller/flp/metrics_api_test.go
@@ -34,7 +34,7 @@ func getConfiguredMetrics(cm *corev1.ConfigMap) (api.MetricsItems, error) {
 
 func defaultBuilderWithMetrics(metrics *metricslatest.FlowMetricList) (monolithBuilder, error) {
 	cfg := getConfig()
-	loki := helper.NewLokiConfig(&cfg.Loki, "any")
+	loki := helper.NewLokiConfig(&cfg.Loki, "any", nil)
 	info := reconcilers.Common{Namespace: "namespace", Loki: &loki, ClusterInfo: &cluster.Info{}}
 	return newMonolithBuilder(info.NewInstance(image, status.Instance{}), &cfg, metrics, nil, nil)
 }

--- a/internal/controller/flp/suite_test.go
+++ b/internal/controller/flp/suite_test.go
@@ -14,10 +14,9 @@ import (
 )
 
 var (
-	namespacesToPrepare = []string{"main-namespace", "other-namespace"}
-	ctx                 context.Context
-	k8sClient           client.Client
-	suiteContext        *test.SuiteContext
+	ctx          context.Context
+	k8sClient    client.Client
+	suiteContext *test.SuiteContext
 )
 
 func TestAPIs(t *testing.T) {
@@ -35,7 +34,12 @@ var _ = Describe("FLP Controller", Ordered, Serial, func() {
 })
 
 var _ = BeforeSuite(func() {
-	ctx, k8sClient, suiteContext = test.PrepareEnvTest([]manager.Registerer{Start}, namespacesToPrepare, "..")
+	ctx, k8sClient, suiteContext = test.PrepareEnvTest(
+		[]manager.Registerer{Start},
+		"main-namespace",
+		[]string{"other-namespace"},
+		"..",
+	)
 })
 
 var _ = AfterSuite(func() {

--- a/internal/controller/flp/suite_test.go
+++ b/internal/controller/flp/suite_test.go
@@ -34,7 +34,7 @@ var _ = Describe("FLP Controller", Ordered, Serial, func() {
 })
 
 var _ = BeforeSuite(func() {
-	ctx, k8sClient, suiteContext = test.PrepareEnvTest(
+	ctx, k8sClient, suiteContext = test.PrepareOCPEnvTest(
 		[]manager.Registerer{Start},
 		"main-namespace",
 		[]string{"other-namespace"},

--- a/internal/controller/lokistack/lokistack_watcher.go
+++ b/internal/controller/lokistack/lokistack_watcher.go
@@ -8,6 +8,7 @@ import (
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	flowslatest "github.com/netobserv/netobserv-operator/api/flowcollector/v1beta2"
 	"github.com/netobserv/netobserv-operator/internal/controller/constants"
+	"github.com/netobserv/netobserv-operator/internal/pkg/helper"
 	"github.com/netobserv/netobserv-operator/internal/pkg/manager"
 	"github.com/netobserv/netobserv-operator/internal/pkg/manager/status"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -75,7 +76,7 @@ func (lsw *Watcher) Reconcile(ctx context.Context, fc *flowslatest.FlowCollector
 	}
 
 	if !lsw.mgr.ClusterInfo.HasLokiStack(ctx) {
-		lsw.status.SetFailure("LokiStackAPIMissing", "Loki is configured in LokiStack mode, but LokiStack API is missing; check that the Loki Operator is correctly installed.")
+		lsw.status.SetFailure(helper.LokiStackAPIMissing, "Loki is configured in LokiStack mode, but LokiStack API is missing; check that the Loki Operator is correctly installed.")
 		return
 	}
 
@@ -125,7 +126,7 @@ func (lsw *Watcher) checkStatus(ctx context.Context, fc *flowslatest.FlowCollect
 	}
 	err := lsw.cl.Get(ctx, nsname, lokiStack)
 	if err != nil {
-		lsw.status.SetFailure("CantFetchLokiStack", err.Error())
+		lsw.status.SetFailure(helper.LokiCantFetchLokiStack, err.Error())
 		return err
 	}
 

--- a/internal/controller/lokistack/lokistack_watcher.go
+++ b/internal/controller/lokistack/lokistack_watcher.go
@@ -67,7 +67,7 @@ func (lsw *Watcher) Reconcile(ctx context.Context, fc *flowslatest.FlowCollector
 	defer func() {
 		ret = lsw.status.Get()
 	}()
-	lsw.status.Reset()
+	_ = lsw.status.Reset()
 
 	if !fc.Spec.UseLoki() {
 		lsw.status.SetUnused("Loki is disabled")

--- a/internal/controller/lokistack/lokistack_watcher.go
+++ b/internal/controller/lokistack/lokistack_watcher.go
@@ -8,7 +8,6 @@ import (
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	flowslatest "github.com/netobserv/netobserv-operator/api/flowcollector/v1beta2"
 	"github.com/netobserv/netobserv-operator/internal/controller/constants"
-	"github.com/netobserv/netobserv-operator/internal/pkg/helper"
 	"github.com/netobserv/netobserv-operator/internal/pkg/manager"
 	"github.com/netobserv/netobserv-operator/internal/pkg/manager/status"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -21,6 +20,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	LokiStackAPIMissing    = "LokiStackAPIMissing"
+	LokiCantFetchLokiStack = "CantFetchLokiStack"
 )
 
 type Watcher struct {
@@ -63,7 +67,7 @@ func (lsw *Watcher) Reconcile(ctx context.Context, fc *flowslatest.FlowCollector
 	defer func() {
 		ret = lsw.status.Get()
 	}()
-	lsw.status.SetUnknown()
+	lsw.status.Reset()
 
 	if !fc.Spec.UseLoki() {
 		lsw.status.SetUnused("Loki is disabled")
@@ -76,7 +80,7 @@ func (lsw *Watcher) Reconcile(ctx context.Context, fc *flowslatest.FlowCollector
 	}
 
 	if !lsw.mgr.ClusterInfo.HasLokiStack(ctx) {
-		lsw.status.SetFailure(helper.LokiStackAPIMissing, "Loki is configured in LokiStack mode, but LokiStack API is missing; check that the Loki Operator is correctly installed.")
+		lsw.status.SetFailure(LokiStackAPIMissing, "Loki is configured in LokiStack mode, but LokiStack API is missing; check that the Loki Operator is correctly installed.")
 		return
 	}
 
@@ -126,7 +130,7 @@ func (lsw *Watcher) checkStatus(ctx context.Context, fc *flowslatest.FlowCollect
 	}
 	err := lsw.cl.Get(ctx, nsname, lokiStack)
 	if err != nil {
-		lsw.status.SetFailure(helper.LokiCantFetchLokiStack, err.Error())
+		lsw.status.SetFailure(LokiCantFetchLokiStack, err.Error())
 		return err
 	}
 

--- a/internal/controller/lokistack/lokistack_watcher_test.go
+++ b/internal/controller/lokistack/lokistack_watcher_test.go
@@ -57,10 +57,10 @@ func TestCheckLoki_Disabled(t *testing.T) {
 	st := lsw.Reconcile(context.Background(), fc)
 
 	assert.Equal(t, status.ComponentStatus{
-		Name:    status.LokiStack,
-		Status:  status.StatusUnused,
-		Reason:  "ComponentUnused",
-		Message: "Loki is disabled",
+		Name:     status.LokiStack,
+		Status:   status.StatusUnused,
+		Reason:   "ComponentUnused",
+		Messages: []string{"Loki is disabled"},
 	}, st)
 }
 
@@ -78,10 +78,10 @@ func TestCheckLoki_NotLokiStackMode(t *testing.T) {
 	st := lsw.Reconcile(context.Background(), fc)
 
 	assert.Equal(t, status.ComponentStatus{
-		Name:    status.LokiStack,
-		Status:  status.StatusUnused,
-		Reason:  "ComponentUnused",
-		Message: "Loki is not configured in LokiStack mode",
+		Name:     status.LokiStack,
+		Status:   status.StatusUnused,
+		Reason:   "ComponentUnused",
+		Messages: []string{"Loki is not configured in LokiStack mode"},
 	}, st)
 }
 
@@ -110,10 +110,10 @@ func TestCheckLoki_LokiStackNotFound(t *testing.T) {
 	st := lsw.Reconcile(context.Background(), fc)
 
 	assert.Equal(t, status.ComponentStatus{
-		Name:    status.LokiStack,
-		Status:  status.StatusFailure,
-		Reason:  "CantFetchLokiStack",
-		Message: ` "loki" not found`,
+		Name:     status.LokiStack,
+		Status:   status.StatusFailure,
+		Reason:   "CantFetchLokiStack",
+		Messages: []string{` "loki" not found`},
 	}, st)
 }
 
@@ -161,10 +161,10 @@ func TestCheckLoki_LokiStackNotReady(t *testing.T) {
 	st := lsw.Reconcile(context.Background(), fc)
 
 	assert.Equal(t, status.ComponentStatus{
-		Name:    status.LokiStack,
-		Status:  status.StatusInProgress,
-		Reason:  "LokiStackNotReady",
-		Message: `LokiStack is not ready [name: loki, namespace: netobserv]: PendingComponents - Some components are still starting`,
+		Name:     status.LokiStack,
+		Status:   status.StatusInProgress,
+		Reason:   "LokiStackNotReady",
+		Messages: []string{`LokiStack is not ready [name: loki, namespace: netobserv]: PendingComponents - Some components are still starting`},
 	}, st)
 }
 
@@ -218,10 +218,10 @@ func TestCheckLoki_LokiStackWithErrorCondition(t *testing.T) {
 	st := lsw.Reconcile(context.Background(), fc)
 
 	assert.Equal(t, status.ComponentStatus{
-		Name:    status.LokiStack,
-		Status:  status.StatusFailure,
-		Reason:  "LokiStackIssues",
-		Message: `LokiStack has issues [name: loki, namespace: netobserv]: StorageError: Cannot connect to S3 backend`,
+		Name:     status.LokiStack,
+		Status:   status.StatusFailure,
+		Reason:   "LokiStackIssues",
+		Messages: []string{`LokiStack has issues [name: loki, namespace: netobserv]: StorageError: Cannot connect to S3 backend`},
 	}, st)
 }
 
@@ -294,8 +294,8 @@ func TestCheckLoki_LokiStackWithWarningAndDegradedConditions(t *testing.T) {
 
 	assert.Equal(t, status.StatusFailure, st.Status)
 	assert.Equal(t, "LokiStackIssues", st.Reason)
-	assert.Contains(t, st.Message, "Missing object storage secret")
-	assert.Contains(t, st.Message, "The schema configuration does not contain the most recent schema version and needs an update")
+	assert.Contains(t, st.Message(), "Missing object storage secret")
+	assert.Contains(t, st.Message(), "The schema configuration does not contain the most recent schema version and needs an update")
 }
 
 func TestCheckLoki_LokiStackWithJustWarnings(t *testing.T) {
@@ -348,10 +348,10 @@ func TestCheckLoki_LokiStackWithJustWarnings(t *testing.T) {
 	st := lsw.Reconcile(context.Background(), fc)
 
 	assert.Equal(t, status.ComponentStatus{
-		Name:    status.LokiStack,
-		Status:  status.StatusDegraded,
-		Reason:  "LokiStackWarnings",
-		Message: `LokiStack has warnings [name: loki, namespace: netobserv]: Warning: The schema configuration does not contain the most recent schema version`,
+		Name:     status.LokiStack,
+		Status:   status.StatusDegraded,
+		Reason:   "LokiStackWarnings",
+		Messages: []string{`LokiStack has warnings [name: loki, namespace: netobserv]: Warning: The schema configuration does not contain the most recent schema version`},
 	}, st)
 }
 
@@ -407,10 +407,10 @@ func TestCheckLoki_LokiStackComponentsWithFailedPods(t *testing.T) {
 	st := lsw.Reconcile(context.Background(), fc)
 
 	assert.Equal(t, status.ComponentStatus{
-		Name:    status.LokiStack,
-		Status:  status.StatusInProgress,
-		Reason:  "LokiStackComponentIssues",
-		Message: `LokiStack components have issues [name: loki, namespace: netobserv]: Ingester has 2 failed pod(s): ingester-0, ingester-1; Querier has 1 pending pod(s): querier-0`,
+		Name:     status.LokiStack,
+		Status:   status.StatusInProgress,
+		Reason:   "LokiStackComponentIssues",
+		Messages: []string{`LokiStack components have issues [name: loki, namespace: netobserv]: Ingester has 2 failed pod(s): ingester-0, ingester-1; Querier has 1 pending pod(s): querier-0`},
 	}, st)
 }
 
@@ -469,10 +469,9 @@ func TestCheckLoki_LokiStackHealthy(t *testing.T) {
 	st := lsw.Reconcile(context.Background(), fc)
 
 	assert.Equal(t, status.ComponentStatus{
-		Name:    status.LokiStack,
-		Status:  status.StatusReady,
-		Reason:  "",
-		Message: "",
+		Name:   status.LokiStack,
+		Status: status.StatusReady,
+		Reason: "",
 	}, st)
 }
 
@@ -521,10 +520,9 @@ func TestCheckLoki_CustomNamespace(t *testing.T) {
 	st := lsw.Reconcile(context.Background(), fc)
 
 	assert.Equal(t, status.ComponentStatus{
-		Name:    status.LokiStack,
-		Status:  status.StatusReady,
-		Reason:  "",
-		Message: "",
+		Name:   status.LokiStack,
+		Status: status.StatusReady,
+		Reason: "",
 	}, st)
 }
 

--- a/internal/controller/monitoring/monitoring_controller.go
+++ b/internal/controller/monitoring/monitoring_controller.go
@@ -73,7 +73,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		return ctrl.Result{}, nil
 	}
 
-	r.status.SetUnknown()
+	r.status.Reset()
 	defer r.status.Commit(ctx, r.Client)
 
 	err = r.reconcile(ctx, clh, desired)

--- a/internal/controller/monitoring/monitoring_controller.go
+++ b/internal/controller/monitoring/monitoring_controller.go
@@ -73,8 +73,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		return ctrl.Result{}, nil
 	}
 
-	r.status.Reset()
-	defer r.status.Commit(ctx, r.Client)
+	commit := r.status.Reset()
+	defer commit(ctx, r.Client)
 
 	err = r.reconcile(ctx, clh, desired)
 	if err != nil {

--- a/internal/controller/monitoring/suite_test.go
+++ b/internal/controller/monitoring/suite_test.go
@@ -14,10 +14,9 @@ import (
 )
 
 var (
-	namespacesToPrepare = []string{"openshift-config-managed", "main-namespace"}
-	ctx                 context.Context
-	k8sClient           client.Client
-	suiteContext        *test.SuiteContext
+	ctx          context.Context
+	k8sClient    client.Client
+	suiteContext *test.SuiteContext
 )
 
 func TestAPIs(t *testing.T) {
@@ -34,7 +33,12 @@ var _ = Describe("FlowCollector Controller", Ordered, Serial, func() {
 })
 
 var _ = BeforeSuite(func() {
-	ctx, k8sClient, suiteContext = test.PrepareEnvTest([]manager.Registerer{Start}, namespacesToPrepare, "..")
+	ctx, k8sClient, suiteContext = test.PrepareEnvTest(
+		[]manager.Registerer{Start},
+		"main-namespace",
+		[]string{"openshift-config-managed"},
+		"..",
+	)
 })
 
 var _ = AfterSuite(func() {

--- a/internal/controller/monitoring/suite_test.go
+++ b/internal/controller/monitoring/suite_test.go
@@ -33,7 +33,7 @@ var _ = Describe("FlowCollector Controller", Ordered, Serial, func() {
 })
 
 var _ = BeforeSuite(func() {
-	ctx, k8sClient, suiteContext = test.PrepareEnvTest(
+	ctx, k8sClient, suiteContext = test.PrepareOCPEnvTest(
 		[]manager.Registerer{Start},
 		"main-namespace",
 		[]string{"openshift-config-managed"},

--- a/internal/controller/networkpolicy/np_controller.go
+++ b/internal/controller/networkpolicy/np_controller.go
@@ -53,8 +53,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		return ctrl.Result{}, nil
 	}
 
-	r.status.Reset()
-	defer r.status.Commit(ctx, r.Client)
+	commit := r.status.Reset()
+	defer commit(ctx, r.Client)
 
 	hasNP, err := r.reconcile(ctx, clh, desired)
 	if err != nil {

--- a/internal/controller/networkpolicy/np_controller.go
+++ b/internal/controller/networkpolicy/np_controller.go
@@ -53,10 +53,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		return ctrl.Result{}, nil
 	}
 
-	r.status.SetUnknown()
+	r.status.Reset()
 	defer r.status.Commit(ctx, r.Client)
 
-	err = r.reconcile(ctx, clh, desired)
+	hasNP, err := r.reconcile(ctx, clh, desired)
 	if err != nil {
 		l.Error(err, "Network policy reconcile failure")
 		// Set status failure unless it was already set
@@ -64,18 +64,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 			r.status.SetFailure("NetworkPolicyError", err.Error())
 		}
 		return ctrl.Result{}, err
+	} else if !hasNP {
+		r.status.SetUnused("Network policy is disabled")
+	} else {
+		r.status.SetReady()
 	}
 
-	r.status.SetReady()
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) reconcile(ctx context.Context, clh *helper.Client, desired *flowslatest.FlowCollector) error {
+// Returns true if policies are enabled
+func (r *Reconciler) reconcile(ctx context.Context, clh *helper.Client, desired *flowslatest.FlowCollector) (bool, error) {
 	l := log.FromContext(ctx)
 
 	cni, err := r.mgr.ClusterInfo.GetCNI()
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Get API server endpoint IPs for network policy
@@ -84,15 +88,19 @@ func (r *Reconciler) reconcile(ctx context.Context, clh *helper.Client, desired 
 		apiServerIPs, err = cluster.GetAPIServerEndpointIPs(ctx, r.Client, r.mgr.ClusterInfo)
 		if err != nil {
 			l.Error(err, "Failed to get API server endpoint IPs")
-			return fmt.Errorf("cannot determine API server endpoint IPs: %w", err)
+			return false, fmt.Errorf("cannot determine API server endpoint IPs: %w", err)
 		}
 	}
 
 	npName, desiredNp := buildMainNetworkPolicy(desired, r.mgr, cni, apiServerIPs)
 	if err := reconcilers.ReconcileNetworkPolicy(ctx, clh, npName, desiredNp); err != nil {
-		return err
+		return false, err
 	}
 
 	privilegedNpName, desiredPrivilegedNp := buildPrivilegedNetworkPolicy(desired, r.mgr, cni)
-	return reconcilers.ReconcileNetworkPolicy(ctx, clh, privilegedNpName, desiredPrivilegedNp)
+	if err := reconcilers.ReconcileNetworkPolicy(ctx, clh, privilegedNpName, desiredPrivilegedNp); err != nil {
+		return false, err
+	}
+
+	return desiredNp != nil, nil
 }

--- a/internal/controller/networkpolicy/suite_test.go
+++ b/internal/controller/networkpolicy/suite_test.go
@@ -14,10 +14,9 @@ import (
 )
 
 var (
-	namespacesToPrepare = []string{"main-namespace", "other-namespace"}
-	ctx                 context.Context
-	k8sClient           client.Client
-	suiteContext        *test.SuiteContext
+	ctx          context.Context
+	k8sClient    client.Client
+	suiteContext *test.SuiteContext
 )
 
 func TestAPIs(t *testing.T) {
@@ -34,7 +33,12 @@ var _ = Describe("Networkpolicy Controller", Ordered, Serial, func() {
 })
 
 var _ = BeforeSuite(func() {
-	ctx, k8sClient, suiteContext = test.PrepareEnvTest([]manager.Registerer{Start}, namespacesToPrepare, "..")
+	ctx, k8sClient, suiteContext = test.PrepareEnvTest(
+		[]manager.Registerer{Start},
+		"main-namespace",
+		[]string{"other-namespace"},
+		"..",
+	)
 })
 
 var _ = AfterSuite(func() {

--- a/internal/controller/static/static_controller.go
+++ b/internal/controller/static/static_controller.go
@@ -72,8 +72,8 @@ func (r *Reconciler) initReconcile(ctx context.Context) error {
 func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	ctx = log.IntoContext(ctx, clog)
 
-	r.status.Reset()
-	defer r.status.Commit(ctx, r.Client)
+	commit := r.status.Reset()
+	defer commit(ctx, r.Client)
 
 	if r.mgr.ClusterInfo.HasConsolePlugin() {
 		// Only deploy static plugin on OpenShift 4.15+

--- a/internal/controller/static/static_controller.go
+++ b/internal/controller/static/static_controller.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -17,6 +16,7 @@ import (
 	"github.com/netobserv/netobserv-operator/internal/pkg/helper"
 	"github.com/netobserv/netobserv-operator/internal/pkg/manager"
 	"github.com/netobserv/netobserv-operator/internal/pkg/manager/status"
+	"github.com/netobserv/netobserv-operator/internal/pkg/retry"
 )
 
 var (
@@ -53,7 +53,7 @@ func Start(ctx context.Context, mgr *manager.Manager) (manager.PostCreateHook, e
 
 func (r *Reconciler) initReconcile(ctx context.Context) error {
 	attempt := 0
-	err := retry.OnError(retryBackoff, func(error) bool { return true }, func() error {
+	err := retry.OnError(ctx, retryBackoff, func(error) bool { return true }, func() error {
 		attempt++
 		if _, err := r.Reconcile(ctx, ctrl.Request{}); err != nil {
 			clog.WithValues("attempt", attempt, "error", err).Info("Initial reconcile: attempt failed")

--- a/internal/controller/static/static_controller.go
+++ b/internal/controller/static/static_controller.go
@@ -72,7 +72,7 @@ func (r *Reconciler) initReconcile(ctx context.Context) error {
 func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	ctx = log.IntoContext(ctx, clog)
 
-	r.status.SetUnknown()
+	r.status.Reset()
 	defer r.status.Commit(ctx, r.Client)
 
 	if r.mgr.ClusterInfo.HasConsolePlugin() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -34,11 +34,11 @@ var (
 	suiteContext *test.SuiteContext
 )
 
-func TestAPIs(t *testing.T) {
+func TestAPIsOCP(t *testing.T) {
 	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
 	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Controller Suite")
+	RunSpecs(t, "Controller Suite - OCP")
 }
 
 // go test ./... runs always Ginkgo test suites in parallel and they would interfere
@@ -54,7 +54,7 @@ var _ = Describe("FlowCollector Controller", Ordered, Serial, func() {
 })
 
 var _ = BeforeSuite(func() {
-	ctx, k8sClient, suiteContext = test.PrepareEnvTest(
+	ctx, k8sClient, suiteContext = test.PrepareOCPEnvTest(
 		Registerers,
 		"main-namespace",
 		[]string{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -29,10 +29,9 @@ import (
 )
 
 var (
-	namespacesToPrepare = []string{"openshift-network-operator", "openshift-config-managed", "loki-namespace", "kafka-exporter-namespace", "main-namespace", "main-namespace-privileged"}
-	ctx                 context.Context
-	k8sClient           client.Client
-	suiteContext        *test.SuiteContext
+	ctx          context.Context
+	k8sClient    client.Client
+	suiteContext *test.SuiteContext
 )
 
 func TestAPIs(t *testing.T) {
@@ -55,7 +54,18 @@ var _ = Describe("FlowCollector Controller", Ordered, Serial, func() {
 })
 
 var _ = BeforeSuite(func() {
-	ctx, k8sClient, suiteContext = test.PrepareEnvTest(Registerers, namespacesToPrepare, ".")
+	ctx, k8sClient, suiteContext = test.PrepareEnvTest(
+		Registerers,
+		"main-namespace",
+		[]string{
+			"openshift-network-operator",
+			"openshift-config-managed",
+			"loki-namespace",
+			"kafka-exporter-namespace",
+			"main-namespace-privileged",
+		},
+		".",
+	)
 })
 
 var _ = AfterSuite(func() {

--- a/internal/pkg/cleanup/cleanup_test.go
+++ b/internal/pkg/cleanup/cleanup_test.go
@@ -32,7 +32,7 @@ func TestCleanup(t *testing.T) {
 var _ = BeforeSuite(func() {
 	// Base path is ".." because we're in internal/pkg/cleanup (3 levels deep)
 	// The test framework adds "../.." to basePath, so this resolves to ../../../ from our location
-	ctx, k8sClient, suiteContext = test.PrepareEnvTest(
+	ctx, k8sClient, suiteContext = test.PrepareOCPEnvTest(
 		nil,
 		"main-namespace",
 		nil,

--- a/internal/pkg/cleanup/cleanup_test.go
+++ b/internal/pkg/cleanup/cleanup_test.go
@@ -32,7 +32,12 @@ func TestCleanup(t *testing.T) {
 var _ = BeforeSuite(func() {
 	// Base path is ".." because we're in internal/pkg/cleanup (3 levels deep)
 	// The test framework adds "../.." to basePath, so this resolves to ../../../ from our location
-	ctx, k8sClient, suiteContext = test.PrepareEnvTest(nil, []string{}, "..")
+	ctx, k8sClient, suiteContext = test.PrepareEnvTest(
+		nil,
+		"main-namespace",
+		nil,
+		"..",
+	)
 })
 
 var _ = AfterSuite(func() {

--- a/internal/pkg/helper/loki_config.go
+++ b/internal/pkg/helper/loki_config.go
@@ -4,19 +4,13 @@ import (
 	"fmt"
 
 	flowslatest "github.com/netobserv/netobserv-operator/api/flowcollector/v1beta2"
-	"github.com/netobserv/netobserv-operator/internal/pkg/manager/status"
-)
-
-const (
-	LokiStackAPIMissing    = "LokiStackAPIMissing"
-	LokiCantFetchLokiStack = "CantFetchLokiStack"
 )
 
 type LokiConfig struct {
 	flowslatest.LokiManualParams
 }
 
-func NewLokiConfig(spec *flowslatest.FlowCollectorLoki, namespace string, lokiStatus *status.ComponentStatus) LokiConfig {
+func NewLokiConfig(spec *flowslatest.FlowCollectorLoki, namespace string) LokiConfig {
 	loki := LokiConfig{}
 	switch spec.Mode {
 	case flowslatest.LokiModeLokiStack:
@@ -57,12 +51,6 @@ func NewLokiConfig(spec *flowslatest.FlowCollectorLoki, namespace string, lokiSt
 					CertKey:   "tls.key",
 				},
 			},
-		}
-		if lokiStatus != nil && (lokiStatus.Reason == LokiStackAPIMissing || lokiStatus.Reason == LokiCantFetchLokiStack) {
-			// If LokiStack is missing, turn off TLS config; queries will fail anyway, but we don't want to try mounting
-			// the missing certificates, as it prevents the console plugin pod to start.
-			loki.LokiManualParams.TLS.Enable = false
-			loki.LokiManualParams.StatusTLS.Enable = false
 		}
 
 	case flowslatest.LokiModeMonolithic:

--- a/internal/pkg/helper/loki_config.go
+++ b/internal/pkg/helper/loki_config.go
@@ -4,13 +4,19 @@ import (
 	"fmt"
 
 	flowslatest "github.com/netobserv/netobserv-operator/api/flowcollector/v1beta2"
+	"github.com/netobserv/netobserv-operator/internal/pkg/manager/status"
+)
+
+const (
+	LokiStackAPIMissing    = "LokiStackAPIMissing"
+	LokiCantFetchLokiStack = "CantFetchLokiStack"
 )
 
 type LokiConfig struct {
 	flowslatest.LokiManualParams
 }
 
-func NewLokiConfig(spec *flowslatest.FlowCollectorLoki, namespace string) LokiConfig {
+func NewLokiConfig(spec *flowslatest.FlowCollectorLoki, namespace string, lokiStatus *status.ComponentStatus) LokiConfig {
 	loki := LokiConfig{}
 	switch spec.Mode {
 	case flowslatest.LokiModeLokiStack:
@@ -52,6 +58,13 @@ func NewLokiConfig(spec *flowslatest.FlowCollectorLoki, namespace string) LokiCo
 				},
 			},
 		}
+		if lokiStatus != nil && (lokiStatus.Reason == LokiStackAPIMissing || lokiStatus.Reason == LokiCantFetchLokiStack) {
+			// If LokiStack is missing, turn off TLS config; queries will fail anyway, but we don't want to try mounting
+			// the missing certificates, as it prevents the console plugin pod to start.
+			loki.LokiManualParams.TLS.Enable = false
+			loki.LokiManualParams.StatusTLS.Enable = false
+		}
+
 	case flowslatest.LokiModeMonolithic:
 		if spec.Monolithic.InstallDemoLoki != nil && *spec.Monolithic.InstallDemoLoki {
 			loki.LokiManualParams = flowslatest.LokiManualParams{

--- a/internal/pkg/manager/status/envtest/flowcollector_controller_status_test.go
+++ b/internal/pkg/manager/status/envtest/flowcollector_controller_status_test.go
@@ -1,0 +1,153 @@
+//nolint:revive
+package envtest
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	flowslatest "github.com/netobserv/netobserv-operator/api/flowcollector/v1beta2"
+	"github.com/netobserv/netobserv-operator/internal/pkg/test"
+)
+
+const (
+	timeout  = test.Timeout
+	interval = test.Interval
+)
+
+// nolint:cyclop
+func flowCollectorStatusSpecs() {
+	namespace := "status-test"
+	crKey := types.NamespacedName{
+		Name: "cluster",
+	}
+
+	BeforeEach(func() {
+		// Add any setup steps that needs to be executed before each test
+	})
+
+	AfterEach(func() {
+		// Add any teardown steps that needs to be executed after each test
+	})
+
+	Context("Initialize flowcollector and status", func() {
+		It("Should create FlowCollector successfully with preset status", func() {
+			toCreate := &flowslatest.FlowCollector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crKey.Name,
+				},
+				Spec: flowslatest.FlowCollectorSpec{
+					Namespace: namespace,
+					Agent: flowslatest.FlowCollectorAgent{
+						EBPF: flowslatest.FlowCollectorEBPF{
+							// Use EbpfManager in order to trigger a failure (no kind is registered for the type v1alpha1.ClusterBpfApplication)
+							Features: []flowslatest.AgentFeature{flowslatest.EbpfManager},
+						},
+					},
+					ConsolePlugin: flowslatest.FlowCollectorConsolePlugin{
+						Enable: ptr.To(false),
+					},
+				},
+				Status: flowslatest.FlowCollectorStatus{},
+			}
+
+			Eventually(func() interface{} {
+				return k8sClient.Create(ctx, toCreate)
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("Should manually set workloads deployed", func() {
+			// envtest won't automatically set workload statuses, hence do it manually
+			By("Updating agent")
+			Eventually(func() interface{} {
+				ds := appsv1.DaemonSet{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "netobserv-ebpf-agent", Namespace: namespace + "-privileged"}, &ds); err != nil {
+					return err
+				}
+				ds.Status.NumberReady = 1
+				ds.Status.DesiredNumberScheduled = 1
+				return k8sClient.Status().Update(ctx, &ds)
+			}, timeout, interval).Should(Succeed())
+
+			By("Updating FLP")
+			Eventually(func() interface{} {
+				dep := appsv1.Deployment{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "flowlogs-pipeline", Namespace: namespace}, &dep); err != nil {
+					return err
+				}
+				dep.Status.ReadyReplicas = 1
+				dep.Status.Replicas = 1
+				dep.Status.Conditions = []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentAvailable,
+						Status: v1.ConditionTrue,
+					},
+				}
+				return k8sClient.Status().Update(ctx, &dep)
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("Should show status errors", func() {
+			Eventually(func() interface{} {
+				fc := flowslatest.FlowCollector{}
+				if err := k8sClient.Get(ctx, crKey, &fc); err != nil {
+					return err
+				}
+				wrongConditions := getWrongConditions(fc.Status.Conditions)
+				if len(wrongConditions) != 4 {
+					return fmt.Errorf("%d/%d conditions are wrong, expected 4: %v", len(wrongConditions), len(fc.Status.Conditions), wrongConditions)
+				}
+				return nil
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("Should fix FlowCollector", func() {
+			Eventually(func() interface{} {
+				fc := flowslatest.FlowCollector{}
+				if err := k8sClient.Get(ctx, crKey, &fc); err != nil {
+					return err
+				}
+				fc.Spec.Agent.EBPF.Features = []flowslatest.AgentFeature{}
+				return k8sClient.Update(ctx, &fc)
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func() interface{} {
+				fc := flowslatest.FlowCollector{}
+				if err := k8sClient.Get(ctx, crKey, &fc); err != nil {
+					return err
+				}
+				wrongConditions := getWrongConditions(fc.Status.Conditions)
+				if len(wrongConditions) > 0 {
+					return fmt.Errorf("%d/%d conditions are unexpected: %v", len(wrongConditions), len(fc.Status.Conditions), wrongConditions)
+				}
+				return nil
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Context("Cleanup", func() {
+		It("Should delete CR", func() {
+			test.CleanupCR(ctx, k8sClient, crKey)
+		})
+	})
+}
+
+func getWrongConditions(all []metav1.Condition) []metav1.Condition {
+	var wrongConditions []metav1.Condition
+	for _, cond := range all {
+		if cond.Type == "Ready" {
+			if cond.Status != metav1.ConditionTrue {
+				wrongConditions = append(wrongConditions, cond)
+			}
+		} else if cond.Status == metav1.ConditionTrue {
+			wrongConditions = append(wrongConditions, cond)
+		}
+	}
+	return wrongConditions
+}

--- a/internal/pkg/manager/status/envtest/suite_test.go
+++ b/internal/pkg/manager/status/envtest/suite_test.go
@@ -1,5 +1,5 @@
 //nolint:revive
-package networkpolicy
+package envtest
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/netobserv/netobserv-operator/internal/pkg/manager"
+	controllers "github.com/netobserv/netobserv-operator/internal/controller"
 	"github.com/netobserv/netobserv-operator/internal/pkg/test"
 )
 
@@ -21,23 +21,29 @@ var (
 
 func TestAPIs(t *testing.T) {
 	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
-	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
+	//	os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Networkpolicy Controller Suite")
+	RunSpecs(t, "FlowCollector Status Test Suite")
 }
 
 // go test ./... runs always Ginkgo test suites in parallel and they would interfere
 // this way we make sure that both test sub-suites are executed serially
-var _ = Describe("Networkpolicy Controller", Ordered, Serial, func() {
-	ControllerSpecs()
+var _ = Describe("FlowCollector Status", Ordered, Serial, func() {
+	flowCollectorStatusSpecs()
 })
 
 var _ = BeforeSuite(func() {
-	ctx, k8sClient, suiteContext = test.PrepareOCPEnvTest(
-		[]manager.Registerer{Start},
-		"main-namespace",
-		[]string{"other-namespace"},
-		"..",
+	ctx, k8sClient, suiteContext = test.PrepareEnvTest(
+		controllers.Registerers,
+		[]string{
+			// "openshift-network-operator",
+			// "openshift-config-managed",
+			// "loki-namespace",
+			// "kafka-exporter-namespace",
+			// "main-namespace",
+			// "main-namespace-privileged",
+		},
+		"../../..",
 	)
 })
 

--- a/internal/pkg/manager/status/pod_health.go
+++ b/internal/pkg/manager/status/pod_health.go
@@ -15,16 +15,16 @@ import (
 const maxPodNamesInSummary = 5
 
 // PodHealthSummary holds aggregated pod health information for a workload.
-type PodHealthSummary struct {
-	UnhealthyCount int32
-	Issues         string
+type podHealthSummary struct {
+	unhealthyCount int32
+	issues         string
 }
 
 // CheckPodHealth lists pods matching the given label selector in the given namespace,
 // inspects container statuses, and returns a summary of unhealthy pods.
 // This is intended to be called only when a workload reports not-ready replicas,
 // to avoid unnecessary API calls when everything is healthy.
-func CheckPodHealth(ctx context.Context, c client.Client, namespace string, matchLabels map[string]string) PodHealthSummary {
+func checkPodHealth(ctx context.Context, c client.Client, namespace string, matchLabels map[string]string) podHealthSummary {
 	rlog := log.FromContext(ctx)
 
 	podList := corev1.PodList{}
@@ -33,7 +33,7 @@ func CheckPodHealth(ctx context.Context, c client.Client, namespace string, matc
 		LabelSelector: labels.SelectorFromSet(matchLabels),
 	}); err != nil {
 		rlog.Error(err, "Failed to list pods for health check")
-		return PodHealthSummary{}
+		return podHealthSummary{}
 	}
 
 	type issueGroup struct {
@@ -63,7 +63,7 @@ func CheckPodHealth(ctx context.Context, c client.Client, namespace string, matc
 	}
 
 	if unhealthyCount == 0 {
-		return PodHealthSummary{}
+		return podHealthSummary{}
 	}
 
 	sortedReasons := make([]string, 0, len(groups))
@@ -90,9 +90,9 @@ func CheckPodHealth(ctx context.Context, c client.Client, namespace string, matc
 		parts = append(parts, part)
 	}
 
-	return PodHealthSummary{
-		UnhealthyCount: unhealthyCount,
-		Issues:         strings.Join(parts, "; "),
+	return podHealthSummary{
+		unhealthyCount: unhealthyCount,
+		issues:         strings.Join(parts, "; "),
 	}
 }
 

--- a/internal/pkg/manager/status/status_manager.go
+++ b/internal/pkg/manager/status/status_manager.go
@@ -15,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -64,36 +63,38 @@ func (s *Manager) getStatus(cpnt ComponentName) *ComponentStatus {
 }
 
 func (s *Manager) setInProgress(cpnt ComponentName, reason, message string) {
-	cs := s.preserveReplicas(cpnt)
-	cs.Status = StatusInProgress
-	cs.Reason = reason
-	cs.Message = message
-	s.statuses.Store(cpnt, cs)
+	s.updateComponentStatus(&ComponentStatus{
+		Name:     cpnt,
+		Status:   StatusInProgress,
+		Reason:   reason,
+		Messages: []string{message},
+	})
 }
 
 func (s *Manager) setFailure(cpnt ComponentName, reason, message string) {
-	cs := s.preserveReplicas(cpnt)
-	cs.Status = StatusFailure
-	cs.Reason = reason
-	cs.Message = message
-	s.statuses.Store(cpnt, cs)
+	s.updateComponentStatus(&ComponentStatus{
+		Name:     cpnt,
+		Status:   StatusFailure,
+		Reason:   reason,
+		Messages: []string{message},
+	})
 }
 
 func (s *Manager) setDegraded(cpnt ComponentName, reason, message string) {
-	cs := s.preserveReplicas(cpnt)
-	cs.Status = StatusDegraded
-	cs.Reason = reason
-	cs.Message = message
-	s.statuses.Store(cpnt, cs)
+	s.updateComponentStatus(&ComponentStatus{
+		Name:     cpnt,
+		Status:   StatusDegraded,
+		Reason:   reason,
+		Messages: []string{message},
+	})
 }
 
-func (s *Manager) preserveReplicas(cpnt ComponentName) ComponentStatus {
-	cs := ComponentStatus{Name: cpnt}
-	if existing := s.getStatus(cpnt); existing != nil {
-		cs.DesiredReplicas = existing.DesiredReplicas
-		cs.ReadyReplicas = existing.ReadyReplicas
+func (s *Manager) updateComponentStatus(other *ComponentStatus) {
+	merged := other
+	if existing := s.getStatus(other.Name); existing != nil {
+		merged = existing.merge(other)
 	}
-	return cs
+	s.statuses.Store(other.Name, *merged)
 }
 
 func (s *Manager) hasFailure(cpnt ComponentName) bool {
@@ -101,32 +102,26 @@ func (s *Manager) hasFailure(cpnt ComponentName) bool {
 	return v != nil && v.(ComponentStatus).Status == StatusFailure
 }
 
-func (s *Manager) setReady(cpnt ComponentName) {
-	existing := s.getStatus(cpnt)
-	cs := ComponentStatus{
-		Name:   cpnt,
-		Status: StatusReady,
-	}
-	if existing != nil {
-		cs.DesiredReplicas = existing.DesiredReplicas
-		cs.ReadyReplicas = existing.ReadyReplicas
-	}
-	s.statuses.Store(cpnt, cs)
-}
-
-func (s *Manager) setUnknown(cpnt ComponentName) {
+func (s *Manager) reset(cpnt ComponentName) {
 	s.statuses.Store(cpnt, ComponentStatus{
 		Name:   cpnt,
 		Status: StatusUnknown,
 	})
 }
 
+func (s *Manager) setReady(cpnt ComponentName) {
+	s.updateComponentStatus(&ComponentStatus{
+		Name:   cpnt,
+		Status: StatusReady,
+	})
+}
+
 func (s *Manager) setUnused(cpnt ComponentName, message string) {
-	s.statuses.Store(cpnt, ComponentStatus{
-		Name:    cpnt,
-		Status:  StatusUnused,
-		Reason:  "ComponentUnused",
-		Message: message,
+	s.updateComponentStatus(&ComponentStatus{
+		Name:     cpnt,
+		Status:   StatusUnused,
+		Reason:   "ComponentUnused",
+		Messages: []string{message},
 	})
 }
 
@@ -281,11 +276,11 @@ func (s *Manager) emitStateTransitionEvents(ctx context.Context, fc *flowslatest
 
 		switch {
 		case current.Status == StatusFailure:
-			msg := fmt.Sprintf("Component %s entered failure state: %s - %s", cpnt, current.Reason, current.Message)
+			msg := fmt.Sprintf("Component %s entered failure state: %s - %s", cpnt, current.Reason, current.Message())
 			s.eventRecorder.Event(fc, "Warning", "ComponentFailure", msg)
 			rlog.Info("Event emitted", "type", "ComponentFailure", "component", cpnt)
 		case current.Status == StatusDegraded:
-			msg := fmt.Sprintf("Component %s degraded: %s - %s", cpnt, current.Reason, current.Message)
+			msg := fmt.Sprintf("Component %s degraded: %s - %s", cpnt, current.Reason, current.Message())
 			s.eventRecorder.Event(fc, "Warning", "ComponentDegraded", msg)
 		case prevStatus.Status == StatusFailure && (current.Status == StatusReady || current.Status == StatusInProgress):
 			msg := fmt.Sprintf("Component %s recovered from failure", cpnt)
@@ -374,19 +369,19 @@ func (s *Manager) GetKafkaCondition() *metav1.Condition {
 	if ts := s.getStatus(FLPTransformer); ts != nil && ts.Status != StatusUnknown && ts.Status != StatusUnused {
 		if ts.Status == StatusFailure || ts.Status == StatusDegraded {
 			hasKafkaIssue = true
-			messages = append(messages, fmt.Sprintf("Transformer: %s", ts.Message))
+			messages = append(messages, fmt.Sprintf("Transformer: %s", ts.Message()))
 		}
-		if ts.PodHealth.UnhealthyCount > 0 {
+		if ts.podHealth.unhealthyCount > 0 {
 			hasKafkaIssue = true
-			messages = append(messages, fmt.Sprintf("Transformer pods: %s", ts.PodHealth.Issues))
+			messages = append(messages, fmt.Sprintf("Transformer pods: %s", ts.podHealth.issues))
 		}
 	}
 
 	// Check agent for Kafka-related pod issues
 	if as := s.getStatus(EBPFAgents); as != nil {
-		if as.PodHealth.UnhealthyCount > 0 && strings.Contains(strings.ToLower(as.PodHealth.Issues), "kafka") {
+		if as.podHealth.unhealthyCount > 0 && strings.Contains(strings.ToLower(as.podHealth.issues), "kafka") {
 			hasKafkaIssue = true
-			messages = append(messages, fmt.Sprintf("Agent pods: %s", as.PodHealth.Issues))
+			messages = append(messages, fmt.Sprintf("Agent pods: %s", as.podHealth.issues))
 		}
 	}
 
@@ -454,7 +449,7 @@ func (s *Manager) NeedsRequeue() bool {
 	needsRequeue := false
 	s.statuses.Range(func(_, v any) bool {
 		cs := v.(ComponentStatus)
-		if cs.Status == StatusInProgress || cs.PodHealth.UnhealthyCount > 0 {
+		if cs.Status == StatusInProgress || cs.podHealth.unhealthyCount > 0 {
 			needsRequeue = true
 			return false
 		}
@@ -472,7 +467,7 @@ func (s *Manager) ClearExporters() {
 }
 
 func (s *Manager) ForComponent(cpnt ComponentName) Instance {
-	s.setUnknown(cpnt)
+	s.reset(cpnt)
 	return Instance{cpnt: cpnt, s: s}
 }
 
@@ -493,8 +488,8 @@ func (i *Instance) SetReady() {
 	i.s.setReady(i.cpnt)
 }
 
-func (i *Instance) SetUnknown() {
-	i.s.setUnknown(i.cpnt)
+func (i *Instance) Reset() {
+	i.s.reset(i.cpnt)
 }
 
 func (i *Instance) SetUnused(message string) {
@@ -533,8 +528,8 @@ func (i *Instance) setDeploymentReplicas(d *appsv1.Deployment) {
 		if d.Spec.Replicas != nil {
 			desired = *d.Spec.Replicas
 		}
-		cs.DesiredReplicas = ptr.To(desired)
-		cs.ReadyReplicas = ptr.To(d.Status.ReadyReplicas)
+		cs.DesiredReplicas = desired
+		cs.ReadyReplicas = d.Status.ReadyReplicas
 		i.s.statuses.Store(i.cpnt, *cs)
 	}
 }
@@ -559,8 +554,8 @@ func (i *Instance) CheckDaemonSetProgress(ds *appsv1.DaemonSet) {
 func (i *Instance) setDaemonSetReplicas(ds *appsv1.DaemonSet) {
 	cs := i.s.getStatus(i.cpnt)
 	if cs != nil {
-		cs.DesiredReplicas = ptr.To(ds.Status.DesiredNumberScheduled)
-		cs.ReadyReplicas = ptr.To(ds.Status.NumberReady)
+		cs.DesiredReplicas = ds.Status.DesiredNumberScheduled
+		cs.ReadyReplicas = ds.Status.NumberReady
 		i.s.statuses.Store(i.cpnt, *cs)
 	}
 }
@@ -573,7 +568,7 @@ func (i *Instance) CheckDeploymentHealth(ctx context.Context, c client.Client, d
 		return
 	}
 	if d.Status.ReadyReplicas < d.Status.Replicas || d.Status.UnavailableReplicas > 0 {
-		health := CheckPodHealth(ctx, c, d.Namespace, d.Spec.Selector.MatchLabels)
+		health := checkPodHealth(ctx, c, d.Namespace, d.Spec.Selector.MatchLabels)
 		i.setPodHealth(health)
 	}
 }
@@ -586,22 +581,19 @@ func (i *Instance) CheckDaemonSetHealth(ctx context.Context, c client.Client, ds
 		return
 	}
 	if ds.Status.NumberReady < ds.Status.DesiredNumberScheduled || ds.Status.NumberUnavailable > 0 {
-		health := CheckPodHealth(ctx, c, ds.Namespace, ds.Spec.Selector.MatchLabels)
+		health := checkPodHealth(ctx, c, ds.Namespace, ds.Spec.Selector.MatchLabels)
 		i.setPodHealth(health)
 	}
 }
 
-func (i *Instance) setPodHealth(health PodHealthSummary) {
-	cs := i.s.getStatus(i.cpnt)
-	if cs != nil {
-		cs.PodHealth = health
-		if health.UnhealthyCount > 0 && (cs.Status == StatusReady || cs.Status == StatusInProgress) {
-			cs.Status = StatusDegraded
-			cs.Reason = "UnhealthyPods"
-			cs.Message = health.Issues
-		}
-		i.s.statuses.Store(i.cpnt, *cs)
-	}
+func (i *Instance) setPodHealth(health podHealthSummary) {
+	i.s.updateComponentStatus(&ComponentStatus{
+		Name:      i.cpnt,
+		Status:    StatusDegraded,
+		Reason:    "UnhealthyPods",
+		Messages:  []string{health.issues},
+		podHealth: health,
+	})
 }
 
 func (i *Instance) SetCreatingDeployment(d *appsv1.Deployment) {

--- a/internal/pkg/manager/status/status_manager.go
+++ b/internal/pkg/manager/status/status_manager.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -528,8 +529,8 @@ func (i *Instance) setDeploymentReplicas(d *appsv1.Deployment) {
 		if d.Spec.Replicas != nil {
 			desired = *d.Spec.Replicas
 		}
-		cs.DesiredReplicas = desired
-		cs.ReadyReplicas = d.Status.ReadyReplicas
+		cs.DesiredReplicas = ptr.To(desired)
+		cs.ReadyReplicas = ptr.To(d.Status.ReadyReplicas)
 		i.s.statuses.Store(i.cpnt, *cs)
 	}
 }
@@ -554,8 +555,8 @@ func (i *Instance) CheckDaemonSetProgress(ds *appsv1.DaemonSet) {
 func (i *Instance) setDaemonSetReplicas(ds *appsv1.DaemonSet) {
 	cs := i.s.getStatus(i.cpnt)
 	if cs != nil {
-		cs.DesiredReplicas = ds.Status.DesiredNumberScheduled
-		cs.ReadyReplicas = ds.Status.NumberReady
+		cs.DesiredReplicas = ptr.To(ds.Status.DesiredNumberScheduled)
+		cs.ReadyReplicas = ptr.To(ds.Status.NumberReady)
 		i.s.statuses.Store(i.cpnt, *cs)
 	}
 }

--- a/internal/pkg/manager/status/status_manager.go
+++ b/internal/pkg/manager/status/status_manager.go
@@ -489,8 +489,11 @@ func (i *Instance) SetReady() {
 	i.s.setReady(i.cpnt)
 }
 
-func (i *Instance) Reset() {
+func (i *Instance) Reset() func(ctx context.Context, c client.Client) {
 	i.s.reset(i.cpnt)
+	return func(ctx context.Context, c client.Client) {
+		i.s.Sync(ctx, c)
+	}
 }
 
 func (i *Instance) SetUnused(message string) {
@@ -624,8 +627,4 @@ func (i *Instance) Error(reason string, err error) error {
 
 func (i *Instance) HasFailure() bool {
 	return i.s.hasFailure(i.cpnt)
-}
-
-func (i *Instance) Commit(ctx context.Context, c client.Client) {
-	i.s.Sync(ctx, c)
 }

--- a/internal/pkg/manager/status/status_manager_test.go
+++ b/internal/pkg/manager/status/status_manager_test.go
@@ -198,8 +198,8 @@ func TestReplicaCounts(t *testing.T) {
 	assert.Equal(t, StatusReady, cs.Status)
 	assert.NotNil(t, cs.DesiredReplicas)
 	assert.NotNil(t, cs.ReadyReplicas)
-	assert.Equal(t, int32(5), cs.DesiredReplicas)
-	assert.Equal(t, int32(5), cs.ReadyReplicas)
+	assert.Equal(t, int32(5), *cs.DesiredReplicas)
+	assert.Equal(t, int32(5), *cs.ReadyReplicas)
 }
 
 func TestReplicaPreservationAcrossTransitions(t *testing.T) {
@@ -215,35 +215,35 @@ func TestReplicaPreservationAcrossTransitions(t *testing.T) {
 		},
 	})
 	cs := agent.Get()
-	require.Equal(t, int32(5), cs.DesiredReplicas)
+	require.Equal(t, int32(5), *cs.DesiredReplicas)
 
 	// Transition to failure: replicas should be preserved
 	agent.SetFailure("AgentKafkaError", "cannot connect to Kafka")
 	cs = agent.Get()
 	assert.Equal(t, StatusFailure, cs.Status)
 	require.NotNil(t, cs.DesiredReplicas, "DesiredReplicas should survive failure transition")
-	assert.Equal(t, int32(5), cs.DesiredReplicas)
+	assert.Equal(t, int32(5), *cs.DesiredReplicas)
 
 	// Transition to degraded: failure takes priority, replicas should still be preserved
 	agent.SetDegraded("SomeWarning", "non-critical issue")
 	cs = agent.Get()
 	assert.Equal(t, StatusFailure, cs.Status)
 	require.NotNil(t, cs.DesiredReplicas, "DesiredReplicas should survive degraded transition")
-	assert.Equal(t, int32(5), cs.DesiredReplicas)
+	assert.Equal(t, int32(5), *cs.DesiredReplicas)
 
 	// Transition to in-progress: failure takes priority, replicas should still be preserved
 	agent.SetNotReady("Updating", "rolling update in progress")
 	cs = agent.Get()
 	assert.Equal(t, StatusFailure, cs.Status)
 	require.NotNil(t, cs.DesiredReplicas, "DesiredReplicas should survive in-progress transition")
-	assert.Equal(t, int32(5), cs.DesiredReplicas)
+	assert.Equal(t, int32(5), *cs.DesiredReplicas)
 
 	// Transition back to ready: failure takes priority, replicas should still be preserved
 	agent.SetReady()
 	cs = agent.Get()
 	assert.Equal(t, StatusFailure, cs.Status)
 	require.NotNil(t, cs.DesiredReplicas)
-	assert.Equal(t, int32(5), cs.DesiredReplicas)
+	assert.Equal(t, int32(5), *cs.DesiredReplicas)
 }
 
 func TestDeploymentReplicaCounts(t *testing.T) {
@@ -267,8 +267,8 @@ func TestDeploymentReplicaCounts(t *testing.T) {
 	cs := plugin.Get()
 	assert.Equal(t, StatusReady, cs.Status)
 	require.NotNil(t, cs.DesiredReplicas)
-	assert.Equal(t, int32(1), cs.DesiredReplicas)
-	assert.Equal(t, int32(1), cs.ReadyReplicas)
+	assert.Equal(t, int32(1), *cs.DesiredReplicas)
+	assert.Equal(t, int32(1), *cs.ReadyReplicas)
 }
 
 func TestDeploymentNotAvailable(t *testing.T) {
@@ -293,8 +293,8 @@ func TestDeploymentNotAvailable(t *testing.T) {
 	assert.Equal(t, StatusInProgress, cs.Status)
 	assert.Contains(t, cs.Message(), "not ready: 1/2")
 	require.NotNil(t, cs.DesiredReplicas)
-	assert.Equal(t, int32(2), cs.DesiredReplicas)
-	assert.Equal(t, int32(1), cs.ReadyReplicas)
+	assert.Equal(t, int32(2), *cs.DesiredReplicas)
+	assert.Equal(t, int32(1), *cs.ReadyReplicas)
 }
 
 func TestDeploymentNilSetsInProgress(t *testing.T) {
@@ -448,8 +448,8 @@ func TestToCRDStatusWithPodHealth(t *testing.T) {
 		Status:          StatusDegraded,
 		Reason:          "UnhealthyPods",
 		Messages:        []string{"2 CrashLoopBackOff (pod-a, pod-b)"},
-		DesiredReplicas: int32(5),
-		ReadyReplicas:   int32(3),
+		DesiredReplicas: ptr.To(int32(5)),
+		ReadyReplicas:   ptr.To(int32(3)),
 		podHealth: podHealthSummary{
 			unhealthyCount: 2,
 			issues:         "2 CrashLoopBackOff (pod-a, pod-b)",

--- a/internal/pkg/manager/status/status_manager_test.go
+++ b/internal/pkg/manager/status/status_manager_test.go
@@ -34,7 +34,7 @@ func TestStatusWorkflow(t *testing.T) {
 		DesiredNumberScheduled: 3,
 		NumberReady:            1,
 	}})
-	sm.SetUnknown()
+	sm.Reset()
 
 	conds = s.getConditions()
 	assertHasConditionTypes(t, conds, []string{"Ready", "WaitingFlowCollectorController", "WaitingMonitoring"})
@@ -42,6 +42,7 @@ func TestStatusWorkflow(t *testing.T) {
 	assertHasCondition(t, conds, "WaitingFlowCollectorController", "DaemonSetNotReady", metav1.ConditionTrue)
 	assertHasCondition(t, conds, "WaitingMonitoring", "Unknown", metav1.ConditionUnknown)
 
+	sl.Reset()
 	sl.CheckDaemonSetProgress(&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Status: appsv1.DaemonSetStatus{
 		DesiredNumberScheduled: 3,
 		NumberReady:            3,
@@ -54,6 +55,8 @@ func TestStatusWorkflow(t *testing.T) {
 	assertHasCondition(t, conds, "WaitingFlowCollectorController", "Ready", metav1.ConditionFalse)
 	assertHasCondition(t, conds, "WaitingMonitoring", "ComponentUnused", metav1.ConditionUnknown)
 
+	sl.Reset()
+	sm.Reset()
 	sl.CheckDeploymentProgress(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Status: appsv1.DeploymentStatus{
 		ReadyReplicas: 2,
 		Replicas:      2,
@@ -65,6 +68,54 @@ func TestStatusWorkflow(t *testing.T) {
 	assertHasCondition(t, conds, "Ready", "Ready", metav1.ConditionTrue)
 	assertHasCondition(t, conds, "WaitingFlowCollectorController", "Ready", metav1.ConditionFalse)
 	assertHasCondition(t, conds, "WaitingMonitoring", "Ready", metav1.ConditionFalse)
+}
+
+func TestStatusAccumulation(t *testing.T) {
+	s := NewManager()
+	sl := s.ForComponent(FlowCollectorController)
+
+	// Start with a degraded status
+	sl.SetDegraded("NotGoingWell", "degraded message")
+
+	cpnt := sl.Get()
+	assert.Equal(t, "degraded message", cpnt.Message())
+	conds := s.getConditions()
+	assertHasConditionTypes(t, conds, []string{"Ready", "WaitingFlowCollectorController"})
+	assertHasCondition(t, conds, "Ready", "Ready,Degraded", metav1.ConditionTrue)
+	assertHasCondition(t, conds, "WaitingFlowCollectorController", "NotGoingWell", metav1.ConditionTrue)
+
+	// Add an "in progress" status: it takes priority over degraded
+	sl.CheckDaemonSetProgress(&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Status: appsv1.DaemonSetStatus{
+		DesiredNumberScheduled: 3,
+		NumberReady:            1,
+	}})
+
+	cpnt = sl.Get()
+	assert.Equal(t, "degraded message; DaemonSet test not ready: 1/3", cpnt.Message())
+	conds = s.getConditions()
+	assertHasConditionTypes(t, conds, []string{"Ready", "WaitingFlowCollectorController"})
+	assertHasCondition(t, conds, "Ready", "Pending", metav1.ConditionFalse)
+	assertHasCondition(t, conds, "WaitingFlowCollectorController", "DaemonSetNotReady", metav1.ConditionTrue)
+
+	// Add a ready status: it's ignored; any sort of issues take priority
+	sl.SetReady()
+
+	cpnt = sl.Get()
+	assert.Equal(t, "degraded message; DaemonSet test not ready: 1/3", cpnt.Message())
+	conds = s.getConditions()
+	assertHasConditionTypes(t, conds, []string{"Ready", "WaitingFlowCollectorController"})
+	assertHasCondition(t, conds, "Ready", "Pending", metav1.ConditionFalse)
+	assertHasCondition(t, conds, "WaitingFlowCollectorController", "DaemonSetNotReady", metav1.ConditionTrue)
+
+	// Add an error: it takes priority
+	sl.SetFailure("Oops", "error message")
+
+	cpnt = sl.Get()
+	assert.Equal(t, "degraded message; DaemonSet test not ready: 1/3; error message", cpnt.Message())
+	conds = s.getConditions()
+	assertHasConditionTypes(t, conds, []string{"Ready", "WaitingFlowCollectorController"})
+	assertHasCondition(t, conds, "Ready", "Failure", metav1.ConditionFalse)
+	assertHasCondition(t, conds, "WaitingFlowCollectorController", "Oops", metav1.ConditionTrue)
 }
 
 func TestDegradedStatus(t *testing.T) {
@@ -83,7 +134,7 @@ func TestDegradedStatus(t *testing.T) {
 	cs := plugin.Get()
 	assert.Equal(t, StatusDegraded, cs.Status)
 	assert.Equal(t, "PluginRegistrationFailed", cs.Reason)
-	assert.Equal(t, "console operator unreachable", cs.Message)
+	assert.Equal(t, "console operator unreachable", cs.Message())
 }
 
 func TestUnusedStatusInCRD(t *testing.T) {
@@ -147,8 +198,8 @@ func TestReplicaCounts(t *testing.T) {
 	assert.Equal(t, StatusReady, cs.Status)
 	assert.NotNil(t, cs.DesiredReplicas)
 	assert.NotNil(t, cs.ReadyReplicas)
-	assert.Equal(t, int32(5), *cs.DesiredReplicas)
-	assert.Equal(t, int32(5), *cs.ReadyReplicas)
+	assert.Equal(t, int32(5), cs.DesiredReplicas)
+	assert.Equal(t, int32(5), cs.ReadyReplicas)
 }
 
 func TestReplicaPreservationAcrossTransitions(t *testing.T) {
@@ -164,35 +215,35 @@ func TestReplicaPreservationAcrossTransitions(t *testing.T) {
 		},
 	})
 	cs := agent.Get()
-	require.Equal(t, int32(5), *cs.DesiredReplicas)
+	require.Equal(t, int32(5), cs.DesiredReplicas)
 
 	// Transition to failure: replicas should be preserved
 	agent.SetFailure("AgentKafkaError", "cannot connect to Kafka")
 	cs = agent.Get()
 	assert.Equal(t, StatusFailure, cs.Status)
 	require.NotNil(t, cs.DesiredReplicas, "DesiredReplicas should survive failure transition")
-	assert.Equal(t, int32(5), *cs.DesiredReplicas)
+	assert.Equal(t, int32(5), cs.DesiredReplicas)
 
-	// Transition to degraded: replicas should still be preserved
+	// Transition to degraded: failure takes priority, replicas should still be preserved
 	agent.SetDegraded("SomeWarning", "non-critical issue")
 	cs = agent.Get()
-	assert.Equal(t, StatusDegraded, cs.Status)
+	assert.Equal(t, StatusFailure, cs.Status)
 	require.NotNil(t, cs.DesiredReplicas, "DesiredReplicas should survive degraded transition")
-	assert.Equal(t, int32(5), *cs.DesiredReplicas)
+	assert.Equal(t, int32(5), cs.DesiredReplicas)
 
-	// Transition to in-progress: replicas should still be preserved
+	// Transition to in-progress: failure takes priority, replicas should still be preserved
 	agent.SetNotReady("Updating", "rolling update in progress")
 	cs = agent.Get()
-	assert.Equal(t, StatusInProgress, cs.Status)
+	assert.Equal(t, StatusFailure, cs.Status)
 	require.NotNil(t, cs.DesiredReplicas, "DesiredReplicas should survive in-progress transition")
-	assert.Equal(t, int32(5), *cs.DesiredReplicas)
+	assert.Equal(t, int32(5), cs.DesiredReplicas)
 
-	// Transition back to ready: replicas should still be preserved
+	// Transition back to ready: failure takes priority, replicas should still be preserved
 	agent.SetReady()
 	cs = agent.Get()
-	assert.Equal(t, StatusReady, cs.Status)
+	assert.Equal(t, StatusFailure, cs.Status)
 	require.NotNil(t, cs.DesiredReplicas)
-	assert.Equal(t, int32(5), *cs.DesiredReplicas)
+	assert.Equal(t, int32(5), cs.DesiredReplicas)
 }
 
 func TestDeploymentReplicaCounts(t *testing.T) {
@@ -216,8 +267,8 @@ func TestDeploymentReplicaCounts(t *testing.T) {
 	cs := plugin.Get()
 	assert.Equal(t, StatusReady, cs.Status)
 	require.NotNil(t, cs.DesiredReplicas)
-	assert.Equal(t, int32(1), *cs.DesiredReplicas)
-	assert.Equal(t, int32(1), *cs.ReadyReplicas)
+	assert.Equal(t, int32(1), cs.DesiredReplicas)
+	assert.Equal(t, int32(1), cs.ReadyReplicas)
 }
 
 func TestDeploymentNotAvailable(t *testing.T) {
@@ -240,10 +291,10 @@ func TestDeploymentNotAvailable(t *testing.T) {
 
 	cs := plugin.Get()
 	assert.Equal(t, StatusInProgress, cs.Status)
-	assert.Contains(t, cs.Message, "not ready: 1/2")
+	assert.Contains(t, cs.Message(), "not ready: 1/2")
 	require.NotNil(t, cs.DesiredReplicas)
-	assert.Equal(t, int32(2), *cs.DesiredReplicas)
-	assert.Equal(t, int32(1), *cs.ReadyReplicas)
+	assert.Equal(t, int32(2), cs.DesiredReplicas)
+	assert.Equal(t, int32(1), cs.ReadyReplicas)
 }
 
 func TestDeploymentNilSetsInProgress(t *testing.T) {
@@ -284,8 +335,8 @@ func TestDaemonSetZeroDesiredScheduled(t *testing.T) {
 	cs := agent.Get()
 	assert.Equal(t, StatusDegraded, cs.Status)
 	assert.Equal(t, "NoPodsScheduled", cs.Reason)
-	assert.Contains(t, cs.Message, "netobserv-ebpf-agent")
-	assert.Contains(t, cs.Message, "nodeSelector")
+	assert.Contains(t, cs.Message(), "netobserv-ebpf-agent")
+	assert.Contains(t, cs.Message(), "nodeSelector")
 }
 
 func TestDaemonSetZeroDesiredScheduledHealth(t *testing.T) {
@@ -333,7 +384,7 @@ func TestDeploymentMissingConditionFallback(t *testing.T) {
 	})
 	cs = plugin2.Get()
 	assert.Equal(t, StatusInProgress, cs.Status)
-	assert.Contains(t, cs.Message, "missing condition")
+	assert.Contains(t, cs.Message(), "missing condition")
 }
 
 func TestSetPodHealthDegradation(t *testing.T) {
@@ -345,16 +396,16 @@ func TestSetPodHealthDegradation(t *testing.T) {
 	assert.Equal(t, StatusReady, agent.Get().Status)
 
 	// Inject pod health issues — should degrade to StatusDegraded
-	agent.setPodHealth(PodHealthSummary{
-		UnhealthyCount: 2,
-		Issues:         "2 CrashLoopBackOff (pod-a, pod-b): can't write messages into Kafka",
+	agent.setPodHealth(podHealthSummary{
+		unhealthyCount: 2,
+		issues:         "2 CrashLoopBackOff (pod-a, pod-b): can't write messages into Kafka",
 	})
 
 	cs := agent.Get()
 	assert.Equal(t, StatusDegraded, cs.Status)
 	assert.Equal(t, "UnhealthyPods", cs.Reason)
-	assert.Contains(t, cs.Message, "Kafka")
-	assert.Equal(t, int32(2), cs.PodHealth.UnhealthyCount)
+	assert.Contains(t, cs.Message(), "Kafka")
+	assert.Equal(t, int32(2), cs.podHealth.unhealthyCount)
 }
 
 func TestSetPodHealthFromInProgress(t *testing.T) {
@@ -364,15 +415,15 @@ func TestSetPodHealthFromInProgress(t *testing.T) {
 	agent.SetNotReady("DaemonSetNotReady", "DaemonSet not ready: 0/2")
 	assert.Equal(t, StatusInProgress, agent.Get().Status)
 
-	agent.setPodHealth(PodHealthSummary{
-		UnhealthyCount: 2,
-		Issues:         "2 CrashLoopBackOff (pod-a, pod-b): Error",
+	agent.setPodHealth(podHealthSummary{
+		unhealthyCount: 2,
+		issues:         "2 CrashLoopBackOff (pod-a, pod-b): Error",
 	})
 
 	cs := agent.Get()
 	assert.Equal(t, StatusDegraded, cs.Status, "InProgress + unhealthy pods should become Degraded")
 	assert.Equal(t, "UnhealthyPods", cs.Reason)
-	assert.Equal(t, int32(2), cs.PodHealth.UnhealthyCount)
+	assert.Equal(t, int32(2), cs.podHealth.unhealthyCount)
 }
 
 func TestSetPodHealthNoDowngradeFromFailure(t *testing.T) {
@@ -381,14 +432,14 @@ func TestSetPodHealthNoDowngradeFromFailure(t *testing.T) {
 
 	// Already in failure — pod health should not override to degraded
 	agent.SetFailure("CriticalError", "crash")
-	agent.setPodHealth(PodHealthSummary{
-		UnhealthyCount: 1,
-		Issues:         "1 CrashLoopBackOff (pod-x)",
+	agent.setPodHealth(podHealthSummary{
+		unhealthyCount: 1,
+		issues:         "1 CrashLoopBackOff (pod-x)",
 	})
 
 	cs := agent.Get()
 	assert.Equal(t, StatusFailure, cs.Status, "setPodHealth should not override Failure with Degraded")
-	assert.Equal(t, int32(1), cs.PodHealth.UnhealthyCount, "PodHealth should still be recorded")
+	assert.Equal(t, int32(1), cs.podHealth.unhealthyCount, "PodHealth should still be recorded")
 }
 
 func TestToCRDStatusWithPodHealth(t *testing.T) {
@@ -396,12 +447,12 @@ func TestToCRDStatusWithPodHealth(t *testing.T) {
 		Name:            EBPFAgents,
 		Status:          StatusDegraded,
 		Reason:          "UnhealthyPods",
-		Message:         "2 CrashLoopBackOff (pod-a, pod-b)",
-		DesiredReplicas: ptr.To(int32(5)),
-		ReadyReplicas:   ptr.To(int32(3)),
-		PodHealth: PodHealthSummary{
-			UnhealthyCount: 2,
-			Issues:         "2 CrashLoopBackOff (pod-a, pod-b)",
+		Messages:        []string{"2 CrashLoopBackOff (pod-a, pod-b)"},
+		DesiredReplicas: int32(5),
+		ReadyReplicas:   int32(3),
+		podHealth: podHealthSummary{
+			unhealthyCount: 2,
+			issues:         "2 CrashLoopBackOff (pod-a, pod-b)",
 		},
 	}
 
@@ -680,9 +731,9 @@ func TestKafkaCondition(t *testing.T) {
 		s := NewManager()
 		transformer := s.ForComponent(FLPTransformer)
 		transformer.SetReady()
-		transformer.setPodHealth(PodHealthSummary{
-			UnhealthyCount: 1,
-			Issues:         "1 CrashLoopBackOff (flp-kafka-0)",
+		transformer.setPodHealth(podHealthSummary{
+			unhealthyCount: 1,
+			issues:         "1 CrashLoopBackOff (flp-kafka-0)",
 		})
 
 		cond := s.GetKafkaCondition()
@@ -697,9 +748,9 @@ func TestKafkaCondition(t *testing.T) {
 		transformer.SetReady()
 		agent := s.ForComponent(EBPFAgents)
 		agent.SetReady()
-		agent.setPodHealth(PodHealthSummary{
-			UnhealthyCount: 3,
-			Issues:         "3 CrashLoopBackOff (agent-a, agent-b, agent-c): can't write Kafka messages",
+		agent.setPodHealth(podHealthSummary{
+			unhealthyCount: 3,
+			issues:         "3 CrashLoopBackOff (agent-a, agent-b, agent-c): can't write Kafka messages",
 		})
 
 		cond := s.GetKafkaCondition()
@@ -714,9 +765,9 @@ func TestKafkaCondition(t *testing.T) {
 		transformer.SetReady()
 		agent := s.ForComponent(EBPFAgents)
 		agent.SetReady()
-		agent.setPodHealth(PodHealthSummary{
-			UnhealthyCount: 1,
-			Issues:         "1 OOMKilled (agent-x)",
+		agent.setPodHealth(podHealthSummary{
+			unhealthyCount: 1,
+			issues:         "1 OOMKilled (agent-x)",
 		})
 
 		cond := s.GetKafkaCondition()
@@ -780,6 +831,7 @@ func TestEmitStateTransitionEvents(t *testing.T) {
 	assert.Empty(t, rec.events, "First call should not emit events (no previous state)")
 
 	// Transition to failure
+	s.reset(agent.cpnt)
 	agent.SetFailure("KafkaError", "broker down")
 	s.emitStateTransitionEvents(ctx(), fc)
 	require.Len(t, rec.events, 1)
@@ -789,6 +841,7 @@ func TestEmitStateTransitionEvents(t *testing.T) {
 	assert.Contains(t, rec.events[0].message, "broker down")
 
 	// Transition to ready (recovery)
+	s.reset(agent.cpnt)
 	rec.events = nil
 	agent.SetReady()
 	s.emitStateTransitionEvents(ctx(), fc)
@@ -797,12 +850,14 @@ func TestEmitStateTransitionEvents(t *testing.T) {
 	assert.Equal(t, "ComponentRecovered", rec.events[0].reason)
 
 	// Same state again — no event
+	s.reset(agent.cpnt)
 	rec.events = nil
 	agent.SetReady()
 	s.emitStateTransitionEvents(ctx(), fc)
 	assert.Empty(t, rec.events, "Same state should not emit events")
 
 	// Transition to degraded
+	s.reset(agent.cpnt)
 	rec.events = nil
 	agent.SetDegraded("HighRestarts", "5 pods restarting")
 	s.emitStateTransitionEvents(ctx(), fc)
@@ -907,9 +962,9 @@ func TestNeedsRequeue(t *testing.T) {
 		s := NewManager()
 		agent := s.ForComponent(EBPFAgents)
 		agent.SetReady()
-		agent.setPodHealth(PodHealthSummary{
-			UnhealthyCount: 2,
-			Issues:         "2 CrashLoopBackOff (pod-a, pod-b)",
+		agent.setPodHealth(podHealthSummary{
+			unhealthyCount: 2,
+			issues:         "2 CrashLoopBackOff (pod-a, pod-b)",
 		})
 		assert.True(t, s.NeedsRequeue())
 	})
@@ -919,7 +974,7 @@ func TestNeedsRequeue(t *testing.T) {
 		a := s.ForComponent(EBPFAgents)
 		b := s.ForComponent(WebConsole)
 		a.SetUnused("disabled")
-		b.SetUnknown()
+		b.Reset()
 		assert.False(t, s.NeedsRequeue())
 	})
 

--- a/internal/pkg/manager/status/statuses.go
+++ b/internal/pkg/manager/status/statuses.go
@@ -1,6 +1,9 @@
 package status
 
 import (
+	"slices"
+	"strings"
+
 	flowslatest "github.com/netobserv/netobserv-operator/api/flowcollector/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -17,14 +20,52 @@ const (
 	StatusDegraded   Status = "Degraded"
 )
 
+var (
+	statusPriority = []Status{
+		StatusFailure,
+		StatusInProgress,
+		StatusDegraded,
+		StatusUnused,
+		StatusReady,
+		StatusUnknown,
+	}
+)
+
 type ComponentStatus struct {
 	Name            ComponentName
 	Status          Status
 	Reason          string
-	Message         string
-	DesiredReplicas *int32
-	ReadyReplicas   *int32
-	PodHealth       PodHealthSummary
+	Messages        []string
+	DesiredReplicas int32
+	ReadyReplicas   int32
+	podHealth       podHealthSummary
+}
+
+func (s *ComponentStatus) Message() string {
+	return strings.Join(s.Messages, "; ")
+}
+
+// merge two component statuses, prioritizing the worst
+func (s *ComponentStatus) merge(other *ComponentStatus) *ComponentStatus {
+	merged := *s
+	if slices.Index(statusPriority, other.Status) <= slices.Index(statusPriority, merged.Status) {
+		merged.Status = other.Status
+		merged.Reason = other.Reason
+	}
+	merged.Messages = append(merged.Messages, other.Messages...)
+	if other.DesiredReplicas > 0 {
+		merged.DesiredReplicas = other.DesiredReplicas
+		merged.ReadyReplicas = other.ReadyReplicas
+	}
+	if other.podHealth.unhealthyCount > 0 {
+		merged.podHealth = other.podHealth
+		if s.Status == StatusInProgress {
+			// Special priority case, Degraded > InProgress with unhealthy pods
+			merged.Status = other.Status
+			merged.Reason = other.Reason
+		}
+	}
+	return &merged
 }
 
 // toCondition returns a Kubernetes condition using "Waiting*" naming with negative polarity:
@@ -34,7 +75,7 @@ type ComponentStatus struct {
 func (s *ComponentStatus) toCondition() metav1.Condition {
 	c := metav1.Condition{
 		Type:    "Waiting" + string(s.Name),
-		Message: s.Message,
+		Message: s.Message(),
 	}
 	switch s.Status {
 	case StatusUnknown:
@@ -63,15 +104,13 @@ func (s *ComponentStatus) toCRDStatus() *flowslatest.FlowCollectorComponentStatu
 	cs := &flowslatest.FlowCollectorComponentStatus{
 		State:   string(s.Status),
 		Reason:  s.Reason,
-		Message: s.Message,
+		Message: s.Message(),
 	}
-	if s.DesiredReplicas != nil {
-		cs.DesiredReplicas = ptr.To(*s.DesiredReplicas)
+	if s.DesiredReplicas > 0 {
+		cs.DesiredReplicas = ptr.To(s.DesiredReplicas)
+		cs.ReadyReplicas = ptr.To(s.ReadyReplicas)
 	}
-	if s.ReadyReplicas != nil {
-		cs.ReadyReplicas = ptr.To(*s.ReadyReplicas)
-	}
-	cs.UnhealthyPodCount = s.PodHealth.UnhealthyCount
-	cs.PodIssues = s.PodHealth.Issues
+	cs.UnhealthyPodCount = s.podHealth.unhealthyCount
+	cs.PodIssues = s.podHealth.issues
 	return cs
 }

--- a/internal/pkg/manager/status/statuses.go
+++ b/internal/pkg/manager/status/statuses.go
@@ -36,8 +36,8 @@ type ComponentStatus struct {
 	Status          Status
 	Reason          string
 	Messages        []string
-	DesiredReplicas int32
-	ReadyReplicas   int32
+	DesiredReplicas *int32
+	ReadyReplicas   *int32
 	podHealth       podHealthSummary
 }
 
@@ -53,9 +53,11 @@ func (s *ComponentStatus) merge(other *ComponentStatus) *ComponentStatus {
 		merged.Reason = other.Reason
 	}
 	merged.Messages = append(merged.Messages, other.Messages...)
-	if other.DesiredReplicas > 0 {
-		merged.DesiredReplicas = other.DesiredReplicas
-		merged.ReadyReplicas = other.ReadyReplicas
+	if other.DesiredReplicas != nil {
+		merged.DesiredReplicas = ptr.To(*other.DesiredReplicas)
+	}
+	if other.ReadyReplicas != nil {
+		merged.ReadyReplicas = ptr.To(*other.ReadyReplicas)
 	}
 	if other.podHealth.unhealthyCount > 0 {
 		merged.podHealth = other.podHealth
@@ -106,9 +108,11 @@ func (s *ComponentStatus) toCRDStatus() *flowslatest.FlowCollectorComponentStatu
 		Reason:  s.Reason,
 		Message: s.Message(),
 	}
-	if s.DesiredReplicas > 0 {
-		cs.DesiredReplicas = ptr.To(s.DesiredReplicas)
-		cs.ReadyReplicas = ptr.To(s.ReadyReplicas)
+	if s.DesiredReplicas != nil {
+		cs.DesiredReplicas = ptr.To(*s.DesiredReplicas)
+	}
+	if s.ReadyReplicas != nil {
+		cs.ReadyReplicas = ptr.To(*s.ReadyReplicas)
 	}
 	cs.UnhealthyPodCount = s.podHealth.unhealthyCount
 	cs.PodIssues = s.podHealth.issues

--- a/internal/pkg/migrator/migrator.go
+++ b/internal/pkg/migrator/migrator.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/netobserv/netobserv-operator/internal/pkg/retry"
 	apix "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -38,7 +39,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/pager"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -106,7 +106,7 @@ func (m *Migrator) migrateWithRetry(ctx context.Context, gr schema.GroupResource
 	// Retrying to allow time for the conversion webhooks to be ready
 	// There's no hurry to get this done, start with a duration > second
 	attempt := 0
-	return retry.OnError(retryBackoff, func(error) bool { return true }, func() error {
+	return retry.OnError(ctx, retryBackoff, func(error) bool { return true }, func() error {
 		log := log.FromContext(ctx)
 		log.WithValues("attempt", attempt).Info("try migrate")
 		attempt++

--- a/internal/pkg/narrowcache/client.go
+++ b/internal/pkg/narrowcache/client.go
@@ -2,11 +2,12 @@ package narrowcache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -67,14 +68,15 @@ func (c *Client) getAndCreateWatchIfNeeded(ctx context.Context, info GVKInfo, gv
 
 	c.wmut.RLock()
 	ca := c.watchedObjects[objKey]
-	c.wmut.RUnlock()
 	if ca != nil {
+		defer c.wmut.RUnlock()
 		if ca.cached == nil {
-			return nil, objKey, errors.NewNotFound(schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind}, key.Name)
+			return nil, objKey, kerr.NewNotFound(schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind}, key.Name)
 		}
 		// Return from cache
 		return ca.cached, objKey, nil
 	}
+	c.wmut.RUnlock()
 
 	// Live query
 	rlog := log.FromContext(ctx).WithName("narrowcache").WithValues("objKey", objKey)
@@ -121,20 +123,31 @@ func copyInto(obj runtime.Object, out client.Object) error {
 
 func (c *Client) updateCache(ctx context.Context, key string, watcher watch.Interface) {
 	rlog := log.FromContext(ctx).WithName("narrowcache")
-	for watchEvent := range watcher.ResultChan() {
-		rlog.WithValues("key", key, "event type", watchEvent.Type).Info("Event received")
-		if watchEvent.Type == watch.Added || watchEvent.Type == watch.Modified {
-			err := c.setToCache(key, watchEvent.Object)
-			if err != nil {
-				rlog.WithValues("key", key).Error(err, "Error while updating cache")
+	defer func() {
+		watcher.Stop()
+		rlog.WithValues("key", key).Info("Watch terminated. Clearing cache entry.")
+		c.clearEntryByKey(key)
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case watchEvent, ok := <-watcher.ResultChan():
+			if !ok {
+				return
 			}
-		} else if watchEvent.Type == watch.Deleted {
-			c.removeFromCache(key)
+			rlog.WithValues("key", key, "event type", watchEvent.Type).Info("Event received")
+			if watchEvent.Type == watch.Added || watchEvent.Type == watch.Modified {
+				if err := c.setToCache(key, watchEvent.Object); err != nil {
+					rlog.WithValues("key", key).Error(err, "Error while updating cache")
+				}
+			} else if watchEvent.Type == watch.Deleted {
+				c.removeFromCache(key)
+			}
+			c.callHandlers(ctx, key, watchEvent)
 		}
-		c.callHandlers(ctx, key, watchEvent)
 	}
-	rlog.WithValues("key", key).Info("Watch terminated. Clearing cache entry.")
-	c.clearEntryByKey(key)
 }
 
 func (c *Client) setToCache(key string, obj runtime.Object) error {
@@ -161,15 +174,24 @@ func (c *Client) removeFromCache(key string) {
 	}
 }
 
-func (c *Client) addHandler(key string, hoq handlerOnQueue) {
+func (c *Client) addHandler(ctx context.Context, key string, hoq handlerOnQueue) error {
+	if ctx.Err() != nil {
+		return errors.New("context canceled, not adding handler")
+	}
 	c.wmut.Lock()
 	defer c.wmut.Unlock()
 	if ca := c.watchedObjects[key]; ca != nil {
 		ca.handlers = append(ca.handlers, hoq)
+	} else {
+		return fmt.Errorf("watching handler could not be attached: object %s not found", key)
 	}
+	return nil
 }
 
 func (c *Client) callHandlers(ctx context.Context, key string, ev watch.Event) {
+	if ctx.Err() != nil {
+		return
+	}
 	var fn func(hoq handlerOnQueue)
 	switch ev.Type {
 	case watch.Added:
@@ -226,8 +248,8 @@ func (c *Client) GetSource(ctx context.Context, obj client.Object, h handler.Eve
 
 	return &NarrowSource{
 		handler: h,
-		onStart: func(_ context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			c.addHandler(key, handlerOnQueue{handler: h, queue: q})
+		onStart: func(ctx context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
+			return c.addHandler(ctx, key, handlerOnQueue{handler: h, queue: q})
 		},
 	}, nil
 }

--- a/internal/pkg/narrowcache/source.go
+++ b/internal/pkg/narrowcache/source.go
@@ -13,13 +13,12 @@ import (
 type NarrowSource struct {
 	source.Source
 	handler handler.EventHandler
-	onStart func(ctx context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request])
+	onStart func(ctx context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error
 }
 
 func (s *NarrowSource) Start(ctx context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
 	if s.handler == nil {
 		return errors.New("must specify NarrowSource.handler")
 	}
-	s.onStart(ctx, q)
-	return nil
+	return s.onStart(ctx, q)
 }

--- a/internal/pkg/retry/retry.go
+++ b/internal/pkg/retry/retry.go
@@ -1,0 +1,25 @@
+package retry
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	kretry "k8s.io/client-go/util/retry"
+)
+
+// OnError retries fn on error, respecting context cancellation between attempts.
+func OnError(ctx context.Context, backoff wait.Backoff, retriable func(error) bool, fn func() error) error {
+	return kretry.OnError(backoff,
+		func(err error) bool {
+			if ctx.Err() != nil {
+				return false
+			}
+			return retriable(err)
+		},
+		func() error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fn()
+		})
+}

--- a/internal/pkg/test/envtest.go
+++ b/internal/pkg/test/envtest.go
@@ -58,11 +58,115 @@ type SuiteContext struct {
 	kubeConfig string
 }
 
-func PrepareEnvTest(controllers []manager.Registerer, opNamespace string, namespaces []string, basePath string) (context.Context, client.Client, *SuiteContext) {
+func PrepareEnvTest(controllers []manager.Registerer, namespaces []string, basePath string) (context.Context, client.Client, *SuiteContext) {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	ctx, cancel := context.WithCancel(context.TODO())
 
-	By("bootstrapping test environment")
+	By("bootstrapping test environment (vanilla)")
+	testEnv := &envtest.Environment{
+		Scheme: scheme.Scheme,
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				// Hack to reintroduce when the API stored version != latest version: comment-out config/crd/bases and use hack instead; see also Makefile "hack-crd-for-test"
+				filepath.Join(basePath, "..", "..", "config", "crd", "bases"),
+				// filepath.Join(basePath, "..", "hack"),
+				filepath.Join(basePath, "..", "..", "test-assets"),
+			},
+			CleanUpAfterUse: true,
+			WebhookOptions: envtest.WebhookInstallOptions{
+				Paths: []string{
+					filepath.Join(basePath, "..", "..", "config", "webhook"),
+				},
+			},
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	kubeConfig, err := writeKubeConfig(testEnv)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = flowsv1beta2.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = metricsv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = slicesv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = corev1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = apiregv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = monitoringv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = lokiv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	for _, ns := range namespaces {
+		err := k8sClient.Create(ctx, &corev1.Namespace{
+			TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: ns},
+		})
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	k8sManager, err := manager.NewManager(
+		ctx,
+		cfg,
+		&manager.Config{
+			EBPFAgentImage:        "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-ebpf-agent@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
+			FlowlogsPipelineImage: "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-flowlogs-pipeline@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e",
+			ConsolePluginImageVariants: []manager.ConsolePluginImageVariant{
+				{Image: "registry-proxy.engineering.redhat.com/rh-osbs/network-observability-console-plugin@sha256:6481481ba23375107233f8d0a4f839436e34e50c2ec550ead0a16c361ae6654e", MinVersion: "4.14.0"},
+			},
+			DownstreamDeployment: false,
+			Namespace:            "main-namespace",
+		},
+		&ctrl.Options{
+			Scheme: scheme.Scheme,
+			Metrics: server.Options{
+				BindAddress: "0", // disable
+			},
+		},
+		controllers,
+	)
+
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sManager).NotTo(BeNil())
+
+	err = helper.SetCRDForTests(filepath.Join(basePath, "..", ".."))
+	Expect(err).NotTo(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = k8sManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+	}()
+
+	return ctx, k8sClient, &SuiteContext{
+		testEnv:    testEnv,
+		cancel:     cancel,
+		kubeConfig: kubeConfig,
+	}
+}
+
+func PrepareOCPEnvTest(controllers []manager.Registerer, opNamespace string, namespaces []string, basePath string) (context.Context, client.Client, *SuiteContext) {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment (OCP)")
 	testEnv := &envtest.Environment{
 		Scheme: scheme.Scheme,
 		CRDInstallOptions: envtest.CRDInstallOptions{

--- a/internal/pkg/test/envtest.go
+++ b/internal/pkg/test/envtest.go
@@ -58,7 +58,7 @@ type SuiteContext struct {
 	kubeConfig string
 }
 
-func PrepareEnvTest(controllers []manager.Registerer, namespaces []string, basePath string) (context.Context, client.Client, *SuiteContext) {
+func PrepareEnvTest(controllers []manager.Registerer, opNamespace string, namespaces []string, basePath string) (context.Context, client.Client, *SuiteContext) {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	ctx, cancel := context.WithCancel(context.TODO())
 
@@ -134,6 +134,7 @@ func PrepareEnvTest(controllers []manager.Registerer, namespaces []string, baseP
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
+	namespaces = append(namespaces, opNamespace)
 	for _, ns := range namespaces {
 		err := k8sClient.Create(ctx, &corev1.Namespace{
 			TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
@@ -195,6 +196,8 @@ func PrepareEnvTest(controllers []manager.Registerer, namespaces []string, baseP
 	err = helper.SetCRDForTests(filepath.Join(basePath, "..", ".."))
 	Expect(err).NotTo(HaveOccurred())
 
+	createFakeController(ctx, k8sClient, opNamespace)
+
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)
@@ -234,11 +237,11 @@ func TeardownEnvTest(suiteContext *SuiteContext) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func CreateFakeController(ctx context.Context, k8sClient client.Client) {
+func createFakeController(ctx context.Context, k8sClient client.Client, opNamespace string) {
 	created := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "netobserv-controller-manager",
-			Namespace: "main-namespace",
+			Namespace: opNamespace,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{

--- a/internal/pkg/watchers/object_ref.go
+++ b/internal/pkg/watchers/object_ref.go
@@ -14,7 +14,7 @@ type objectRef struct {
 func (w *Watcher) refFromFile(fr *flowslatest.FileReference) objectRef {
 	ns := fr.Namespace
 	if ns == "" {
-		ns = w.defaultNamespace
+		ns = w.getDefaultNamespace()
 	}
 	return objectRef{
 		kind:      fr.Type,
@@ -27,7 +27,7 @@ func (w *Watcher) refFromFile(fr *flowslatest.FileReference) objectRef {
 func (w *Watcher) refFromCert(cert *flowslatest.CertificateReference) objectRef {
 	ns := cert.Namespace
 	if ns == "" {
-		ns = w.defaultNamespace
+		ns = w.getDefaultNamespace()
 	}
 	keys := []string{cert.CertFile}
 	if cert.CertKey != "" {

--- a/internal/pkg/watchers/watcher.go
+++ b/internal/pkg/watchers/watcher.go
@@ -50,13 +50,19 @@ func kindToWatchable(kind flowslatest.MountableType) Watchable {
 }
 
 func (w *Watcher) Reset(namespace string) {
+	w.wmut.Lock()
 	w.defaultNamespace = namespace
 	// Reset all registered watches as inactive
-	w.wmut.Lock()
 	for k := range w.watches {
 		w.watches[k] = false
 	}
 	w.wmut.Unlock()
+}
+
+func (w *Watcher) getDefaultNamespace() string {
+	w.wmut.RLock()
+	defer w.wmut.RUnlock()
+	return w.defaultNamespace
 }
 
 func key(kind flowslatest.MountableType, name, namespace string) string {
@@ -101,11 +107,7 @@ func (w *Watcher) watch(ctx context.Context, cl *narrowcache.Client, kind flowsl
 	// Note that currently, watches are never removed (they can't - cf https://github.com/kubernetes-sigs/controller-runtime/issues/1884)
 	// This isn't a big deal here, as the number of watches that we set is very limited and not meant to grow over and over
 	// (unless user keeps reconfiguring cert references endlessly)
-	err = w.ctrl.Watch(s)
-	if err != nil {
-		return err
-	}
-	return nil
+	return w.ctrl.Watch(s)
 }
 
 func (w *Watcher) ProcessMTLSCerts(ctx context.Context, cl helper.Client, tls *flowslatest.ClientTLS, targetNamespace string) (caDigest string, userDigest string, err error) {

--- a/test-assets/loki.grafana.com_lokistacks.yaml
+++ b/test-assets/loki.grafana.com_lokistacks.yaml
@@ -1,0 +1,43 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: lokistacks.loki.grafana.com
+spec:
+  group: loki.grafana.com
+  names:
+    categories:
+    - logging
+    kind: LokiStack
+    listKind: LokiStackList
+    plural: lokistacks
+    singular: lokistack
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: LokiStack is the Schema for the lokistacks API
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LokiStack CR spec field.
+            type: object
+          status:
+            description: LokiStack CR spec Status.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null


### PR DESCRIPTION
## Description

Configure console k8s client token access.
Also make the ConsoleMode config (standalone vs plugin vs mock) explicit

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
- Console: https://github.com/netobserv/netobserv-web-console/pull/1550

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added read-only viewer role for accessing flow collector resource information

* **Improvements**
  * Enhanced error resilience: missing certificates and API availability issues now trigger graceful degradation with status updates instead of blocking reconciliation
  * Improved standalone console mode support
  * Refined component status reporting for better visibility into system health
<!-- end of auto-generated comment: release notes by coderabbit.ai -->