### PR TITLE
NETOBSERV-2748 add Dockerfile for e2etests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin/
 tmp.Dockerfile
 _tmp/
+**/e2e-tests.test

--- a/integration-tests/backend/Dockerfile
+++ b/integration-tests/backend/Dockerfile
@@ -11,16 +11,6 @@ COPY go.sum go.sum
 RUN go mod download
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@latest
 
-# Pre-compile all dependencies (cached layer - rebuilds only when go.mod changes)
-# Uses a stub test file to trigger dependency compilation without real source
-RUN mkdir -p /tmp/depbuild && \
-    cp go.mod go.sum /tmp/depbuild/ && \
-    cd /tmp/depbuild && \
-    echo 'package e2etests' > stub.go && \
-    echo 'package e2etests_test' > stub_test.go && \
-    GOOS=linux GOARCH=$TARGETARCH go test -c -o /dev/null 2>/dev/null || true && \
-    rm -rf /tmp/depbuild
-
 # Copy the source code (changes frequently - separate layer)
 COPY *.go ./
 COPY testdata/ testdata/

--- a/integration-tests/backend/Dockerfile
+++ b/integration-tests/backend/Dockerfile
@@ -1,0 +1,45 @@
+ARG TARGETARCH
+
+FROM docker.io/library/golang:1.25 AS builder
+
+ARG TARGETARCH=amd64
+
+WORKDIR /workspace
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@latest
+
+# Pre-compile all dependencies (cached layer - rebuilds only when go.mod changes)
+# Uses a stub test file to trigger dependency compilation without real source
+RUN mkdir -p /tmp/depbuild && \
+    cp go.mod go.sum /tmp/depbuild/ && \
+    cd /tmp/depbuild && \
+    echo 'package e2etests' > stub.go && \
+    echo 'package e2etests_test' > stub_test.go && \
+    GOOS=linux GOARCH=$TARGETARCH go test -c -o /dev/null 2>/dev/null || true && \
+    rm -rf /tmp/depbuild
+
+# Copy the source code (changes frequently - separate layer)
+COPY *.go ./
+COPY testdata/ testdata/
+
+# Build ginkgo test binary (only recompiles test code, deps already cached)
+RUN GOGC=50 GOMAXPROCS=4 GOOS=linux GOARCH=$TARGETARCH \
+    ginkgo build --ldflags="-s -w" -o e2e-tests.test
+
+FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:9.8-1777460003
+
+WORKDIR /tests
+
+# Copy the pre-compiled test binary, testdata and ginkgo binary
+COPY --from=builder /workspace/e2e-tests.test .
+COPY --from=builder /workspace/testdata/ testdata/
+COPY --from=builder /go/bin/ginkgo /usr/local/bin/ginkgo
+
+USER 65532:65532
+
+# Default entrypoint uses ginkgo CLI pointing to pre-compiled binary
+# This enables clean ginkgo syntax without -ginkgo. prefix
+ENTRYPOINT ["ginkgo", "run", "./e2e-tests.test"]

--- a/integration-tests/backend/Makefile
+++ b/integration-tests/backend/Makefile
@@ -1,5 +1,26 @@
 GOLANGCI_LINT_VERSION = v2.8.0
 
+# Detect OS
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	GOOS = linux
+endif
+ifeq ($(UNAME_S),Darwin)
+	GOOS = darwin
+endif
+
+# Detect architecture
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_M),x86_64)
+	GOARCH = amd64
+endif
+ifeq ($(UNAME_M),arm64)
+	GOARCH = arm64
+endif
+ifeq ($(UNAME_M),aarch64)
+	GOARCH = arm64
+endif
+
 ##@ Development
 .PHONY: prereqs
 prereqs:
@@ -15,3 +36,14 @@ fmt: ## Run go fmt against code.
 lint: prereqs ## Run linter (golangci-lint)
 	@echo "### Linting code"
 	./bin/golangci-lint-${GOLANGCI_LINT_VERSION} --config .golangci.yml run --timeout 15m ./...
+
+##@ Build
+.PHONY: install-ginkgo
+install-ginkgo: ## Install ginkgo CLI
+	@echo "### Installing ginkgo CLI"
+	go install github.com/onsi/ginkgo/v2/ginkgo@latest
+
+.PHONY: build-test-binary
+build-test-binary: install-ginkgo ## Build test binary for current platform with ginkgo CLI
+	@echo "### Building e2e test binary for $(GOOS)/$(GOARCH)"
+	GOOS=$(GOOS) GOARCH=$(GOARCH) ginkgo build --ldflags="-s -w" -o e2e-tests.test


### PR DESCRIPTION
## Description

[NETOBSERV-2748](https://redhat.atlassian.net/browse/NETOBSERV-2748) Adding Dockerfile for e2etests and make targets

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [X] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

Assisted-By: Claude Sonnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added containerized, multi-stage builds for precompiled end-to-end test binaries to support portable test execution.
  * Added build automation to detect target platform, produce platform-specific test binaries, and install the test runner CLI.
  * Updated .gitignore to exclude generated end-to-end test artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->