### PR TITLE
Update .ci-operator.yaml to golang 1.26 / openshift 5.0

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.25-openshift-4.21
+  tag: rhel-9-release-golang-1.26-openshift-5.0


### PR DESCRIPTION
## Description

Update .ci-operator.yaml to golang 1.26 / openshift 5.0

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build environment configuration to use newer versions of development toolchain and container runtime platform. This upgrade ensures builds operate with the latest compatible build tools and improves infrastructure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->