### PR TITLE
Test additional include list

### DIFF
--- a/integration-tests/backend/metrics.go
+++ b/integration-tests/backend/metrics.go
@@ -174,3 +174,31 @@ func getMetricsServerName(oc *exutil.CLI, servicemonitor string, namespace strin
 	out, err := oc.AsAdmin().Run("get").Args("servicemonitor", servicemonitor, "-n", namespace, "-o", "jsonpath='{.spec.endpoints[].tlsConfig.serverName}'").Output()
 	return out, err
 }
+
+// getAllNetobservMetricNames queries Prometheus for all netobserv flow metrics and returns their names
+// Flow metrics are those controlled by includeList/additionalIncludeList configuration
+// (node_*, workload_*, namespace_*), excluding operational metrics (agent_*, ingest_*, etc.)
+func getAllNetobservMetricNames(oc *exutil.CLI) ([]string, error) {
+	// Query for flow metrics only (node_, workload_, namespace_ prefixes)
+	query := `{__name__=~"netobserv_(node|workload|namespace)_.*"}`
+	metrics, err := getMetric(oc, query)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract unique metric names
+	metricNames := make(map[string]bool)
+	for _, m := range metrics {
+		if m.Metric.Name != "" {
+			metricNames[m.Metric.Name] = true
+		}
+	}
+
+	// Convert map to slice
+	result := make([]string, 0, len(metricNames))
+	for name := range metricNames {
+		result = append(result, name)
+	}
+
+	return result, nil
+}

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -326,7 +326,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 	g.It("Author:osmakal-High-89198-Verify processor metrics configuration with includeList and additionalIncludeList [Serial]", func() {
 		namespace := oc.Namespace()
 
-		g.By(fmt.Sprintf("Deploy initial FlowCollector"))
+		g.By(fmt.Sprintf("Deploy initial FlowCollector without additionalIncludeList"))
 		flow := Flowcollector{
 			Namespace:  namespace,
 			Template:   flowFixturePath,
@@ -335,54 +335,68 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		defer func() { _ = flow.DeleteFlowcollector(oc) }()
 		flow.CreateFlowcollector(oc)
 
-		// Apply patch if specified
-		g.By(fmt.Sprintf("Patch FlowCollector with metrics configuration"))
+		g.By(fmt.Sprintf("Wait for FlowCollector to reconcile"))
+		flow.WaitForFlowcollectorReady(oc)
+
+		g.By(fmt.Sprintf("Wait for baseline metrics to be available"))
+		time.Sleep(90 * time.Second)
+
+		// Capture baseline metrics (defaults only)
+		g.By(fmt.Sprintf("Query Prometheus for baseline netobserv_* metrics"))
+		baselineMetrics, err := getAllNetobservMetricNames(oc)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("failed to query Prometheus for baseline"))
+
+		e2e.Logf("Found %d baseline netobserv metrics in Prometheus", len(baselineMetrics))
+
+		baselineSet := make(map[string]bool)
+		for _, m := range baselineMetrics {
+			baselineSet[m] = true
+		}
+
+		// Apply patch to add additional metrics
+		g.By(fmt.Sprintf("Patch FlowCollector with additionalIncludeList"))
+		additionalIncludeList := []string{"namespace_egress_bytes_total", "namespace_ingress_bytes_total"}
 		patch := `[{"op": "add", "path": "/spec/processor/metrics/additionalIncludeList", "value": ["namespace_egress_bytes_total", "namespace_ingress_bytes_total"]}]`
 		out, err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=json", "-p", patch).Output()
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("failed to patch FlowCollector"))
 		o.Expect(out).To(o.ContainSubstring("patched"))
 
-		g.By(fmt.Sprintf("Wait for FlowCollector to reconcile"))
+		g.By(fmt.Sprintf("Wait for FlowCollector to reconcile after patch"))
 		flow.WaitForFlowcollectorReady(oc)
 
-		g.By(fmt.Sprintf("Wait for metrics to be available"))
+		g.By(fmt.Sprintf("Wait for updated metrics to be available"))
 		time.Sleep(90 * time.Second)
 
-		// Get all netobserv metrics currently exposed
-		g.By(fmt.Sprintf("Query Prometheus for all netobserv_* metrics"))
+		// Get all metrics after patch
+		g.By(fmt.Sprintf("Query Prometheus for all netobserv_* metrics after patch"))
 		allMetrics, err := getAllNetobservMetricNames(oc)
-		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("failed to query Prometheus"))
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("failed to query Prometheus after patch"))
 
