### PR TITLE
NETOBSERV-2654 enable informers for all tests and bump e2etests go vesion

### DIFF
--- a/integration-tests/backend/.golangci.yml
+++ b/integration-tests/backend/.golangci.yml
@@ -1,6 +1,8 @@
 version: "2"
 run:
   go: "1.23"
+  concurrency: 2
+  timeout: 30m
 linters:
   enable:
     - copyloopvar
@@ -16,6 +18,10 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
     rules:
       - linters:
         - staticcheck
@@ -26,3 +32,9 @@ linters:
 formatters:
   enable:
     - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/integration-tests/backend/Dockerfile
+++ b/integration-tests/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.25 AS builder
+FROM docker.io/library/golang:1.26 AS builder
 
 ARG TARGETARCH=amd64
 

--- a/integration-tests/backend/Makefile
+++ b/integration-tests/backend/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_LINT_VERSION = v2.8.0
+GOLANGCI_LINT_VERSION = v2.12.2
 
 # Detect OS
 UNAME_S := $(shell uname -s)

--- a/integration-tests/backend/Makefile
+++ b/integration-tests/backend/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_LINT_VERSION = v2.12.2
+GOLANGCI_LINT_VERSION = v2.8.0
 
 # Detect OS
 UNAME_S := $(shell uname -s)

--- a/integration-tests/backend/Makefile
+++ b/integration-tests/backend/Makefile
@@ -35,7 +35,7 @@ fmt: ## Run go fmt against code.
 .PHONY: lint
 lint: prereqs ## Run linter (golangci-lint)
 	@echo "### Linting code"
-	./bin/golangci-lint-${GOLANGCI_LINT_VERSION} --config .golangci.yml run --timeout 15m ./...
+	./bin/golangci-lint-${GOLANGCI_LINT_VERSION} --config .golangci.yml run --verbose ./...
 
 ##@ Build
 .PHONY: install-ginkgo

--- a/integration-tests/backend/flowcollector.go
+++ b/integration-tests/backend/flowcollector.go
@@ -212,6 +212,9 @@ func (flow *Flowcollector) WaitForFlowcollectorReady(oc *exutil.CLI) {
 	default:
 		waitUntilDaemonSetReady(oc, "flowlogs-pipeline", flow.Namespace)
 	}
+	// check informers deployment
+	waitUntilDeploymentReady(oc, "flowlogs-pipeline-informers", flow.Namespace)
+
 	// check ebpf-agent status
 	waitUntilDaemonSetReady(oc, "netobserv-ebpf-agent", flow.Namespace+"-privileged")
 

--- a/integration-tests/backend/go.mod
+++ b/integration-tests/backend/go.mod
@@ -1,6 +1,6 @@
 module e2etests
 
-go 1.25.7
+go 1.26.3
 
 replace (
 	bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/integration-tests/backend/testdata/flowcollector_v1beta2_template.yaml
+++ b/integration-tests/backend/testdata/flowcollector_v1beta2_template.yaml
@@ -32,6 +32,8 @@ objects:
               tls:
                 type: "${EBPFMetricServerTLSType}"
       processor:
+        informerCacheProxy:
+          enabled: true
         multiClusterDeployment: "${{MultiClusterDeployment}}"
         addZone: "${{AddZone}}"
         service:


### PR DESCRIPTION
## Description

- [NETOBSERV-2654](https://redhat.atlassian.net/browse/NETOBSERV-2654) enable informers for all tests
- Also, updating golang version for e2etests to 1.26 to be inline with operator version and compatible with golangci-lint version. 
- optimizing golangci-lint config

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [X] Regression tests only (e.g. refactoring with no user-facing change).
  * [X] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Updated integration test FlowCollector templates to enable the eBPF informer cache proxy configuration.
* **Bug Fixes**
  * Improved FlowCollector readiness detection by adding an additional wait step for the `flowlogs-pipeline-informers` deployment.
* **Chores**
  * Updated the backend Go toolchain version and corresponding builder image used for integration test builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->