### PR TITLE
NETOBSERV-2817: Fixes for tests on OCP 4.14

### DIFF
--- a/integration-tests/backend/Makefile
+++ b/integration-tests/backend/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_LINT_VERSION = v2.8.0
+GOLANGCI_LINT_VERSION = v2.12.2
 
 # Detect OS
 UNAME_S := $(shell uname -s)

--- a/integration-tests/backend/go.mod
+++ b/integration-tests/backend/go.mod
@@ -1,6 +1,6 @@
 module e2etests
 
-go 1.25.1
+go 1.25.7
 
 replace (
 	bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 
 	filePath "path/filepath"
 	"strings"
@@ -175,11 +174,11 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		defer func() { _ = flow.DeleteFlowcollector(oc) }()
 		flow.CreateFlowcollector(oc)
 
+		// Note: In older OCP versions, oc adm inspect outputs benign discovery errors that don't affect data collection.
 		g.By("Run must-gather command")
-		defer func() { _, _ = exec.Command("bash", "-c", "rm -rf "+mustgatherDir).Output() }()
-		output, err := oc.AsAdmin().WithoutNamespace().Run("adm").Args("must-gather", "--image", mustgatherImage, "--dest-dir="+mustgatherDir).Output()
+		defer func() { _ = os.RemoveAll(mustgatherDir) }()
+		_, err := oc.AsAdmin().WithoutNamespace().Run("adm").Args("must-gather", "--image", mustgatherImage, "--dest-dir="+mustgatherDir).Output()
 		o.Expect(err).NotTo(o.HaveOccurred(), "must-gather command failed")
-		o.Expect(output).NotTo(o.ContainSubstring("error"))
 
 		g.By("Wait for must-gather directory to be populated")
 		var mustgatherLogsDir string
@@ -804,7 +803,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		})
 
 		g.It("Author:memodi-NonPreRelease-Longduration-High-63839-Verify-multi-tenancy [Disruptive][Slow]", func() {
-			SkipIfOCPBelow("v4.15")
 			users, usersHTpassFile, htPassSecret := getNewUser(oc, 2)
 			defer userCleanup(oc, users, usersHTpassFile, htPassSecret)
 
@@ -1985,7 +1983,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		})
 
 		g.It("Author:aramesha-NonPreRelease-High-80090-Verify FLP tail-based filtering [Serial]", func() {
-			SkipIfOCPBelow("v4.15")
 			// Accept flows with Source Namespace = < namespace > and
 			// Source Name containing 'flowlogs-pipeline-' and
 			// NOT Source Port 9401 and
@@ -2667,15 +2664,21 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			e2e.Logf("Components after pause: %s", componentsAfterPause)
 
 			// Components with stable names that should remain when paused
+			// Common components across all OCP versions
 			componentsShouldRemain := []string{
-				"deployment.apps/netobserv-plugin-static",
-				"service/netobserv-plugin-static",
-				"networkpolicy.networking.k8s.io/netobserv",
 				"configmap/lokistack-ca-bundle",
 				"configmap/lokistack-gateway-ca-bundle",
 				"configmap/grafana-dashboard-netobserv-health",
 				"configmap/netobserv-main",
 				"secret/lokistack-query-frontend-http",
+			}
+			// Static plugin and network policy are only available on OCP 4.15+
+			if IsOCPVersionAtLeast("v4.15") {
+				componentsShouldRemain = append(componentsShouldRemain,
+					"deployment.apps/netobserv-plugin-static",
+					"service/netobserv-plugin-static",
+					"networkpolicy.networking.k8s.io/netobserv",
+				)
 			}
 			verifyComponentsExist(componentsAfterPause, componentsShouldRemain)
 
@@ -2684,7 +2687,9 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				"pod", "-A", "-l", "netobserv-managed=true", "-o", "name",
 			).Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(podsAfterPause).Should(o.ContainSubstring("pod/netobserv-plugin-static-"), "netobserv-plugin-static pod should exist after pause")
+			if IsOCPVersionAtLeast("v4.15") {
+				o.Expect(podsAfterPause).Should(o.ContainSubstring("pod/netobserv-plugin-static-"), "netobserv-plugin-static pod should exist after pause")
+			}
 			o.Expect(podsAfterPause).ShouldNot(o.ContainSubstring("pod/flowlogs-pipeline-"), "flowlogs-pipeline pods should be deleted")
 			o.Expect(podsAfterPause).ShouldNot(o.ContainSubstring("pod/netobserv-ebpf-agent-"), "netobserv-ebpf-agent pods should be deleted")
 			// Verify regular netobserv-plugin pod is deleted (not the static one)

--- a/integration-tests/backend/version_checker.go
+++ b/integration-tests/backend/version_checker.go
@@ -25,9 +25,8 @@ func GetOCPVersion(oc *exutil.CLI) (string, error) {
 	return clusterVersion, err
 }
 
-// SkipIfOCPBelow skips test if cluster version is below requirement
-// expects "v4.19" format
-func SkipIfOCPBelow(requiredVersion string) {
+// validateRequiredVersion validates and canonicalizes the required version string
+func validateRequiredVersion(requiredVersion string) string {
 	if clusterVersion == "" {
 		ginkgo.Fail("Cluster version not initialized")
 	}
@@ -37,7 +36,23 @@ func SkipIfOCPBelow(requiredVersion string) {
 		ginkgo.Fail("Requested cluster version is invalid")
 	}
 
+	return requiredVersion
+}
+
+// SkipIfOCPBelow skips test if cluster version is below requirement
+// expects "v4.19" format
+func SkipIfOCPBelow(requiredVersion string) {
+	requiredVersion = validateRequiredVersion(requiredVersion)
+
 	if semver.Compare(clusterVersion, requiredVersion) == -1 {
 		ginkgo.Skip(fmt.Sprintf("Requires at least OCP %s+, cluster is %s", requiredVersion, clusterVersion))
 	}
+}
+
+// IsOCPVersionAtLeast returns true if cluster version is at or above the required version
+// expects "v4.15" format
+func IsOCPVersionAtLeast(requiredVersion string) bool {
+	requiredVersion = validateRequiredVersion(requiredVersion)
+
+	return semver.Compare(clusterVersion, requiredVersion) >= 0
 }


### PR DESCRIPTION
## Description

- Fixes for backend tests on OCP 4.14
- Bump go and lint version

## Dependencies
n/a

## Test Results

- Test 53844 - Sanity Test
   Detected OCP version: v4.14
  [sig-netobserv] Network_Observability with Loki Author:memodi-Critical-53844-Sanity Test NetObserv [Serial]
  /Users/amoghrd/repos/netobserv/netobserv-operator/integration-tests/backend/test_flowcollector.go:1471
  • PASSED [564.287 seconds]


- Test 63185 - Must-gather Test
  Detected OCP version: v4.14
  [sig-netobserv] Network_Observability Author:memodi-Medium-63185-Verify NetOberv must-gather plugin [Serial]
  /Users/amoghrd/repos/netobserv/netobserv-operator/integration-tests/backend/test_flowcollector.go:163
  • PASSED [133.721 seconds]

- Test 88334 - Pause Functions Test
  Detected OCP version: v4.14
  [sig-netobserv] Network_Observability with Loki Author:kapjain-Medium-88334-Pause Network Observability functions [Serial]
  /Users/amoghrd/repos/netobserv/netobserv-operator/integration-tests/backend/test_flowcollector.go:2612
  • PASSED [564.418 seconds]

- Test 80090 - FLP Tail-based Filtering
  Detected OCP version: v4.14
  [sig-netobserv] Network_Observability with Loki Author:aramesha-NonPreRelease-High-80090-Verify FLP tail-based filtering [Serial]
  /Users/amoghrd/repos/netobserv/netobserv-operator/integration-tests/backend/test_flowcollector.go:1986
  • PASSED [473.593 seconds]

- Test 63839 - Multi-tenancy
  Detected OCP version: v4.14
  [sig-netobserv] Network_Observability with Loki Author:memodi-NonPreRelease-Longduration-High-63839-Verify-multi-tenancy [Disruptive][Slow]
  /Users/amoghrd/repos/netobserv/netobserv-operator/integration-tests/backend/test_flowcollector.go:806
  • PASSED [859.613 seconds]

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of backend integration tests with older OpenShift versions.
  * Must-gather checks are now more tolerant of benign discovery-related output.
  * Pause/resume expectations are now version-aware, requiring newer components only when applicable.
* **Tests**
  * Enabled multi-tenancy and FLP tail-based filtering tests on older cluster versions.
* **Chores**
  * Updated lint tooling and the Go toolchain patch level.
* **Refactor**
  * Added safer version validation and a helper for “at least” version checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->