### PR TITLE
security: use sha digests for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/workflows/build_image_pr.yml
+++ b/.github/workflows/build_image_pr.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build PR image and upload artifact
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: Install make
@@ -44,7 +44,7 @@ jobs:
       - name: build and save catalog image
         run: IMAGE_ORG=${{ env.WF_ORG }} BUNDLE_VERSION=0.0.0-tmp CLEAN_BUILD=1 make catalog-tar
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr
           path: out/

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,11 +15,11 @@ jobs:
     - name: install make
       run: sudo apt-get install make
     - name: set up go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '1.26'
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: check format
@@ -43,7 +43,7 @@ jobs:
     - name: install make
       run: sudo apt-get install make
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: generate bundle
@@ -62,7 +62,7 @@ jobs:
       run: sudo apt-get install make
 
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
 

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -22,7 +22,7 @@ jobs:
       - name: install make
         run: sudo apt-get install make
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: docker login to quay.io
@@ -61,9 +61,10 @@ jobs:
     - name: install make
       run: sudo apt-get install make
     - name: set up go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '1.26'
+        cache: false
     - name: checkout
       uses: actions/checkout@v6
       with:

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -43,7 +43,7 @@ jobs:
           echo "bundle_image=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}-bundle:v0.0.0-sha-${head_sha::8}" >> $GITHUB_ENV
           echo "catalog_image=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}-catalog:v0.0.0-sha-${head_sha::8}" >> $GITHUB_ENV
       - name: download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: pr
           run-id: ${{github.event.workflow_run.id }}
@@ -67,7 +67,7 @@ jobs:
           DOCKER_BUILDKIT=1 docker push ${{ env.main_image }}
           DOCKER_BUILDKIT=1 docker push ${{ env.bundle_image }}
           DOCKER_BUILDKIT=1 docker push ${{ env.catalog_image }}
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: docker login to quay.io
@@ -60,28 +60,11 @@ jobs:
         run: IMAGE_ORG=${{ env.WF_ORG }} BUNDLE_VERSION=${{ env.tag }} make catalog-push
       - name: extract binaries
         run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} make extract-binaries
-      - name: create draft release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: create draft release and upload binaries
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ env.tag }}
-          release_name: ${{ env.tag }}
+          name: ${{ env.tag }}
           draft: true
           prerelease: false
-      - name: upload binaries
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const fs = require('fs').promises;
-            const upload_url = '${{ steps.create_release.outputs.upload_url }}';
-            for (let file of await fs.readdir('./release-assets')) {
-              console.log('uploading', file);
-              await github.rest.repos.uploadReleaseAsset({
-                url: upload_url,
-                name: file,
-                data: await fs.readFile(`./release-assets/${file}`)
-              }); 
-            }
+          files: ./release-assets/*


### PR DESCRIPTION
## Description

using sha digests for github actions is more secure than tags.

https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash


## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened CI/CD pipeline security by pinning key GitHub Actions steps (e.g., checkout, setup-go, artifact upload/download, and release tooling) to specific commit SHAs instead of floating version tags.
  * Updated Dependabot configuration to add automated dependency checks for the GitHub Actions ecosystem on a monthly schedule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->