### PR TITLE
CSV: set maintainers to RH support, maturity stable

### DIFF
--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -1142,21 +1142,9 @@ spec:
   - name: Discussion board
     url: https://github.com/netobserv/netobserv-operator/discussions
   maintainers:
-  - email: jpinsonn@redhat.com
-    name: Julien Pinsonneau
-  - email: jtakvori@redhat.com
-    name: Joel Takvorian
-  - email: lberetta@redhat.com
-    name: Leandro Beretta
-  - email: ljira@redhat.com
-    name: Luis Jira
-  - email: mmahmoud2201@gmail.com
-    name: Mohamed S. Mahmoud
-  - email: ocazade@redhat.com
-    name: Olivier Cazade
-  - email: stlee@redhat.com
-    name: Steven Lee
-  maturity: alpha
+  - email: support@redhat.com
+    name: Red Hat Support
+  maturity: stable
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat

--- a/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
+++ b/config/csv/bases/netobserv-operator.clusterserviceversion.yaml
@@ -337,21 +337,9 @@ spec:
   - name: Discussion board
     url: https://github.com/netobserv/netobserv-operator/discussions
   maintainers:
-  - email: jpinsonn@redhat.com
-    name: Julien Pinsonneau
-  - email: jtakvori@redhat.com
-    name: Joel Takvorian
-  - email: lberetta@redhat.com
-    name: Leandro Beretta
-  - email: ljira@redhat.com
-    name: Luis Jira
-  - email: mmahmoud2201@gmail.com
-    name: Mohamed S. Mahmoud
-  - email: ocazade@redhat.com
-    name: Olivier Cazade
-  - email: stlee@redhat.com
-    name: Steven Lee
-  maturity: alpha
+  - email: support@redhat.com
+    name: Red Hat Support
+  maturity: stable
   minKubeVersion: 1.23.0
   provider:
     name: Red Hat

--- a/hack/patch_csv.py
+++ b/hack/patch_csv.py
@@ -85,7 +85,6 @@ csv['spec']['description'] = file.read()
 file.close()
 
 csv['spec']['displayName'] = 'Network Observability'
-csv['spec']['maturity'] = 'stable'
 
 for relatedImage in csv['spec']['relatedImages']:
    if relatedImage["name"] == "ebpf-agent":


### PR DESCRIPTION
It's simpler if we just set a global RH support maintainer in the CSV description, rather than an individual list. Most other operators do that.
Also, set maturity as "stable" upstream (it was only done for downstream)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated operator maturity status from alpha to stable
  * Consolidated maintainer contact information to Red Hat Support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->