### PR TITLE
Update install checks method to work with bundles installed via operator-sdk

### DIFF
--- a/integration-tests/backend/operator.go
+++ b/integration-tests/backend/operator.go
@@ -233,28 +233,46 @@ func checkOperatorChannel(oc *exutil.CLI, operatorNamespace string, operatorName
 
 func CheckOperatorStatus(oc *exutil.CLI, operatorNamespace string, operatorName string) (bool, error) {
 	err := oc.AsAdmin().WithoutNamespace().Run("get").Args("namespace", operatorNamespace).Execute()
-	if err == nil {
-		err1 := oc.AsAdmin().WithoutNamespace().Run("get").Args("sub", operatorName, "-n", operatorNamespace).Execute()
-		if err1 == nil {
-			csvName, err2 := oc.AsAdmin().WithoutNamespace().Run("get").Args("sub", operatorName, "-n", operatorNamespace, "-o=jsonpath={.status.installedCSV}").Output()
-			o.Expect(err2).NotTo(o.HaveOccurred())
-			o.Expect(csvName).NotTo(o.BeEmpty())
-			err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 360*time.Second, false, func(context.Context) (bool, error) {
-				csvState, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("csv", csvName, "-n", operatorNamespace, "-o=jsonpath={.status.phase}").Output()
-				if err != nil {
-					return false, err
-				}
-				e2e.Logf("CSV %s state: %s", csvName, csvState)
-				return csvState == "Succeeded", nil
-			})
-			if err != nil {
-				return false, err
-			}
-			return true, nil
+	if err != nil {
+		e2e.Logf("%s operator will be created by tests", operatorName)
+		return false, nil
+	}
+
+	// Check for subscription by exact name first, then fall back to finding any
+	// subscription for this package (e.g. operator-sdk run bundle creates subs
+	// with a different naming convention like <name>-v1-11-4-community-sub).
+	csvName := ""
+	err1 := oc.AsAdmin().WithoutNamespace().Run("get").Args("sub", operatorName, "-n", operatorNamespace).Execute()
+	if err1 == nil {
+		csvName, _ = oc.AsAdmin().WithoutNamespace().Run("get").Args("sub", operatorName, "-n", operatorNamespace, "-o=jsonpath={.status.installedCSV}").Output()
+	}
+	if csvName == "" {
+		// Look for any CSV owned by a subscription for this package in the namespace
+		// operator-sdk run bundle creates subs with names like <name>-v0-0-0-sha-main-sub
+		allSubs, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("sub", "-n", operatorNamespace,
+			"-o=jsonpath={range .items[?(@.spec.name==\""+operatorName+"\")]}{.status.installedCSV}{end}").Output()
+		if allSubs != "" {
+			csvName = allSubs
 		}
 	}
-	e2e.Logf("%s operator will be created by tests", operatorName)
-	return false, nil
+	if csvName == "" {
+		e2e.Logf("%s operator will be created by tests", operatorName)
+		return false, nil
+	}
+
+	e2e.Logf("Found CSV %s for operator %s", csvName, operatorName)
+	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 360*time.Second, false, func(context.Context) (bool, error) {
+		csvState, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("csv", csvName, "-n", operatorNamespace, "-o=jsonpath={.status.phase}").Output()
+		if err != nil {
+			return false, err
+		}
+		e2e.Logf("CSV %s state: %s", csvName, csvState)
+		return csvState == "Succeeded", nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (ns *OperatorNamespace) DeployOperatorNamespace(oc *exutil.CLI) {


### PR DESCRIPTION
## Description


Update install checks method to work with bundles installed via operator-sdk. I tested with both types of installs operator-sdk and when tests installs the Operator.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced operator status detection reliability in integration tests through improved subscription discovery logic with fallback mechanisms and extended polling for installation readiness.

---

**Note:** This change impacts internal testing infrastructure only and has no effect on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->