### PR TITLE
bump go1.26

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.26-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-4.21

--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.26-openshift-4.21
+  tag: rhel-9-release-golang-1.25-openshift-4.21

--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.25-openshift-4.21 
+  tag: rhel-9-release-golang-1.26-openshift-4.22

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
     - name: set up go 1.x
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - name: checkout
       uses: actions/checkout@v6
       with:

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -63,7 +63,7 @@ jobs:
     - name: set up go 1.x
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - name: checkout
       uses: actions/checkout@v6
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG TARGETARCH
 
 # Build the manager binary
-FROM docker.io/library/golang:1.25 AS builder
+FROM docker.io/library/golang:1.26 AS builder
 
 ARG TARGETARCH=amd64
 ARG LDFLAGS

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ endif
 IMAGE ?= $(IMAGE_TAG_BASE):$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
-GOLANGCI_LINT_VERSION = v2.8.0
+GOLANGCI_LINT_VERSION = v2.12.2
 CRDOC_VERSION = 0.6.4
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)

--- a/internal/pkg/helper/cardinality/cardinality.go
+++ b/internal/pkg/helper/cardinality/cardinality.go
@@ -78,7 +78,7 @@ func (r *Report) GetDetails() string {
 	for _, lvl := range []Warn{WarnAvoid, WarnUnknown, WarnCareful, WarnFine} {
 		labels := r.perLevel[lvl]
 		if len(labels) > 0 {
-			sb.WriteString(fmt.Sprintf("Cardinality level '%s': %d labels (%s); ", lvl, len(labels), strings.Join(labels, ", ")))
+			fmt.Fprintf(&sb, "Cardinality level '%s': %d labels (%s); ", lvl, len(labels), strings.Join(labels, ", "))
 		}
 	}
 	return sb.String()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go version from 1.25 to 1.26 across build systems and CI workflows
  * Updated golangci-lint to v2.12.2
  * Updated CI operator image tag to support Go 1.26 and OpenShift 4.22

<!-- end of auto-generated comment: release notes by coderabbit.ai -->