### PR TITLE
NETOBSERV-2739: Fix multi-tenancy tests

### DIFF
--- a/integration-tests/backend/flowcollector_utils.go
+++ b/integration-tests/backend/flowcollector_utils.go
@@ -360,6 +360,10 @@ func (lokilabels Lokilabels) getLokiFlowLogs(token, lokiRoute string, startTime 
 		res, qErr = lc.searchLogsInLoki(tenantID, lokiQuery)
 		if qErr != nil {
 			e2e.Logf("\ngot error %v when getting %s logs for query: %s\n", qErr, tenantID, lokiQuery)
+			// Don't retry on permission errors
+			if strings.Contains(qErr.Error(), "permission") {
+				return false, qErr
+			}
 			return false, nil
 		}
 

--- a/integration-tests/backend/loki_client.go
+++ b/integration-tests/backend/loki_client.go
@@ -287,6 +287,14 @@ func (c *lokiClient) doRequest(path, query string, quiet bool, out interface{}) 
 		if resp.StatusCode/100 != 2 {
 			buf, _ := io.ReadAll(resp.Body) //  nolint
 			e2e.Logf("Error response from server: %s (%v) attempts remaining: %d", string(buf), err, attempts)
+			// Don't retry on authorization/authentication errors - these are permanent failures
+			// Verifies multi-tenancy behavior
+			if resp.StatusCode == 401 || resp.StatusCode == 403 {
+				if err := resp.Body.Close(); err != nil {
+					e2e.Logf("error closing body: %v", err)
+				}
+				return fmt.Errorf("permission denied: %s", string(buf))
+			}
 			if err := resp.Body.Close(); err != nil {
 				e2e.Logf("error closing body: %v", err)
 			}

--- a/integration-tests/backend/loki_storage.go
+++ b/integration-tests/backend/loki_storage.go
@@ -658,8 +658,12 @@ func getStorageType(oc *exutil.CLI) string {
 }
 
 // initialize a s3 client with credential
-func newS3Client(cfg aws.Config) *s3.Client {
-	return s3.NewFromConfig(cfg)
+func newS3Client(cfg aws.Config, usePathStyle ...bool) *s3.Client {
+	return s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if len(usePathStyle) > 0 && usePathStyle[0] {
+			o.UsePathStyle = true
+		}
+	})
 }
 
 func getStorageClassName(oc *exutil.CLI) (string, error) {
@@ -807,7 +811,7 @@ func (l lokiStack) prepareResourcesForLokiStack(oc *exutil.CLI) error {
 		{
 			cred := getMinIOCreds(oc, minioNS)
 			cfg := generateS3Config(cred)
-			client := newS3Client(cfg)
+			client := newS3Client(cfg, true)
 			err = createS3Bucket(client, l.BucketName, "")
 			if err != nil {
 				return err
@@ -905,7 +909,7 @@ func (l lokiStack) removeObjectStorage(oc *exutil.CLI) {
 		{
 			cred := getMinIOCreds(oc, minioNS)
 			cfg := generateS3Config(cred)
-			client := newS3Client(cfg)
+			client := newS3Client(cfg, true)
 			err = deleteS3Bucket(client, l.BucketName)
 		}
 	}

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -3203,6 +3203,8 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				o.Expect(err).ToNot(o.HaveOccurred())
 				waitUntilHyperConvergedReady(oc, "kubevirt-hyperconverged", virtOperatorNS)
 				WaitForPodsReadyWithLabel(oc, virtOperatorNS, "app.kubernetes.io/managed-by=virt-operator")
+				// Wait for kubemacpool service endpoints to be ready to avoid race condition when creating VMs
+				waitForServiceEndpoints(oc, virtOperatorNS, "kubemacpool-service")
 			})
 
 			g.It("Author:aramesha-NonPreRelease-Longduration-High-76537-Verify flow enrichment for VM's secondary interfaces [Disruptive][Slow]", func() {

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -842,8 +842,12 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				FlowDirection:   "0",
 			}
 			flowRecords, err = lokilabels.getLokiFlowLogs(user0token, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).NotTo(o.BeNumerically(">", 0), "expected number of flowRecords to be equal to 0")
+			// Multi-tenancy verification: Loki Gateway returns permission errors for unauthorized namespace access
+			if err != nil {
+				o.Expect(err.Error()).To(o.ContainSubstring("permission"), "expected permission error for unauthorized namespace access, got: %v", err)
+			} else {
+				o.Expect(len(flowRecords)).To(o.Equal(0), "expected zero flowRecords for unauthorized namespace access")
+			}
 		})
 
 		g.It("Author:aramesha-NonPreRelease-Critical-59746-NetObserv upgrade testing [Serial]", func() {

--- a/integration-tests/backend/test_flowcollectorslice.go
+++ b/integration-tests/backend/test_flowcollectorslice.go
@@ -609,8 +609,12 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			FlowDirection:   "0",
 		}
 		flowRecords, err = lokilabels.getLokiFlowLogs(user0token, ls.Route, startTime)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(len(flowRecords)).Should(o.BeNumerically("==", 0), "expected testuser to NOT see flows from test-b namespace")
+		// Multi-tenancy verification: Loki Gateway returns permission errors for unauthorized namespace access
+		if err != nil {
+			o.Expect(err.Error()).Should(o.ContainSubstring("permission"), "expected permission error for unauthorized namespace access, got: %v", err)
+		} else {
+			o.Expect(len(flowRecords)).Should(o.BeNumerically("==", 0), "expected testuser to NOT see flows from test-b namespace")
+		}
 
 		g.By("Add testuser-0 as viewer for test-b namespace")
 		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("rolebinding", "testuser-0-view",

--- a/integration-tests/backend/util.go
+++ b/integration-tests/backend/util.go
@@ -531,6 +531,35 @@ func waitForStatefulsetReady(oc *exutil.CLI, namespace, name string) error {
 	return err
 }
 
+// waitForServiceEndpoints waits for a service to have available endpoints
+func waitForServiceEndpoints(oc *exutil.CLI, namespace, serviceName string) {
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 360*time.Second, false, func(context.Context) (done bool, err error) {
+		endpoints, err := oc.AdminKubeClient().CoreV1().Endpoints(namespace).Get(context.Background(), serviceName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				e2e.Logf("Waiting for endpoints for service %s to appear\n", serviceName)
+				return false, nil
+			}
+			return false, err
+		}
+		// Check if endpoints has at least one address
+		hasEndpoints := false
+		for _, subset := range endpoints.Subsets {
+			if len(subset.Addresses) > 0 {
+				hasEndpoints = true
+				break
+			}
+		}
+		if !hasEndpoints {
+			e2e.Logf("Waiting for service %s to have available endpoints...\n", serviceName)
+			return false, nil
+		}
+		e2e.Logf("Service %s has available endpoints\n", serviceName)
+		return true, nil
+	})
+	compat_otp.AssertWaitPollNoErr(err, fmt.Sprintf("Service %s does not have available endpoints", serviceName))
+}
+
 // wait until DaemonSet is Ready
 func waitUntilDaemonSetReady(oc *exutil.CLI, daemonset, namespace string) {
 	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 600*time.Second, false, func(context.Context) (done bool, err error) {


### PR DESCRIPTION
## Description

PR changes: 
- Multi-tenancy tests on newer OCP versions(4.21, 4.22) are failing when user tries to query logs which they dont have access to. So adding logic to check if user encounters expected permission denied when querying logs. Still kept the old approach of querying loki and getting 0 flows approach too since that seems to be working on older OCP versions(4.18, 4.16)
- Baremetal loki creation fixes
- Also add wait for `kubemacpool-service` endpoint before VM creation to reduce flakyness

## Dependencies

n/a

## Test Results

- [sig-netobserv] Network_Observability with Loki Author:memodi-NonPreRelease-Longduration-High-63839-Verify-multi-tenancy [Disruptive][Slow] (4.22)
  /Users/amoghrd/repos/netobserv/netobserv-operator/integration-tests/backend/test_flowcollector.go:730
  • PASSED [832.617 seconds]
 
 - [sig-netobserv] Network_Observability Author:aramesha-NonPreRelease-Longduration-High-87145-Verify FlowCollectorSlices multi-tenancy [Disruptive][Slow] (4.22)
  /Users/amoghrd/repos/netobserv/netobserv-operator/integration-tests/backend/test_flowcollectorslice.go:418
  • PASSED [881.157 seconds]

- Test 76537 - Verify flow enrichment for VM's secondary interfaces(4.22)
  [sig-netobserv] Network_Observability with Loki with VMs Author:aramesha-NonPreRelease-Longduration-High-76537-Verify flow enrichment for VM's secondary interfaces
  [Disruptive][Slow]
  • PASSED [1248.689 seconds]

 - Test 85887 - Verify UDN with VMs (4.22)
  [sig-netobserv] Network_Observability with Loki with VMs Author:aramesha-NonPreRelease-Longduration-Medium-85887-Verify UDN with VMs [Disruptive][Slow]
  • PASSED [1126.165 seconds]
  
- Test 85935 - Validate CUDN with Localnet and VM's (4.22)
  [sig-netobserv] Network_Observability with Loki with VMs Author:aramesha-High-85935-Validate CUDN with Localnet and VM's[Serial]
  • PASSED [1273.167 seconds]

- [sig-netobserv] Network_Observability with Loki Author:memodi-Critical-53844-Sanity Test NetObserv [Serial]
  • PASSED [747.535 seconds] (4.22)




- [sig-netobserv] Network_Observability with Loki Author:memodi-NonPreRelease-Longduration-High-63839-Verify-multi-tenancy [Disruptive][Slow] (4.21)
  /Users/amoghrd/repos/netobserv/netobserv-operator/integration-tests/backend/test_flowcollector.go:730
  • PASSED [852.088 seconds]

- [sig-netobserv] Network_Observability Author:aramesha-NonPreRelease-Longduration-High-87145-Verify FlowCollectorSlices multi-tenancy [Disruptive][Slow] (4.21)
  /Users/amoghrd/repos/netobserv/netobserv-operator/integration-tests/backend/test_flowcollectorslice.go:418
  • PASSED [929.509 seconds]

- [sig-netobserv] Network_Observability with Loki Author:memodi-Critical-53844-Sanity Test NetObserv [Serial]
  • PASSED [764.346 seconds] (4.21)

- [sig-netobserv] Network_Observability with Loki with VMs Author:aramesha-NonPreRelease-Longduration-High-76537-Verify flow enrichment for VM's secondary interfaces
  [Disruptive][Slow]
  • PASSED [1482.825 seconds] (24m42s)
  
- [sig-netobserv] Network_Observability with Loki with VMs Author:aramesha-NonPreRelease-Longduration-Medium-85887-Verify UDN with VMs [Disruptive][Slow]
  • PASSED [1158.752 seconds] (19m18s)

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization failures (HTTP 401/403 / permission errors) are now reported immediately as permission-denied results instead of triggering retries.
* **Compatibility**
  * Improved S3/MinIO compatibility by enabling path-style addressing for storage client setup.
* **Tests**
  * Multi-tenant verification updated to accept either permission errors or empty results for unauthorized namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->