### PR TITLE
NETOBSERV-2613: Health Rules disappear when sampling increases due to lowVolumeThreshold

### DIFF
--- a/internal/pkg/metrics/alerts/promql.go
+++ b/internal/pkg/metrics/alerts/promql.go
@@ -55,35 +55,30 @@ func histogramQuantile(promQL promQLRate, groupBy flowslatest.HealthRuleGroupBy,
 }
 
 func percentagePromQL(promQLMetricSum, promQLTotalSum string, threshold, upperThreshold, lowVolumeThreshold string) string {
-	var lowVolumeThresholdPart string
-	if lowVolumeThreshold != "" {
-		lowVolumeThresholdPart = " > " + lowVolumeThreshold
-	}
+	percentageCalc := fmt.Sprintf("100 * (%s) / (%s)", promQLMetricSum, promQLTotalSum)
 
 	// For recording rules, return only the calculation without comparison
 	if threshold == "" {
-		return fmt.Sprintf(
-			"100 * (%s) / (%s%s)",
-			promQLMetricSum,
-			promQLTotalSum,
-			lowVolumeThresholdPart,
-		)
+		return percentageCalc
 	}
 
-	var upperThresholdPart string
+	var conditions []string
+	thresholdCondition := fmt.Sprintf("%s > %s", percentageCalc, threshold)
+	conditions = append(conditions, thresholdCondition)
+
 	if upperThreshold != "" {
-		upperThresholdPart = " < " + upperThreshold
+		upperCondition := fmt.Sprintf("%s < %s", percentageCalc, upperThreshold)
+		conditions = append(conditions, upperCondition)
 	}
 
-	// For alert rules, include the threshold comparison
-	return fmt.Sprintf(
-		"100 * (%s) / (%s%s) > %s%s",
-		promQLMetricSum,
-		promQLTotalSum,
-		lowVolumeThresholdPart,
-		threshold,
-		upperThresholdPart,
-	)
+	if lowVolumeThreshold != "" {
+		// Normalize sampled metric by multiplying with sampling rate to estimate real traffic
+		normalizedMetric := fmt.Sprintf("(%s) * avg(netobserv_agent_sampling_rate > 0)", promQLTotalSum)
+		volumeCondition := fmt.Sprintf("%s > %s", normalizedMetric, lowVolumeThreshold)
+		conditions = append(conditions, volumeCondition)
+	}
+
+	return strings.Join(conditions, " and ")
 }
 
 func baselineIncreasePromQL(promQLMetric, promQLBaseline string, threshold, upperThreshold string) string {

--- a/internal/pkg/metrics/alerts/promql_test.go
+++ b/internal/pkg/metrics/alerts/promql_test.go
@@ -56,10 +56,10 @@ func TestPercentagePromQL(t *testing.T) {
 	assert.Equal(t, "100 * (sum(rate(my_metric[1m]))) / (sum(rate(my_total[1m]))) > 10", pql)
 
 	pql = percentagePromQL("sum(rate(my_metric[1m]))", "sum(rate(my_total[1m]))", "10", "20", "")
-	assert.Equal(t, "100 * (sum(rate(my_metric[1m]))) / (sum(rate(my_total[1m]))) > 10 < 20", pql)
+	assert.Equal(t, "100 * (sum(rate(my_metric[1m]))) / (sum(rate(my_total[1m]))) > 10 and 100 * (sum(rate(my_metric[1m]))) / (sum(rate(my_total[1m]))) < 20", pql)
 
 	pql = percentagePromQL("sum(rate(my_metric[1m]))", "sum(rate(my_total[1m]))", "10", "20", "2")
-	assert.Equal(t, "100 * (sum(rate(my_metric[1m]))) / (sum(rate(my_total[1m])) > 2) > 10 < 20", pql)
+	assert.Equal(t, "100 * (sum(rate(my_metric[1m]))) / (sum(rate(my_total[1m]))) > 10 and 100 * (sum(rate(my_metric[1m]))) / (sum(rate(my_total[1m]))) < 20 and (sum(rate(my_total[1m]))) * avg(netobserv_agent_sampling_rate > 0) > 2", pql)
 
 	// Test recording mode (isRecording = true) - no threshold comparisons
 	pql = percentagePromQL("sum(rate(my_metric[1m]))", "sum(rate(my_total[1m]))", "", "", "")
@@ -72,7 +72,6 @@ func TestPercentagePromQL(t *testing.T) {
 	assert.NotContains(t, pql, "<", "recording rules should not have threshold comparisons")
 
 	pql = percentagePromQL("sum(rate(my_metric[1m]))", "sum(rate(my_total[1m]))", "", "20", "2")
-	assert.Equal(t, "100 * (sum(rate(my_metric[1m]))) / (sum(rate(my_total[1m])) > 2)", pql)
-	assert.Contains(t, pql, "> 2", "recording rules should keep lowVolumeThreshold filter")
-	assert.NotContains(t, pql, "> 10", "recording rules should not have threshold comparison")
+	assert.Equal(t, "100 * (sum(rate(my_metric[1m]))) / (sum(rate(my_total[1m])))", pql)
+	assert.NotContains(t, pql, ">", "recording rules should not have threshold comparisons")
 }


### PR DESCRIPTION
## Description

Due to increase in sampling, some alerts/recording rules are not triggered.
Fixing the issue by normalizing metrics using `netobserv_agent_sampling_rate` metric so that lowVolumeThreshold reflects the real traffic volume

## Dependencies
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [x] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed percentage-based alert rule query generation to compute the percentage once and apply threshold checks correctly using logical `and`.
  * Corrected low-volume gating for percentage alerts so alert triggering properly respects both sampling rate volume and the configured low-volume threshold.

* **Tests**
  * Updated percentage alert/recording rule PromQL expectations to match the corrected behavior for threshold and low-volume scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->