-		e2e.Logf("Found %d netobserv metrics in Prometheus", len(allMetrics))
+		e2e.Logf("Found %d netobserv metrics in Prometheus after patch", len(allMetrics))
 
-		// Convert both to sets for comparison
 		actualSet := make(map[string]bool)
 		for _, m := range allMetrics {
 			actualSet[m] = true
 		}
 
-		expectedMetrics := []string{
-			// 9 base metrics (from defaults without features)
-			"netobserv_node_egress_bytes_total",
-			"netobserv_node_ingress_bytes_total",
-			"netobserv_node_ingress_packets_total",
-			"netobserv_node_to_node_ingress_flows_total",
-			"netobserv_workload_egress_bytes_total",
-			"netobserv_workload_egress_packets_total",
-			"netobserv_workload_flows_total",
-			"netobserv_workload_ingress_bytes_total",
-			"netobserv_workload_ingress_packets_total",
-			// Plus 2 additional metrics
-			"netobserv_namespace_egress_bytes_total",
-			"netobserv_namespace_ingress_bytes_total",
-		}
-		o.Expect(len(expectedMetrics)).To(o.Equal(len(allMetrics)),
-			fmt.Sprintf("expected %d metrics but found %d: %v", len(expectedMetrics), len(allMetrics), allMetrics))
-
-		for _, metric := range expectedMetrics {
+		// Verify all baseline metrics are still present (superset check)
+		for _, metric := range baselineMetrics {
 			o.Expect(actualSet[metric]).To(o.BeTrue(),
-				fmt.Sprintf("metric %s should exist in %v", metric, actualSet))
+				fmt.Sprintf("baseline metric %s should still exist in %v", metric, allMetrics))
 		}
+
+		// Verify the additional metrics are now present
+		for _, metric := range additionalIncludeList {
+			fullMetricName := "netobserv_" + metric
+			o.Expect(actualSet[fullMetricName]).To(o.BeTrue(),
+				fmt.Sprintf("additional metric %s should exist in %v", fullMetricName, allMetrics))
+		}
+
+		// Verify the total count increased by exactly len(additionalIncludeList)
+		expectedCount := len(baselineMetrics) + len(additionalIncludeList)
+		o.Expect(len(allMetrics)).To(o.Equal(expectedCount),
+			fmt.Sprintf("expected %d metrics (baseline: %d + additional: %d) but found %d: %v",
+				expectedCount, len(baselineMetrics), len(additionalIncludeList), len(allMetrics), allMetrics))
 	})
 
 	g.Context("with Loki", func() {

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -324,7 +324,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 	})
 
 	g.It("Author:osmakal-High-89198-Verify processor metrics configuration with includeList and additionalIncludeList [Serial]", func() {
-		SkipIfOCPBelow("v4.14")
 		namespace := oc.Namespace()
 
 		type MetricsTestScenario struct {

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -323,6 +323,122 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		}
 	})
 
