### PR TITLE
ok-to-test: Use sha when building artifact

### DIFF
--- a/.github/workflows/build_image_pr.yml
+++ b/.github/workflows/build_image_pr.yml
@@ -23,26 +23,29 @@ jobs:
           persist-credentials: false
       - name: Install make
         run: sudo apt -y install make
+      - name: Get short sha
+        run: |
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          echo "short_sha=$(echo ${head_sha::8})" >> $GITHUB_ENV
       - name: build and save operator image
-        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:tmp CLEAN_BUILD=1 make tar-image
+        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} CLEAN_BUILD=1 make tar-image
       - name: get related images target
         if: startsWith(github.ref_name, 'release-')
         run: echo "WF_RELIMG_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
       - name: build and save bundle image
         run: |
-          head_sha="${{ github.event.pull_request.head.sha }}"
           OCI_BUILD_OPTS="--label quay.expires-after=2w" \
             IMAGE_ORG=${{ env.WF_ORG }} \
-            VERSION=${head_sha::8} \
+            VERSION=${{ env.short_sha }} \
             PLG_VERSION=${{ env.WF_RELIMG_VERSION }} \
             FLP_VERSION=${{ env.WF_RELIMG_VERSION }} \
             BPF_VERSION=${{ env.WF_RELIMG_VERSION }} \
-            BUNDLE_VERSION=0.0.0-tmp \
+            BUNDLE_VERSION=0.0.0-sha-${{ env.short_sha }} \
             CLEAN_BUILD=1 \
             BUNDLE_SET_DATE=true \
             make bundle-nogen bundle-tar
       - name: build and save catalog image
-        run: IMAGE_ORG=${{ env.WF_ORG }} BUNDLE_VERSION=0.0.0-tmp CLEAN_BUILD=1 make catalog-tar
+        run: IMAGE_ORG=${{ env.WF_ORG }} BUNDLE_VERSION=0.0.0-sha-${{ env.short_sha }} CLEAN_BUILD=1 make catalog-tar
       - name: upload artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -53,9 +53,6 @@ jobs:
           docker load --input ./operator.tar
           docker load --input ./bundle.tar
           docker load --input ./catalog.tar
-          docker image tag ${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:tmp ${{ env.main_image }}
-          docker image tag ${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}-bundle:v0.0.0-tmp ${{ env.bundle_image }}
-          docker image tag ${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}-catalog:v0.0.0-tmp ${{ env.catalog_image }}
       - name: docker login to quay.io
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image versioning so PR builds use a consistent, traceable identifier across operator, bundle, and catalog images.
  * Updated build/publish behavior to ensure images are tagged predictably without intermediate retagging artifacts.

* **Chores**
  * Refined build and release automation for PR workflows so published images are easier to identify and correlate during validation and deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->