### PR TITLE
NETOBSERV-2637: fix minio setup

### DIFF
--- a/integration-tests/backend/loki_storage.go
+++ b/integration-tests/backend/loki_storage.go
@@ -81,7 +81,8 @@ func getMinIOCreds(oc *exutil.CLI, ns string) s3Credential {
 	secretAccessKey, err := os.ReadFile(dirname + "/secret_access_key")
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	endpoint := "http://" + getRouteAddress(oc, ns, "minio")
+	// endpoint := "http://" + getRouteAddress(oc, ns, "minio")
+	endpoint := "https://" + getRouteAddress(oc, ns, "minio")
 	return s3Credential{Endpoint: endpoint, AccessKeyID: string(accessKeyID), SecretAccessKey: string(secretAccessKey)}
 }
 
@@ -944,7 +945,31 @@ func deployMinIO(oc *exutil.CLI) {
 		_ = Resource{rs, "minio", minioNS}.WaitForResourceToAppear(oc)
 	}
 	WaitForDeploymentPodsToBeReady(oc, minioNS, "minio")
+
+       // patch routes to enable TLS termination
+       patchMinioRoutesWithTLS(oc, minioNS)
 }
+
+// patchMinioRoutesWithTLS patches the MinIO routes to add edge TLS termination
+func patchMinioRoutesWithTLS(oc *exutil.CLI, ns string) {
+       tlsPatch := `{"spec":{"tls":{"termination":"edge","insecureEdgeTerminationPolicy":"Redirect"}}}`
+
+       // Patch the main MinIO route
+       err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("route", "minio", "-n", ns, "--type=merge", "-p", tlsPatch).Execute()
+       if err != nil {
+               e2e.Logf("Warning: failed to patch minio route with TLS: %v", err)
+       } else {
+               e2e.Logf("Successfully patched minio route with edge TLS termination")
+       }
+
+       // Patch the MinIO console route
+       err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("route", "minio-console", "-n", ns, "--type=merge", "-p", tlsPatch).Execute()
+       if err != nil {
+               e2e.Logf("Warning: failed to patch minio-console route with TLS: %v", err)
+       } else {
+               e2e.Logf("Successfully patched minio-console route with edge TLS termination")
+       }
+ }
 
 func getPoolID(oc *exutil.CLI) (string, error) {
 	// pool_id="$(oc get authentication cluster -o json | jq -r .spec.serviceAccountIssuer | sed 's/.*\/\([^\/]*\)-oidc/\1/')"

--- a/integration-tests/backend/loki_storage.go
+++ b/integration-tests/backend/loki_storage.go
@@ -81,7 +81,6 @@ func getMinIOCreds(oc *exutil.CLI, ns string) s3Credential {
 	secretAccessKey, err := os.ReadFile(dirname + "/secret_access_key")
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	// endpoint := "http://" + getRouteAddress(oc, ns, "minio")
 	endpoint := "https://" + getRouteAddress(oc, ns, "minio")
 	return s3Credential{Endpoint: endpoint, AccessKeyID: string(accessKeyID), SecretAccessKey: string(secretAccessKey)}
 }
@@ -945,31 +944,7 @@ func deployMinIO(oc *exutil.CLI) {
 		_ = Resource{rs, "minio", minioNS}.WaitForResourceToAppear(oc)
 	}
 	WaitForDeploymentPodsToBeReady(oc, minioNS, "minio")
-
-       // patch routes to enable TLS termination
-       patchMinioRoutesWithTLS(oc, minioNS)
 }