+	g.It("Author:osmakal-High-89198-Verify processor metrics configuration with includeList and additionalIncludeList [Serial]", func() {
+		SkipIfOCPBelow("v4.14")
+		namespace := oc.Namespace()
+
+		type MetricsTestScenario struct {
+			Name            string
+			PatchJSON       string
+			ExpectedMetrics []string
+		}
+
+		tests := []MetricsTestScenario{
+			{
+				Name:      "Default behavior",
+				PatchJSON: "", // No patch, Loki disabled - uses DefaultIncludeListLokiDisabled but only metrics that don't require features
+				ExpectedMetrics: []string{
+					"netobserv_node_egress_bytes_total",
+					"netobserv_node_ingress_bytes_total",
+					"netobserv_node_ingress_packets_total",
+					"netobserv_node_to_node_ingress_flows_total",
+					"netobserv_workload_egress_bytes_total",
+					"netobserv_workload_egress_packets_total",
+					"netobserv_workload_flows_total",
+					"netobserv_workload_ingress_bytes_total",
+					"netobserv_workload_ingress_packets_total",
+				},
+			},
+			{
+				Name:      "includeList only",
+				PatchJSON: `[{"op": "add", "path": "/spec/processor/metrics/includeList", "value": ["node_ingress_bytes_total"]}]`,
+				ExpectedMetrics: []string{
+					"netobserv_node_ingress_bytes_total",
+				},
+			},
+			{
+				Name:      "additionalIncludeList only",
+				PatchJSON: `[{"op": "add", "path": "/spec/processor/metrics/additionalIncludeList", "value": ["namespace_egress_bytes_total", "namespace_ingress_bytes_total"]}]`,
+				ExpectedMetrics: []string{
+					// 9 base metrics (from defaults without features)
+					"netobserv_node_egress_bytes_total",
+					"netobserv_node_ingress_bytes_total",
+					"netobserv_node_ingress_packets_total",
+					"netobserv_node_to_node_ingress_flows_total",
+					"netobserv_workload_egress_bytes_total",
+					"netobserv_workload_egress_packets_total",
+					"netobserv_workload_flows_total",
+					"netobserv_workload_ingress_bytes_total",
+					"netobserv_workload_ingress_packets_total",
+					// Plus 2 additional metrics
+					"netobserv_namespace_egress_bytes_total",
+					"netobserv_namespace_ingress_bytes_total",
+				},
+			},
+			{
+				Name:      "Both fields set",
+				PatchJSON: `[{"op": "add", "path": "/spec/processor/metrics/includeList", "value": ["node_ingress_bytes_total"]}, {"op": "add", "path": "/spec/processor/metrics/additionalIncludeList", "value": ["namespace_egress_bytes_total", "namespace_ingress_bytes_total"]}]`,
+				ExpectedMetrics: []string{
+					"netobserv_node_ingress_bytes_total",
+				},
+			},
+		}
+
+		for _, t := range tests {
+			func() {
+				g.By(fmt.Sprintf("Test: %s", t.Name))
+				g.By(fmt.Sprintf("[%s]: Deploy initial FlowCollector", t.Name))
+				flow := Flowcollector{
+					Namespace:  namespace,
+					Template:   flowFixturePath,
+					LokiEnable: "false",
+				}
+				defer func() { _ = flow.DeleteFlowcollector(oc) }()
+				flow.CreateFlowcollector(oc)
+
+				// Apply patch if specified
+				if t.PatchJSON != "" {
+					g.By(fmt.Sprintf("[%s]: Patch FlowCollector with metrics configuration", t.Name))
+					out, err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=json", "-p", t.PatchJSON).Output()
+					o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("%s: failed to patch FlowCollector", t.Name))
+					o.Expect(out).To(o.ContainSubstring("patched"))
+
+					g.By(fmt.Sprintf("[%s]: Wait for FlowCollector to reconcile", t.Name))
+					flow.WaitForFlowcollectorReady(oc)
+				}
+
+				g.By(fmt.Sprintf("[%s]: Wait for metrics to be available", t.Name))
+				time.Sleep(60 * time.Second)
+
+				// Get all netobserv metrics currently exposed
+				g.By(fmt.Sprintf("[%s]: Query Prometheus for all netobserv_* metrics", t.Name))
+				allMetrics, err := getAllNetobservMetricNames(oc)
+				o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("%s: failed to query Prometheus", t.Name))
+
+				e2e.Logf("[%s]: Found %d netobserv metrics in Prometheus", t.Name, len(allMetrics))
+
+				// Convert both to sets for comparison
+				actualSet := make(map[string]bool)
+				for _, m := range allMetrics {
+					actualSet[m] = true
+				}
+
+				expectedSet := make(map[string]bool)
+				for _, m := range t.ExpectedMetrics {
+					expectedSet[m] = true
+				}
+
+				o.Expect(len(t.ExpectedMetrics)).To(o.Equal(len(allMetrics)),
+					fmt.Sprintf("[%s]: expected %d metrics but found %d: %v", t.Name, len(t.ExpectedMetrics), len(allMetrics), allMetrics))
+
+				for _, expectedMetric := range t.ExpectedMetrics {
+					o.Expect(actualSet[expectedMetric]).To(o.BeTrue(),
+						fmt.Sprintf("[%s]: metric %s should exist in %v", t.Name, expectedMetric, actualSet))
+				}
+			}()
+		}
+	})
+
 	g.Context("with Loki", func() {
 		var (
 			lokiDir, _ = filePath.Abs("testdata/loki")

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -423,11 +423,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 					actualSet[m] = true
 				}
 
-				expectedSet := make(map[string]bool)
-				for _, m := range t.ExpectedMetrics {
-					expectedSet[m] = true
-				}
-
 				o.Expect(len(t.ExpectedMetrics)).To(o.Equal(len(allMetrics)),
 					fmt.Sprintf("[%s]: expected %d metrics but found %d: %v", t.Name, len(t.ExpectedMetrics), len(allMetrics), allMetrics))
 

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -326,117 +326,69 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 	g.It("Author:osmakal-High-89198-Verify processor metrics configuration with includeList and additionalIncludeList [Serial]", func() {
 		namespace := oc.Namespace()
 
-		type MetricsTestScenario struct {
-			Name            string
-			PatchJSON       string
-			ExpectedMetrics []string
+		g.By(fmt.Sprintf("Deploy initial FlowCollector"))
+		flow := Flowcollector{
+			Namespace:  namespace,
+			Template:   flowFixturePath,
+			LokiEnable: "false",
+		}
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		// Apply patch if specified
+		g.By(fmt.Sprintf("Patch FlowCollector with metrics configuration"))
+		patch := `[{"op": "add", "path": "/spec/processor/metrics/additionalIncludeList", "value": ["namespace_egress_bytes_total", "namespace_ingress_bytes_total"]}]`
+		out, err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=json", "-p", patch).Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("failed to patch FlowCollector"))
+		o.Expect(out).To(o.ContainSubstring("patched"))
+
+		g.By(fmt.Sprintf("Wait for FlowCollector to reconcile"))
+		flow.WaitForFlowcollectorReady(oc)
+
+		g.By(fmt.Sprintf("Wait for metrics to be available"))
+		time.Sleep(90 * time.Second)
+
+		// Get all netobserv metrics currently exposed
+		g.By(fmt.Sprintf("Query Prometheus for all netobserv_* metrics"))
+		allMetrics, err := getAllNetobservMetricNames(oc)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("failed to query Prometheus"))
+
+		e2e.Logf("Found %d netobserv metrics in Prometheus", len(allMetrics))
+
+		// Convert both to sets for comparison
+		actualSet := make(map[string]bool)
+		for _, m := range allMetrics {
+			actualSet[m] = true
 		}
 
-		tests := []MetricsTestScenario{
-			{
-				Name:      "Default behavior",
-				PatchJSON: "", // No patch, Loki disabled - uses DefaultIncludeListLokiDisabled but only metrics that don't require features
-				ExpectedMetrics: []string{
-					"netobserv_node_egress_bytes_total",
-					"netobserv_node_ingress_bytes_total",
-					"netobserv_node_ingress_packets_total",
-					"netobserv_node_to_node_ingress_flows_total",
-					"netobserv_workload_egress_bytes_total",
-					"netobserv_workload_egress_packets_total",
-					"netobserv_workload_flows_total",
-					"netobserv_workload_ingress_bytes_total",
-					"netobserv_workload_ingress_packets_total",
-				},
-			},
-			{
-				Name:      "includeList only",
-				PatchJSON: `[{"op": "add", "path": "/spec/processor/metrics/includeList", "value": ["node_ingress_bytes_total"]}]`,
-				ExpectedMetrics: []string{
-					"netobserv_node_ingress_bytes_total",
-				},
-			},
-			{
-				Name:      "additionalIncludeList only",
-				PatchJSON: `[{"op": "add", "path": "/spec/processor/metrics/additionalIncludeList", "value": ["namespace_egress_bytes_total", "namespace_ingress_bytes_total"]}]`,
-				ExpectedMetrics: []string{
-					// 9 base metrics (from defaults without features)
-					"netobserv_node_egress_bytes_total",
-					"netobserv_node_ingress_bytes_total",
-					"netobserv_node_ingress_packets_total",
-					"netobserv_node_to_node_ingress_flows_total",
-					"netobserv_workload_egress_bytes_total",
-					"netobserv_workload_egress_packets_total",
-					"netobserv_workload_flows_total",
-					"netobserv_workload_ingress_bytes_total",
-					"netobserv_workload_ingress_packets_total",
-					// Plus 2 additional metrics
-					"netobserv_namespace_egress_bytes_total",
-					"netobserv_namespace_ingress_bytes_total",
-				},
-			},
-			{
-				Name:      "Both fields set",
-				PatchJSON: `[{"op": "add", "path": "/spec/processor/metrics/includeList", "value": ["node_ingress_bytes_total"]}, {"op": "add", "path": "/spec/processor/metrics/additionalIncludeList", "value": ["namespace_egress_bytes_total", "namespace_ingress_bytes_total"]}]`,
-				ExpectedMetrics: []string{
-					"netobserv_node_ingress_bytes_total",
-				},
-			},
+		expectedMetrics := []string{
+			// 9 base metrics (from defaults without features)
+			"netobserv_node_egress_bytes_total",
+			"netobserv_node_ingress_bytes_total",
+			"netobserv_node_ingress_packets_total",
+			"netobserv_node_to_node_ingress_flows_total",
+			"netobserv_workload_egress_bytes_total",
+			"netobserv_workload_egress_packets_total",
+			"netobserv_workload_flows_total",
+			"netobserv_workload_ingress_bytes_total",
+			"netobserv_workload_ingress_packets_total",
+			// Plus 2 additional metrics
+			"netobserv_namespace_egress_bytes_total",
+			"netobserv_namespace_ingress_bytes_total",
 		}
+		o.Expect(len(expectedMetrics)).To(o.Equal(len(allMetrics)),
+			fmt.Sprintf("expected %d metrics but found %d: %v", len(expectedMetrics), len(allMetrics), allMetrics))
 
-		for _, t := range tests {
-			func() {
-				g.By(fmt.Sprintf("Test: %s", t.Name))
-				g.By(fmt.Sprintf("[%s]: Deploy initial FlowCollector", t.Name))
-				flow := Flowcollector{
-					Namespace:  namespace,
-					Template:   flowFixturePath,
-					LokiEnable: "false",
-				}
-				defer func() { _ = flow.DeleteFlowcollector(oc) }()
-				flow.CreateFlowcollector(oc)
-
-				// Apply patch if specified
-				if t.PatchJSON != "" {
-					g.By(fmt.Sprintf("[%s]: Patch FlowCollector with metrics configuration", t.Name))
-					out, err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=json", "-p", t.PatchJSON).Output()
-					o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("%s: failed to patch FlowCollector", t.Name))
-					o.Expect(out).To(o.ContainSubstring("patched"))
-
-					g.By(fmt.Sprintf("[%s]: Wait for FlowCollector to reconcile", t.Name))
-					flow.WaitForFlowcollectorReady(oc)
-				}
-
-				g.By(fmt.Sprintf("[%s]: Wait for metrics to be available", t.Name))
-				time.Sleep(90 * time.Second)
-
-				// Get all netobserv metrics currently exposed
-				g.By(fmt.Sprintf("[%s]: Query Prometheus for all netobserv_* metrics", t.Name))
-				allMetrics, err := getAllNetobservMetricNames(oc)
-				o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("%s: failed to query Prometheus", t.Name))
-
-				e2e.Logf("[%s]: Found %d netobserv metrics in Prometheus", t.Name, len(allMetrics))
-
-				// Convert both to sets for comparison
-				actualSet := make(map[string]bool)
-				for _, m := range allMetrics {
-					actualSet[m] = true
-				}
-
-				o.Expect(len(t.ExpectedMetrics)).To(o.Equal(len(allMetrics)),
-					fmt.Sprintf("[%s]: expected %d metrics but found %d: %v", t.Name, len(t.ExpectedMetrics), len(allMetrics), allMetrics))
-
-				for _, expectedMetric := range t.ExpectedMetrics {
-					o.Expect(actualSet[expectedMetric]).To(o.BeTrue(),
-						fmt.Sprintf("[%s]: metric %s should exist in %v", t.Name, expectedMetric, actualSet))
-				}
-			}()
+		for _, metric := range expectedMetrics {
+			o.Expect(actualSet[metric]).To(o.BeTrue(),
+				fmt.Sprintf("metric %s should exist in %v", metric, actualSet))
 		}
 	})
 
 	g.Context("with Loki", func() {
 		var (
 			lokiDir, _ = filePath.Abs("testdata/loki")
-                      	// Loki Operator variables
+			// Loki Operator variables
 			lokiPackageName = "loki-operator"
 			lokiSource      CatalogSourceObjects
 			lokiCatalog     = "redhat-operators"
@@ -451,7 +403,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
 				CatalogSource: &lokiSource,
 			}
-                       	// LokiStack variables
+			// LokiStack variables
 			ipStackType       string
 			lokiStackTemplate = filePath.Join(lokiDir, "lokistack-simple.yaml")
 			lokiTenant        = "openshift-network"

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -408,7 +408,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				}
 
 				g.By(fmt.Sprintf("[%s]: Wait for metrics to be available", t.Name))
-				time.Sleep(60 * time.Second)
+				time.Sleep(90 * time.Second)
 
 				// Get all netobserv metrics currently exposed
 				g.By(fmt.Sprintf("[%s]: Query Prometheus for all netobserv_* metrics", t.Name))


### PR DESCRIPTION
## Description

Adding testcase [OCP-89198](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-89198) for [appending new metrics to the default list of metrics](https://redhat.atlassian.net/browse/NETOBSERV-2655) feature.  

```
api-osmakal-bpfman-422-qe-devcluster-openshift-com:6443(default):~/Repos/network-observability-operator-wip/test_additional_include_list$ go run github.com/onsi/ginkgo/v2/ginkgo --focus="89198" -v ./integration-tests/backend
[1779806190] Backend Suite - 1/7491 specs Running Suite: Backend Suite - /home/osmakal/Repos/network-observability-operator-wip/test_additional_include_list/integration-tests/backend
==========================================================================================================
Random Seed: 1779806190

Will run 1 specs
Detected OCP version: v4.22
^[[A^[[A^[OA^[OA^[OA^[OAgit[sig-netobserv] Network_Observability Author:osmakal-High-89198-Verify processor metrics configuration with includeList and additionalIncludeList [Serial]
/home/osmakal/Repos/network-observability-operator-wip/test_additional_include_list/integration-tests/backend/test_flowcollector.go:326
• PASSED [874.740 seconds]
•------------------------------

Backend Suite - 1/1 specs • SUCCESS! [875.356 seconds]

Ran 1 tests
Passed: 1, Failed: 0, Skipped: 0
 SUCCESS! 14m35.35628213s PASS

Ginkgo ran 1 suite in 14m43.822737548s
Test Suite Passed
```

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test that validates processor metrics behavior when custom include lists are applied, ensuring expected netobserv_* metrics appear.
  * Improved metric discovery in tests with a helper that collects and verifies all exposed netobserv_* metric names for exact-match validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->