-
-// patchMinioRoutesWithTLS patches the MinIO routes to add edge TLS termination
-func patchMinioRoutesWithTLS(oc *exutil.CLI, ns string) {
-       tlsPatch := `{"spec":{"tls":{"termination":"edge","insecureEdgeTerminationPolicy":"Redirect"}}}`
-
-       // Patch the main MinIO route
-       err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("route", "minio", "-n", ns, "--type=merge", "-p", tlsPatch).Execute()
-       if err != nil {
-               e2e.Logf("Warning: failed to patch minio route with TLS: %v", err)
-       } else {
-               e2e.Logf("Successfully patched minio route with edge TLS termination")
-       }
-
-       // Patch the MinIO console route
-       err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("route", "minio-console", "-n", ns, "--type=merge", "-p", tlsPatch).Execute()
-       if err != nil {
-               e2e.Logf("Warning: failed to patch minio-console route with TLS: %v", err)
-       } else {
-               e2e.Logf("Successfully patched minio-console route with edge TLS termination")
-       }
- }
 
 func getPoolID(oc *exutil.CLI) (string, error) {
 	// pool_id="$(oc get authentication cluster -o json | jq -r .spec.serviceAccountIssuer | sed 's/.*\/\([^\/]*\)-oidc/\1/')"

--- a/integration-tests/backend/testdata/logging/minIO/deploy.yaml
+++ b/integration-tests/backend/testdata/logging/minIO/deploy.yaml
@@ -111,6 +111,7 @@ objects:
       targetPort: 9000
     tls:
       termination: edge
+      insecureEdgeTerminationPolicy: Redirect
     to:
       kind: Service
       name: ${NAME}
@@ -124,6 +125,9 @@ objects:
   spec:
     port:
       targetPort: 9001
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
     to:
       kind: Service
       name: minio-service-console


### PR DESCRIPTION
## Dependencies

Works together with [the openshift-release-fix](https://github.com/openshift/release/pull/78402).

```
[1779965939] Backend Suite - 3/7490 specs Running Suite: Backend Suite - /home/osmakal/Repos/network-observability-operator-wip/test_udn_with_vm/integration-tests/backend
==========================================================================================================
Random Seed: 1779965939

Will run 3 specs
Detected OCP version: v4.21
[sig-netobserv] Network_Observability with Loki with VMs Author:aramesha-NonPreRelease-Longduration-High-76537-Verify flow enrichment for VM's secondary interfaces [Disruptive][Slow]
/home/osmakal/Repos/network-observability-operator-wip/test_udn_with_vm/integration-tests/backend/test_flowcollector.go:3207
• PASSED [1053.848 seconds]
•[sig-netobserv] Network_Observability with Loki with VMs Author:aramesha-NonPreRelease-Longduration-Medium-85887-Verify UDN with VMs [Disruptive][Slow]
/home/osmakal/Repos/network-observability-operator-wip/test_udn_with_vm/integration-tests/backend/test_flowcollector.go:3323
• PASSED [953.291 seconds]
•  STEP: Check the image digest mirror set and catalog source 05/28/26 13:39:47.896
  STEP: Creating image digest mirror set 05/28/26 13:39:48.528
  STEP: Creating catalog source 05/28/26 13:40:01.04
  STEP: Create NMState CR 05/28/26 13:41:25.432
  STEP: Configure NNCP for creating OvnMapping NMstate Feature 05/28/26 13:42:12.738
  STEP: Create two namespaces and label them 05/28/26 13:42:30.432
  STEP: Create secondary localnet CUDN 05/28/26 13:42:35.299
[sig-netobserv] Network_Observability with Loki with VMs Author:aramesha-High-85935-Validate CUDN with Localnet and VM's[Serial]
/home/osmakal/Repos/network-observability-operator-wip/test_udn_with_vm/integration-tests/backend/test_flowcollector.go:3436
• PASSED [1180.826 seconds]
•------------------------------

Backend Suite - 3/3 specs • SUCCESS! [3188.766 seconds]

Ran 3 tests
Passed: 3, Failed: 0, Skipped: 0
 SUCCESS! 53m8.766284498s PASS

Ginkgo ran 1 suite in 53m17.060251632s
Test Suite Passed
```

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upgraded credential endpoint configuration to enforce HTTPS protocol instead of HTTP for secure communication.
  * Enhanced TLS routing policies with insecure connection redirects to enforce encrypted connections across all endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netobserv/netobserv-operator/pull/2788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->