### PR TITLE
NETOBSERV-2848: Split test files and switch to demoLoki

### DIFF
--- a/integration-tests/backend/alerts.go
+++ b/integration-tests/backend/alerts.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"time"
 
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -15,30 +17,56 @@ func getConfiguredAlertRules(oc *exutil.CLI, ruleName string, namespace string) 
 	return oc.AsAdmin().WithoutNamespace().Run("get").Args("prometheusrules", ruleName, "-o=jsonpath='{.spec.groups[*].rules[*].alert}'", "-n", namespace).Output()
 }
 
-func getAlertStatus(oc *exutil.CLI, alertName string) (map[string]interface{}, error) {
-	alertOut, err := oc.AsAdmin().WithoutNamespace().Run("exec").Args("-n", "openshift-monitoring", "alertmanager-main-0", "--", "amtool", "--alertmanager.url", "http://localhost:9093", "alert", "query", alertName, "-o", "json").Output()
-	if err != nil {
-		return make(map[string]interface{}), err
-	}
-	var alertStatus []interface{}
-	_ = json.Unmarshal([]byte(alertOut), &alertStatus)
-
-	if len(alertStatus) == 0 {
-		return make(map[string]interface{}), nil
-	}
-	return alertStatus[0].(map[string]interface{}), nil
+type prometheusAlertResult struct {
+	Data struct {
+		Result []struct {
+			Metric map[string]string `json:"metric"`
+		} `json:"result"`
+	} `json:"data"`
 }
 
-func waitForAlertToBeActive(oc *exutil.CLI, alertName string) {
-	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 900*time.Second, false, func(context.Context) (done bool, err error) {
-		alertStatus, err := getAlertStatus(oc, alertName)
-		if err != nil {
-			return false, err
-		}
-		if len(alertStatus) == 0 {
+// getAlertLabels queries Prometheus for an alert and returns its labels.
+func getAlertLabels(oc *exutil.CLI, alertName string) (map[string]string, error) {
+	bearerToken := getSAToken(oc, "prometheus-k8s", "openshift-monitoring")
+	promRoute := "https://" + getRouteAddress(oc, "openshift-monitoring", "prometheus-k8s")
+	query := fmt.Sprintf(`ALERTS{alertname="%s"}`, alertName)
+
+	h := make(http.Header)
+	h.Add("Content-Type", "application/json")
+	h.Add("Authorization", "Bearer "+bearerToken)
+
+	params := url.Values{}
+	params.Add("query", query)
+
+	resp, err := doHTTPRequest(h, promRoute, "/api/v1/query", params.Encode(), "GET", false, 5, nil, 200)
+	if err != nil {
+		return nil, err
+	}
+
+	var result prometheusAlertResult
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, err
+	}
+	if len(result.Data.Result) == 0 {
+		return nil, nil
+	}
+	return result.Data.Result[0].Metric, nil
+}
+
+func waitForAlertToBePending(oc *exutil.CLI, alertName string) {
+	bearerToken := getSAToken(oc, "prometheus-k8s", "openshift-monitoring")
+	promRoute := "https://" + getRouteAddress(oc, "openshift-monitoring", "prometheus-k8s")
+	query := fmt.Sprintf(`ALERTS{alertname="%s"}`, alertName)
+
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 300*time.Second, false, func(context.Context) (done bool, err error) {
+		res, qErr := queryPrometheus(promRoute, query, bearerToken)
+		if qErr != nil {
 			return false, nil
 		}
-		return alertStatus["status"].(map[string]interface{})["state"] == "active", nil
+		if len(res.Data.Result) == 0 {
+			return false, nil
+		}
+		return true, nil
 	})
-	compat_otp.AssertWaitPollNoErr(err, fmt.Sprintf("%s Alert did not become active", alertName))
+	compat_otp.AssertWaitPollNoErr(err, fmt.Sprintf("%s Alert did not become pending/active", alertName))
 }

--- a/integration-tests/backend/backend_suite_test.go
+++ b/integration-tests/backend/backend_suite_test.go
@@ -11,8 +11,9 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	"github.com/onsi/ginkgo/v2/types"
-	"github.com/onsi/gomega"
+	o "github.com/onsi/gomega"
 	exutil "github.com/openshift/origin/test/extended/util"
+	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
 	e2eframework "k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -38,16 +39,26 @@ var _ = g.BeforeSuite(func() {
 	e2eframework.TestContext.DumpLogsOnFailure = dumpEvents
 
 	// Initialize test
-	gomega.Expect(exutil.InitTest(false)).NotTo(gomega.HaveOccurred())
+	o.Expect(exutil.InitTest(false)).NotTo(o.HaveOccurred())
 
 	oc := exutil.NewCLIForMonitorTest("netobserv")
 	_, err = GetOCPVersion(oc)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	if strings.Contains(os.Getenv("E2E_RUN_TAGS"), "disconnected") {
+		g.Skip("Skipping tests for disconnected profiles")
+	}
+
+	isHypershift := compat_otp.IsHypershiftHostedCluster(oc)
+	OperatorNS.DeployOperatorNamespace(oc)
+	catSrcErr := setupCatalogSource(oc, NOcatSrc, catSrcTemplate, imageDigest, catalogSource, isHypershift, &NOSource, &NO)
+	o.Expect(catSrcErr).NotTo(o.HaveOccurred())
+	ensureNetObservOperatorDeployed(oc, NO, NOSource)
 })
 
 func TestBackend(t *testing.T) {
 	exutil.WithCleanup(func() {
-		gomega.RegisterFailHandler(g.Fail)
+		o.RegisterFailHandler(g.Fail)
 
 		suiteConfig, reporterConfig := g.GinkgoConfiguration()
 

--- a/integration-tests/backend/flowcollector.go
+++ b/integration-tests/backend/flowcollector.go
@@ -25,13 +25,8 @@ type Flowcollector struct {
 	DeploymentModel                   string
 	LokiEnable                        string
 	LokiMode                          string
-	LokiURL                           string
-	LokiTLSCertName                   string
-	LokiStatusTLSEnable               string
-	LokiStatusURL                     string
-	LokiStatusTLSCertName             string
-	LokiStatusTLSUserCertName         string
 	LokiNamespace                     string
+	InstallDemoLoki                   string
 	MonolithicLokiURL                 string
 	KafkaAddress                      string
 	KafkaTLSEnable                    string
@@ -177,6 +172,8 @@ type Lokilabels struct {
 	SrcK8SType      string `loki:"SrcK8S_Type"`
 	DstK8SType      string `loki:"DstK8S_Type"`
 	Interfaces      string `loki:"Interfaces"`
+	// When set, AllowEmpty is for tests expecting 0 flows (e.g. multi-tenancy, filtering)
+	AllowEmpty bool `loki:"-"`
 }
 
 // create flowcollector CRD for a given manifest file
@@ -207,10 +204,10 @@ func (flow *Flowcollector) WaitForFlowcollectorReady(oc *exutil.CLI) {
 	switch flow.DeploymentModel {
 	case "Kafka":
 		waitUntilDeploymentReady(oc, "flowlogs-pipeline-transformer", flow.Namespace)
-	case "Service":
-		waitUntilDeploymentReady(oc, "flowlogs-pipeline", flow.Namespace)
-	default:
+	case "Direct":
 		waitUntilDaemonSetReady(oc, "flowlogs-pipeline", flow.Namespace)
+	default:
+		waitUntilDeploymentReady(oc, "flowlogs-pipeline", flow.Namespace)
 	}
 	// check ebpf-agent status
 	waitUntilDaemonSetReady(oc, "netobserv-ebpf-agent", flow.Namespace+"-privileged")
@@ -223,21 +220,17 @@ func (flow *Flowcollector) WaitForFlowcollectorReady(oc *exutil.CLI) {
 	compat_otp.AssertAllPodsToBeReady(oc, flow.Namespace)
 	compat_otp.AssertAllPodsToBeReady(oc, flow.Namespace+"-privileged")
 	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 600*time.Second, false, func(context.Context) (done bool, err error) {
-
-		status, err := oc.AsAdmin().Run("get").Args("flowcollector", "-o", "jsonpath='{.items[*].status.conditions[0].reason}'").Output()
-
+		condStatus, err := oc.AsAdmin().Run("get").Args("flowcollector", "cluster", "-o", `jsonpath='{.status.conditions[?(@.type=="Ready")].status}'`).Output()
 		if err != nil {
-			return false, err
+			return false, nil
 		}
-		if strings.Contains(status, "Ready") {
+		condStatusStr := strings.TrimSpace(condStatus)
+		if condStatusStr == "'True'" {
 			return true, nil
 		}
 
-		msg, err := oc.AsAdmin().Run("get").Args("flowcollector", "-o", "jsonpath='{.items[*].status.conditions[0].message}'").Output()
-		e2e.Logf("flowcollector status is %s due to %s", status, msg)
-		if err != nil {
-			return false, err
-		}
+		msg, _ := oc.AsAdmin().Run("get").Args("flowcollector", "cluster", "-o", `jsonpath='{.status.conditions[?(@.type=="Ready")].reason},{.status.conditions[?(@.type=="Ready")].message}'`).Output()
+		e2e.Logf("flowcollector Ready condition status=%s: %s", condStatusStr, strings.TrimSpace(msg))
 
 		return false, nil
 	})

--- a/integration-tests/backend/flowcollector_utils.go
+++ b/integration-tests/backend/flowcollector_utils.go
@@ -3,7 +3,6 @@ package e2etests
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -13,7 +12,13 @@ import (
 	"time"
 
 	o "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
+	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
@@ -55,7 +60,7 @@ func verifyFlowRecordFromLogs(podLog string) {
 }
 
 // Get flow recrods from loki
-func getFlowRecords(lokiValues [][]string) ([]FlowRecord, error) {
+func getFlowRecords(lokiValues [][]string, stream lokiStream) ([]FlowRecord, error) {
 	flowRecords := []FlowRecord{}
 	for _, values := range lokiValues {
 		timestamp, _ := strconv.ParseInt(values[0], 10, 64)
@@ -63,6 +68,26 @@ func getFlowRecords(lokiValues [][]string) ([]FlowRecord, error) {
 		err := json.Unmarshal([]byte(values[1]), &flowlog)
 		if err != nil {
 			return []FlowRecord{}, err
+		}
+		// FLP strips fields configured as Loki labels from the JSON body;
+		// merge them back from the stream labels so assertions can access them.
+		if flowlog.SrcK8SType == "" && stream.SrcK8SType != "" {
+			flowlog.SrcK8SType = stream.SrcK8SType
+		}
+		if flowlog.DstK8SType == "" && stream.DstK8SType != "" {
+			flowlog.DstK8SType = stream.DstK8SType
+		}
+		if flowlog.SrcK8SZone == "" && stream.SrcK8SZone != "" {
+			flowlog.SrcK8SZone = stream.SrcK8SZone
+		}
+		if flowlog.DstK8SZone == "" && stream.DstK8SZone != "" {
+			flowlog.DstK8SZone = stream.DstK8SZone
+		}
+		if flowlog.K8SClusterName == "" && stream.K8SClusterName != "" {
+			flowlog.K8SClusterName = stream.K8SClusterName
+		}
+		if flowlog.RecordType == "" && stream.RecordType != "" {
+			flowlog.RecordType = stream.RecordType
 		}
 		flowRecord := FlowRecord{
 			Timestamp: timestamp,
@@ -252,8 +277,12 @@ func (lokilabels Lokilabels) getLokiQueryLabels() string {
 			field := labelType.Field(i)
 
 			// Get the label name from loki tag, or use field name as fallback
+			lokiTag := field.Tag.Get("loki")
+			if lokiTag == "-" {
+				continue
+			}
 			labelName := field.Name
-			if lokiTag := field.Tag.Get("loki"); lokiTag != "" {
+			if lokiTag != "" {
 				labelName = lokiTag
 			}
 
@@ -313,11 +342,68 @@ func (lokilabels Lokilabels) getLokiQuery(filterType string, parameters ...strin
 	return lokiQuery
 }
 
-func (lokilabels Lokilabels) GetMonolithicLokiFlowLogs(lokiRoute string, startTime time.Time, parameters ...string) ([]FlowRecord, error) {
+// createLokiRoute creates an OpenShift Route for the demoLoki service if one doesn't already exist.
+// It also creates a NetworkPolicy to allow ingress from the OpenShift router.
+func createLokiRoute(oc *exutil.CLI, namespace string) string {
+	// Allow ingress from the OpenShift router to reach the Loki pod
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-from-openshift-ingress-to-loki",
+			Namespace: namespace,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "loki"},
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"policy-group.network.openshift.io/ingress": "",
+						},
+					},
+				}},
+			}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		},
+	}
+	_, err := oc.AdminKubeClient().NetworkingV1().NetworkPolicies(namespace).Create(context.Background(), np, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}
+
+	route := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "loki",
+			Namespace: namespace,
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: "loki",
+			},
+			Port: &routev1.RoutePort{
+				TargetPort: intstr.FromInt32(3100),
+			},
+		},
+	}
+	_, err = oc.AdminRouteClient().RouteV1().Routes(namespace).Create(context.Background(), route, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	return getRouteAddress(oc, namespace, "loki")
+}
+
+func deleteLokiRoute(oc *exutil.CLI, namespace string) {
+	_ = oc.AdminRouteClient().RouteV1().Routes(namespace).Delete(context.Background(), "loki", metav1.DeleteOptions{})
+	_ = oc.AdminKubeClient().NetworkingV1().NetworkPolicies(namespace).Delete(context.Background(), "allow-from-openshift-ingress-to-loki", metav1.DeleteOptions{})
+}
+
+func (lokilabels Lokilabels) GetMonolithicLokiFlowLogs(oc *exutil.CLI, namespace string, startTime time.Time, parameters ...string) ([]FlowRecord, error) {
+	lokiRoute := "http://" + createLokiRoute(oc, namespace)
+	defer deleteLokiRoute(oc, namespace)
+
 	lc := newLokiClient(lokiRoute, startTime).retry(5)
 	lc.quiet = false
-	lc.localhost = true
-	lokiQuery := lokilabels.getLokiQuery("REGEX", parameters...)
+	lokiQuery := lokilabels.getLokiQuery("JSON", parameters...)
 	flowRecords := []FlowRecord{}
 	var res *lokiQueryResponse
 	err := wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 300*time.Second, false, func(context.Context) (done bool, err error) {
@@ -325,12 +411,15 @@ func (lokilabels Lokilabels) GetMonolithicLokiFlowLogs(lokiRoute string, startTi
 		res, qErr = lc.searchLogsInLoki("", lokiQuery)
 		if qErr != nil {
 			e2e.Logf("\ngot error %v when getting logs for query: %s\n", qErr, lokiQuery)
-			return false, qErr
+			return false, nil
 		}
 
-		// return results if no error and result is empty
-		// caller should add assertions to ensure len([]FlowRecord) is as they expected for given loki query
-		return len(res.Data.Result) > 0, nil
+		if !lokilabels.AllowEmpty && len(res.Data.Result) == 0 {
+			e2e.Logf("waiting for non-empty results for query: %s", lokiQuery)
+			return false, nil
+		}
+
+		return true, nil
 	})
 
 	if err != nil {
@@ -338,10 +427,11 @@ func (lokilabels Lokilabels) GetMonolithicLokiFlowLogs(lokiRoute string, startTi
 	}
 
 	for _, result := range res.Data.Result {
-		flowRecords, err = getFlowRecords(result.Values)
-		if err != nil {
-			return []FlowRecord{}, err
+		records, recErr := getFlowRecords(result.Values, result.Stream)
+		if recErr != nil {
+			return []FlowRecord{}, recErr
 		}
+		flowRecords = append(flowRecords, records...)
 	}
 
 	return flowRecords, err
@@ -367,6 +457,11 @@ func (lokilabels Lokilabels) getLokiFlowLogs(token, lokiRoute string, startTime 
 			return false, nil
 		}
 
+		if !lokilabels.AllowEmpty && len(res.Data.Result) == 0 {
+			e2e.Logf("waiting for non-empty results for query: %s", lokiQuery)
+			return false, nil
+		}
+
 		return true, nil
 	})
 
@@ -375,40 +470,40 @@ func (lokilabels Lokilabels) getLokiFlowLogs(token, lokiRoute string, startTime 
 	}
 
 	for _, result := range res.Data.Result {
-		flowRecords, err = getFlowRecords(result.Values)
-		if err != nil {
-			return []FlowRecord{}, err
+		records, recErr := getFlowRecords(result.Values, result.Stream)
+		if recErr != nil {
+			return []FlowRecord{}, recErr
 		}
+		flowRecords = append(flowRecords, records...)
 	}
 
 	return flowRecords, err
 }
 
-// Verify loki flow records and if it was written in the last 5 minutes
-func verifyLokilogsTime(token, lokiRoute string, startTime time.Time) error {
-	lc := newLokiClient(lokiRoute, startTime).withToken(token).retry(5)
-	res, err := lc.searchLogsInLoki("network", "{app=\"netobserv-flowcollector\", FlowDirection=\"0\"}")
-
-	if err != nil {
-		return err
-	}
-	if len(res.Data.Result) == 0 {
-		return errors.New("network logs not found")
-	}
-	flowRecords := []FlowRecord{}
-
-	for _, result := range res.Data.Result {
-		flowRecords, err = getFlowRecords(result.Values)
-		if err != nil {
-			return err
-		}
-	}
-
-	for _, r := range flowRecords {
-		r.Flowlog.verifyFlowRecord()
-	}
-	return nil
-}
+// func verifyLokilogsTime(token, lokiRoute string, startTime time.Time) error {
+// 	lc := newLokiClient(lokiRoute, startTime).withToken(token).retry(5)
+// 	res, err := lc.searchLogsInLoki("network", "{app=\"netobserv-flowcollector\", FlowDirection=\"0\"}")
+//
+// 	if err != nil {
+// 		return err
+// 	}
+// 	if len(res.Data.Result) == 0 {
+// 		return errors.New("network logs not found")
+// 	}
+// 	flowRecords := []FlowRecord{}
+//
+// 	for _, result := range res.Data.Result {
+// 		flowRecords, err = getFlowRecords(result.Values, result.Stream)
+// 		if err != nil {
+// 			return err
+// 		}
+// 	}
+//
+// 	for _, r := range flowRecords {
+// 		r.Flowlog.verifyFlowRecord()
+// 	}
+// 	return nil
+// }
 
 // Verify some key and deterministic conversation record fields and their values
 func (flowlog *Flowlog) verifyConversationRecord() {
@@ -491,4 +586,70 @@ func verifyNetworkEvents(flowRecords []FlowRecord, action NWEvents, policytype, 
 		}
 	}
 	o.Expect(nNWEventsLogs).Should(o.BeNumerically(">=", 1), "Found no logs with Network Events")
+}
+
+func waitForNewPodLogs(oc *exutil.CLI, namespace, podName, filter string) (string, error) {
+	sinceTime := time.Now().Format(time.RFC3339)
+	e2e.Logf("Waiting for new pod logs since %s with filter %q", sinceTime, filter)
+
+	err := wait.PollUntilContextTimeout(context.Background(), 20*time.Second, 10*time.Minute, false, func(context.Context) (bool, error) {
+		logs, err := oc.AsAdmin().WithoutNamespace().Run("logs").Args("--since-time="+sinceTime, podName, "-n", namespace).Output()
+		if err != nil {
+			e2e.Logf("unable to get pod (%s) logs: %v, will retry", podName, err)
+			return false, nil
+		}
+		if strings.Contains(logs, filter) {
+			e2e.Logf("Found new log entries matching filter %q", filter)
+			return true, nil
+		}
+		e2e.Logf("Waiting for new log entries matching %q", filter)
+		return false, nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return compat_otp.WaitAndGetSpecificPodLogs(oc, namespace, "", podName, "'"+filter+"'")
+}
+
+func verifyMonolithicLokilogsTime(oc *exutil.CLI, namespace string, startTime time.Time) error {
+	lokiRoute := "http://" + createLokiRoute(oc, namespace)
+	defer deleteLokiRoute(oc, namespace)
+
+	lc := newLokiClient(lokiRoute, startTime).retry(5)
+	lc.quiet = false
+
+	var res *lokiQueryResponse
+	flowRecords := []FlowRecord{}
+
+	err := wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 300*time.Second, false, func(context.Context) (done bool, err error) {
+		var qErr error
+		res, qErr = lc.searchLogsInLoki("", "{app=\"netobserv-flowcollector\", FlowDirection=\"0\"}")
+		if qErr != nil {
+			e2e.Logf("\ngot error %v when getting logs\n", qErr)
+			return false, nil
+		}
+		if len(res.Data.Result) == 0 {
+			e2e.Logf("network logs not found yet, will retry")
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	for _, result := range res.Data.Result {
+		records, recErr := getFlowRecords(result.Values, result.Stream)
+		if recErr != nil {
+			return recErr
+		}
+		flowRecords = append(flowRecords, records...)
+	}
+
+	for _, r := range flowRecords {
+		r.Flowlog.verifyFlowRecord()
+	}
+	return nil
 }

--- a/integration-tests/backend/flowcollectorslice.go
+++ b/integration-tests/backend/flowcollectorslice.go
@@ -47,13 +47,12 @@ func (flowSlice *FlowcollectorSlice) DeleteFlowcollectorSlice(oc *exutil.CLI) er
 // WaitForFlowcollectorSliceReady waits for FlowCollectorSlice to be ready by checking status conditions
 func (flowSlice *FlowcollectorSlice) WaitForFlowcollectorSliceReady(oc *exutil.CLI) {
 	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 600*time.Second, false, func(context.Context) (done bool, err error) {
-		// Check Ready condition
 		readyCondition, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("flowcollectorslice", flowSlice.Name, "-n", flowSlice.Namespace, "-o", "jsonpath={.status.conditions[?(@.type==\"Ready\")].status}").Output()
-		if err != nil || readyCondition != "True" {
+		if err != nil {
 			e2e.Logf("Error getting Ready condition: %v", err)
 			return false, nil
 		}
-		return true, nil
+		return readyCondition == "True", nil
 	})
 	compat_otp.AssertWaitPollNoErr(err, fmt.Sprintf("FlowCollectorSlice %s/%s did not become Ready", flowSlice.Namespace, flowSlice.Name))
 }

--- a/integration-tests/backend/go.mod
+++ b/integration-tests/backend/go.mod
@@ -59,11 +59,13 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
+	github.com/openshift/api v0.0.0-20260327065519-582dc3d316b7
 	github.com/openshift/origin v1.5.0-alpha.3.0.20260403210430-c77ff4a065bf
 	github.com/tidwall/gjson v1.18.0
 	golang.org/x/mod v0.35.0
 	google.golang.org/api v0.247.0
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/api v0.35.1
 	k8s.io/apimachinery v0.35.1
 	k8s.io/kubernetes v1.35.1
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
@@ -265,7 +267,6 @@ require (
 	github.com/opencontainers/runc v1.3.0 // indirect
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/opencontainers/selinux v1.13.1 // indirect
-	github.com/openshift/api v0.0.0-20260327065519-582dc3d316b7 // indirect
 	github.com/openshift/client-go v0.0.0-20260330134249-7e1499aaacd7 // indirect
 	github.com/openshift/library-go v0.0.0-20260303171201-5d9eb6295ff6 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
@@ -338,7 +339,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/api v0.35.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.1 // indirect
 	k8s.io/apiserver v0.35.1 // indirect
 	k8s.io/cli-runtime v0.33.4 // indirect

--- a/integration-tests/backend/loki_client.go
+++ b/integration-tests/backend/loki_client.go
@@ -79,19 +79,28 @@ type lokiClient struct {
 	localhost       bool      // whether loki is port-forwarded to localhost, useful for monolithic loki
 }
 
+type lokiStream struct {
+	App             string `json:"app"`
+	DstK8SNamespace string `json:"DstK8S_Namespace"`
+	FlowDirection   string `json:"FlowDirection"`
+	SrcK8SNamespace string `json:"SrcK8S_Namespace"`
+	SrcK8SOwnerName string `json:"SrcK8S_OwnerName"`
+	DstK8SOwnerName string `json:"DstK8S_OwnerName"`
+	SrcK8SType      string `json:"SrcK8S_Type"`
+	DstK8SType      string `json:"DstK8S_Type"`
+	SrcK8SZone      string `json:"SrcK8S_Zone"`
+	DstK8SZone      string `json:"DstK8S_Zone"`
+	K8SClusterName  string `json:"K8S_ClusterName"`
+	K8SFlowLayer    string `json:"K8S_FlowLayer"`
+	RecordType      string `json:"_RecordType"`
+}
+
 type lokiQueryResponse struct {
 	Status string `json:"status"`
 	Data   struct {
 		ResultType string `json:"resultType"`
 		Result     []struct {
-			Stream struct {
-				App             string `json:"app"`
-				DstK8SNamespace string `json:"DstK8S_Namespace"`
-				FlowDirection   string `json:"FlowDirection"`
-				SrcK8SNamespace string `json:"SrcK8S_Namespace"`
-				SrcK8SOwnerName string `json:"SrcK8S_OwnerName"`
-				DstK8SOwnerName string `json:"kubernetes_pod_name"`
-			} `json:"stream"`
+			Stream lokiStream `json:"stream"`
 			Values [][]string `json:"values"`
 		} `json:"result"`
 		Stats struct {

--- a/integration-tests/backend/operator.go
+++ b/integration-tests/backend/operator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	filePath "path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -45,23 +44,6 @@ type CatalogSourceObjects struct {
 type OperatorNamespace struct {
 	Name              string
 	NamespaceTemplate string
-}
-
-type subscriptionResource struct {
-	name             string
-	namespace        string
-	operatorName     string
-	channel          string
-	catalog          string
-	catalogNamespace string
-	template         string
-}
-
-type operatorGroupResource struct {
-	name             string
-	namespace        string
-	targetNamespaces string
-	template         string
 }
 
 // waitForPackagemanifestAppear waits for the packagemanifest to appear in the cluster
@@ -277,239 +259,15 @@ func CheckOperatorStatus(oc *exutil.CLI, operatorNamespace string, operatorName 
 
 func (ns *OperatorNamespace) DeployOperatorNamespace(oc *exutil.CLI) {
 	e2e.Logf("Creating %s operator namespace", ns.Name)
-	nsParameters := []string{"--ignore-unknown-parameters=true", "-f", ns.NamespaceTemplate, "-p", "NAMESPACE_NAME=" + ns.Name}
+	// -n default: oc process requires a valid namespace context; in BeforeSuite the CLI may not have one yet
+	nsParameters := []string{"-n", "default", "--ignore-unknown-parameters=true", "-f", ns.NamespaceTemplate, "-p", "NAMESPACE_NAME=" + ns.Name}
 	compat_otp.ApplyClusterResourceFromTemplate(oc, nsParameters...)
 }
 
-func generateTemplateAbsolutePath(fileName string) string {
-	testDataDir, _ := filePath.Abs("testdata/networking/nmstate")
-	return filePath.Join(testDataDir, fileName)
-}
-
-func operatorInstall(oc *exutil.CLI, sub subscriptionResource, ns OperatorNamespace, og operatorGroupResource) (status bool) {
-	//Installing Operator
-	g.By("INSTALLING Operator in the namespace")
-
-	//Applying the config of necessary yaml files from templates to create metallb operator
-	g.By("Applying namespace template")
-	err0 := applyResourceFromTemplateByAdmin(oc, "--ignore-unknown-parameters=true", "-f", ns.NamespaceTemplate, "-p", "NAME="+ns.Name)
-	if err0 != nil {
-		e2e.Logf("Error creating namespace %v", err0)
-	}
-
-	g.By("Applying operatorgroup yaml")
-	err0 = applyResourceFromTemplateByAdmin(oc, "--ignore-unknown-parameters=true", "-f", og.template, "-p", "NAME="+og.name, "NAMESPACE="+og.namespace, "TARGETNAMESPACES="+og.targetNamespaces)
-	if err0 != nil {
-		e2e.Logf("Error creating operator group %v", err0)
-	}
-
-	g.By("Creating subscription YAML from template")
-	// no need to check for an existing subscription
-	err0 = applyResourceFromTemplateByAdmin(oc, "--ignore-unknown-parameters=true", "-f", sub.template, "-p", "OPERATORNAME="+sub.operatorName, "SUBSCRIPTIONNAME="+sub.name, "NAMESPACE="+sub.namespace, "CHANNEL="+sub.channel,
-		"CATALOGSOURCE="+sub.catalog, "CATALOGSOURCENAMESPACE="+sub.catalogNamespace)
-	if err0 != nil {
-		e2e.Logf("Error creating subscription %v", err0)
-	}
-
-	//confirming operator install
-	g.By("Verify the operator finished subscribing")
-	errCheck := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 360*time.Second, false, func(context.Context) (bool, error) {
-		subState, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("sub", sub.name, "-n", sub.namespace, "-o=jsonpath={.status.state}").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		if strings.Compare(subState, "AtLatestKnown") == 0 {
-			return true, nil
-		}
-		// log full status of sub for installation failure debugging
-		subState, _ = oc.AsAdmin().WithoutNamespace().Run("get").Args("sub", sub.name, "-n", sub.namespace, "-o=jsonpath={.status}").Output()
-		e2e.Logf("Status of subscription: %v", subState)
-		return false, nil
-	})
-	compat_otp.AssertWaitPollNoErr(errCheck, fmt.Sprintf("Subscription %s in namespace %v does not have expected status", sub.name, sub.namespace))
-
-	g.By("Get csvName")
-	csvName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("sub", sub.name, "-n", sub.namespace, "-o=jsonpath={.status.installedCSV}").Output()
-	o.Expect(err).NotTo(o.HaveOccurred())
-	o.Expect(csvName).NotTo(o.BeEmpty())
-	errCheck = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 360*time.Second, false, func(context.Context) (bool, error) {
-		csvState, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("csv", csvName, "-n", sub.namespace, "-o=jsonpath={.status.phase}").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		if strings.Compare(csvState, "Succeeded") == 0 {
-			e2e.Logf("CSV check complete!!!")
-			return true, nil
-
-		}
-		return false, nil
-	})
-	compat_otp.AssertWaitPollNoErr(errCheck, fmt.Sprintf("CSV %v in %v namespace does not have expected status", csvName, sub.namespace))
-	return true
-}
-
-func getOpenshiftVersion(oc *exutil.CLI) string {
-	version, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterversion/version", "-ojsonpath={.status.desired.version}").Output()
-	if err != nil {
-		return ""
-	}
-	re := regexp.MustCompile(`^(\d+\.\d+)`)
-	matches := re.FindStringSubmatch(version)
-	if len(matches) < 2 {
-		return ""
-	}
-	return matches[1]
-}
-
-func createImageDigestMirrorSet(oc *exutil.CLI, imagedigestmirrorsetname string, imageDigestMirrorSetFile string) error {
-	pollInterval := 10 * time.Second
-	waitTimeout := 120 * time.Second
-	err := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", imageDigestMirrorSetFile).Execute()
-	if err != nil {
-		return fmt.Errorf("error applying image digest mirror set: %w", err)
-	}
-	return wait.PollUntilContextTimeout(context.Background(), pollInterval, waitTimeout, false, func(_ context.Context) (bool, error) {
-		err := oc.AsAdmin().WithoutNamespace().
-			Run("get").Args("imagedigestmirrorset", imagedigestmirrorsetname).Execute()
-		return err == nil, nil
-	})
-}
-
-func createCatalogSource(oc *exutil.CLI, operatorName string, catalogSourceName string, catalogNamespace string, catalogSourceTemplateFile string) error {
-	pollInterval := 10 * time.Second
-	waitTimeout := 120 * time.Second
-	openshiftVersion := getOpenshiftVersion(oc)
-	if openshiftVersion == "" {
-		return fmt.Errorf("failed to get OpenShift version")
-	}
-	image := "quay.io/redhat-user-workloads/ocp-art-tenant/art-fbc:ocp__" + openshiftVersion + "__" + operatorName + "-rhel9-operator"
-	e2e.Logf("Creating catalog source with name  '%s' in namespace '%s'", catalogSourceName, catalogNamespace)
-	err := applyResourceFromTemplateByAdmin(oc, "--ignore-unknown-parameters=true", "-f", catalogSourceTemplateFile, "-p", "CATALOGSOURCENAME="+catalogSourceName, "CATALOGNAMESPACE="+catalogNamespace, "IMAGE="+image)
-	if err != nil {
-		return fmt.Errorf("error applying catalog source: %w", err)
-	}
-
-	// Wait for CatalogSource to exist and be ready
-	return wait.PollUntilContextTimeout(context.Background(), pollInterval, waitTimeout, false, func(_ context.Context) (bool, error) {
-		// Check if CatalogSource exists
-		err := oc.AsAdmin().WithoutNamespace().Run("get").Args("catalogsource", catalogSourceName, "-n", catalogNamespace).Execute()
-		if err != nil {
-			e2e.Logf("CatalogSource not found yet: %v", err)
-			return false, nil
-		}
-
-		// Check if CatalogSource connection state is READY
-		connectionState, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("catalogsource", catalogSourceName,
-			"-n", catalogNamespace, "-o=jsonpath={.status.connectionState.lastObservedState}").Output()
-		if err != nil {
-			e2e.Logf("Failed to get connection state: %v", err)
-			return false, nil
-		}
-
-		if string(connectionState) != "READY" {
-			e2e.Logf("CatalogSource connection state is '%s', waiting for 'READY'", string(connectionState))
-			return false, nil
-		}
-
-		// Check if registry pod is running and ready
-		podName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-n", catalogNamespace,
-			"-l", "olm.catalogSource="+catalogSourceName,
-			"-o=jsonpath={.items[0].metadata.name}").Output()
-		if err != nil || len(podName) == 0 {
-			e2e.Logf("Registry pod not found yet: %v", err)
-			return false, nil
-		}
-
-		// Check pod ready condition
-		podReady, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", string(podName), "-n", catalogNamespace,
-			"-o=jsonpath={.status.conditions[?(@.type=='Ready')].status}").Output()
-		if err != nil {
-			e2e.Logf("Failed to get pod ready status: %v", err)
-			return false, nil
-		}
-
-		if string(podReady) != "True" {
-			e2e.Logf("Registry pod '%s' is not ready yet: %s", string(podName), string(podReady))
-			return false, nil
-		}
-		e2e.Logf("CatalogSource '%s' is ready with pod '%s'", catalogSourceName, string(podName))
-		return true, nil
-	})
-}
-
-func getOperatorCatalogSource(oc *exutil.CLI, catalog string, namespace string) string {
-	if isBaselineCapsSet(oc) && !(isEnabledCapability(oc, "OperatorLifecycleManager")) {
-		g.Skip("Skipping the test as baselinecaps have been set and OperatorLifecycleManager capability is not enabled!")
-	}
-	catalogSourceNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("catalogsource", "-n", namespace, "-o=jsonpath={.items[*].metadata.name}").Output()
-	o.Expect(err).NotTo(o.HaveOccurred())
-	if strings.Contains(catalogSourceNames, catalog) {
-		return catalog
-	}
-	return ""
-}
-
-func getImageDigestMirrorSet(oc *exutil.CLI, imagedigestmirrorsetname string) string {
-	imageDigestMirrorSetNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("imagedigestmirrorset", "-o=jsonpath={.items[*].metadata.name}").Output()
-	o.Expect(err).NotTo(o.HaveOccurred())
-	if strings.Contains(imageDigestMirrorSetNames, imagedigestmirrorsetname) {
-		return imagedigestmirrorsetname
-	}
-	return ""
-}
-
-func installNMstateOperator(oc *exutil.CLI) {
-	var (
-		opNamespace              = "openshift-nmstate"
-		opName                   = "kubernetes-nmstate-operator"
-		catalogNamespace         = "openshift-marketplace"
-		catalogSourceName        = "kubernetes-nmstate-operator-fbc-catalog"
-		imageDigestMirrorSetName = "kubernetes-nmstate-images-mirror-set"
-	)
-
-	e2e.Logf("Check catalogsource and install nmstate operator.")
-	namespaceTemplate := generateTemplateAbsolutePath("namespace-template.yaml")
-	operatorGroupTemplate := generateTemplateAbsolutePath("operatorgroup-template.yaml")
-	subscriptionTemplate := generateTemplateAbsolutePath("subscription-template.yaml")
-	catalogSourceTemplate := generateTemplateAbsolutePath("catalogsource-template.yaml")
-	imageDigestMirrorSetFile := generateTemplateAbsolutePath("image-digest-mirrorset.yaml")
-	sub := subscriptionResource{
-		name:             "nmstate-operator-sub",
-		namespace:        opNamespace,
-		operatorName:     opName,
-		channel:          "stable",
-		catalog:          catalogSourceName,
-		catalogNamespace: catalogNamespace,
-		template:         subscriptionTemplate,
-	}
-	compat_otp.By("Check the image digest mirror set and catalog source")
-	imageDigestMirrorSet := getImageDigestMirrorSet(oc, imageDigestMirrorSetName)
-	if imageDigestMirrorSet == "" {
-		compat_otp.By("Creating image digest mirror set")
-		o.Expect(createImageDigestMirrorSet(oc, imageDigestMirrorSetName, imageDigestMirrorSetFile)).NotTo(o.HaveOccurred())
-	}
-	catalogSource := getOperatorCatalogSource(oc, catalogSourceName, catalogNamespace)
-	if catalogSource == "" {
-		compat_otp.By("Creating catalog source")
-		o.Expect(createCatalogSource(oc, "kubernetes-nmstate", catalogSourceName, catalogNamespace, catalogSourceTemplate)).NotTo(o.HaveOccurred())
-	}
-	//sub.catalog = catalogSource
-	ns := OperatorNamespace{
-		Name:              opNamespace,
-		NamespaceTemplate: namespaceTemplate,
-	}
-	og := operatorGroupResource{
-		name:             opName,
-		namespace:        opNamespace,
-		targetNamespaces: opNamespace,
-		template:         operatorGroupTemplate,
-	}
-
-	operatorInstall(oc, sub, ns, og)
-	e2e.Logf("SUCCESS - NMState operator installed")
-}
-
 // setupCatalogSource deploys the catalog source and image digest mirror set
-func setupCatalogSource(oc *exutil.CLI, catSrc Resource, catSrcTemplate, imageDigest, catalogSource string, isHypershift bool, NOSource *CatalogSourceObjects, NO *SubscriptionObjects) (bool, error) {
+func setupCatalogSource(oc *exutil.CLI, catSrc Resource, catSrcTemplate, imageDigest, catalogSource string, isHypershift bool, NOSource *CatalogSourceObjects, NO *SubscriptionObjects) error {
 	g.By("Deploy konflux FBC and ImageDigestMirrorSet")
 	upstreamCatalogSource := "quay.io/netobserv/network-observability-operator-catalog:v0.0.0-sha-main"
-	deployedUpstreamCatalogSource := false
 	var catsrcErr error
 
 	if catalogSource != "" {
@@ -520,7 +278,6 @@ func setupCatalogSource(oc *exutil.CLI, catSrc Resource, catSrcTemplate, imageDi
 		catsrcErr = catSrc.applyFromTemplate(oc, "-n", catSrc.Namespace, "-f", catSrcTemplate, "-p", "NAMESPACE="+catSrc.Namespace, "IMAGE="+upstreamCatalogSource)
 		NOSource.Channel = "latest"
 		NO.CatalogSource = NOSource
-		deployedUpstreamCatalogSource = true
 	} else {
 		e2e.Logf("Using default ystream catalog")
 		catsrcErr = catSrc.applyFromTemplate(oc, "-n", catSrc.Namespace, "-f", catSrcTemplate, "-p", "NAMESPACE="+catSrc.Namespace)
@@ -530,7 +287,7 @@ func setupCatalogSource(oc *exutil.CLI, catSrc Resource, catSrcTemplate, imageDi
 	if !isHypershift {
 		ApplyResourceFromFile(oc, catSrc.Namespace, imageDigest)
 	}
-	return deployedUpstreamCatalogSource, catsrcErr
+	return catsrcErr
 }
 
 // ensureOperatorDeployed checks and deploys an operator if not already present
@@ -560,7 +317,7 @@ func ensureOperatorDeployed(oc *exutil.CLI, operator SubscriptionObjects, operat
 }
 
 // ensureNetObservOperatorDeployed checks and deploys the NetObserv operator with specific configurations
-func ensureNetObservOperatorDeployed(oc *exutil.CLI, NO SubscriptionObjects, NOSource CatalogSourceObjects, deployedUpstreamCatalogSource bool) {
+func ensureNetObservOperatorDeployed(oc *exutil.CLI, NO SubscriptionObjects, NOSource CatalogSourceObjects) {
 	ensureOperatorDeployed(oc, NO, NOSource, "app="+NO.OperatorName)
 
 	// NetObserv-specific checks only if operator was just deployed
@@ -572,13 +329,6 @@ func ensureNetObservOperatorDeployed(oc *exutil.CLI, NO SubscriptionObjects, NOS
 		flowcollectorAPIExists, err := isFlowCollectorAPIExists(oc)
 		o.Expect(flowcollectorAPIExists).To(o.BeTrue())
 		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// Patch upstream catalog source if needed
-		if deployedUpstreamCatalogSource {
-			_, err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("csv", "netobserv-operator.v0.0.0-sha-main", "-n", NO.Namespace,
-				"--type=json", "--patch", "[{\"op\": \"replace\",\"path\": \"/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/4/value\", \"value\": \"true\"}]").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-		}
 	}
 }
 

--- a/integration-tests/backend/suite_vars.go
+++ b/integration-tests/backend/suite_vars.go
@@ -1,0 +1,35 @@
+package e2etests
+
+import (
+	"os"
+	filePath "path/filepath"
+)
+
+var (
+	// NetObserv Operator variables
+	NOcatSrc = Resource{"catsrc", "netobserv-konflux-fbc", netobservNS}
+	NOSource = CatalogSourceObjects{"stable", NOcatSrc.Name, NOcatSrc.Namespace}
+
+	// Template directories
+	baseDir, _      = filePath.Abs("testdata")
+	subscriptionDir = filePath.Join(baseDir, "subscription")
+	flowFixturePath = filePath.Join(baseDir, "flowcollector_v1beta2_template.yaml")
+
+	// Operator namespace object
+	OperatorNS = OperatorNamespace{
+		Name:              netobservNS,
+		NamespaceTemplate: filePath.Join(subscriptionDir, "namespace.yaml"),
+	}
+	NO = SubscriptionObjects{
+		OperatorName:  "netobserv-operator",
+		Namespace:     netobservNS,
+		PackageName:   NOPackageName,
+		Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
+		OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
+		CatalogSource: &NOSource,
+	}
+
+	imageDigest    = filePath.Join(subscriptionDir, "image-digest-mirror-set.yaml")
+	catSrcTemplate = filePath.Join(subscriptionDir, "catalog-source.yaml")
+	catalogSource  = os.Getenv("MULTISTAGE_PARAM_OVERRIDE_NETOBSERV_CS_IMAGE")
+)

--- a/integration-tests/backend/test_exporters.go
+++ b/integration-tests/backend/test_exporters.go
@@ -3,7 +3,6 @@ package e2etests
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"strconv"
 
@@ -21,31 +20,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc = compat_otp.NewCLI("netobserv", compat_otp.KubeConfigPath())
-		// NetObserv Operator variables
-		NOcatSrc = Resource{"catsrc", "netobserv-konflux-fbc", netobservNS}
-		NOSource = CatalogSourceObjects{"stable", NOcatSrc.Name, NOcatSrc.Namespace}
-
-		// Template directories
-		baseDir, _      = filePath.Abs("testdata")
-		subscriptionDir = filePath.Join(baseDir, "subscription")
-		flowFixturePath = filePath.Join(baseDir, "flowcollector_v1beta2_template.yaml")
-
-		// Operator namespace object
-		OperatorNS = OperatorNamespace{
-			Name:              netobservNS,
-			NamespaceTemplate: filePath.Join(subscriptionDir, "namespace.yaml"),
-		}
-		NO = SubscriptionObjects{
-			OperatorName:  "netobserv-operator",
-			Namespace:     netobservNS,
-			PackageName:   NOPackageName,
-			Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
-			OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
-			CatalogSource: &NOSource,
-		}
-		imageDigest    = filePath.Join(subscriptionDir, "image-digest-mirror-set.yaml")
-		catSrcTemplate = filePath.Join(subscriptionDir, "catalog-source.yaml")
-		catalogSource  = os.Getenv("MULTISTAGE_PARAM_OVERRIDE_NETOBSERV_CS_IMAGE")
 
 		OtelNS = OperatorNamespace{
 			Name:              "openshift-opentelemetry-operator",
@@ -67,19 +41,9 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 
 	g.BeforeEach(func() {
 		namespace = oc.Namespace()
-
-		if strings.Contains(os.Getenv("E2E_RUN_TAGS"), "disconnected") {
-			g.Skip("Skipping tests for disconnected profiles")
-		}
-
-		OperatorNS.DeployOperatorNamespace(oc)
-		deployedUpstreamCatalogSource, catSrcErr := setupCatalogSource(oc, NOcatSrc, catSrcTemplate, imageDigest, catalogSource, false, &NOSource, &NO)
-		o.Expect(catSrcErr).NotTo(o.HaveOccurred())
-		ensureNetObservOperatorDeployed(oc, NO, NOSource, deployedUpstreamCatalogSource)
 	})
 
 	g.It("Author:aramesha-High-64156-Verify IPFIX-exporter [Serial]", func() {
-		SkipIfOCPBelow("v4.10")
 		clusterArch, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-o=jsonpath={.items[0].status.nodeInfo.architecture}").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if !strings.Contains(clusterArch, "amd64") {
@@ -120,7 +84,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			Namespace:                         namespace,
 			Template:                          flowFixturePath,
 			LokiEnable:                        "false",
-			LokiNamespace:                     namespace,
+			InstallDemoLoki:                   "false",
 			Exporters:                         []string{IPFIXexporter},
 			NetworkPolicyAdditionalNamespaces: []string{additionalNamespaces},
 			Sampling:                          strconv.Itoa(samplingValue),
@@ -159,7 +123,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 	})
 
 	g.It("Author:memodi-High-74977-Verify OTEL exporter with TLS [Serial]", func() {
-		SkipIfOCPBelow("v4.13")
 		// don't delete the OTEL Operator at the end of the test
 		g.By("Subscribe to OTEL Operator")
 		OtelNS.DeployOperatorNamespace(oc)
@@ -213,11 +176,11 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 
 		g.By("Deploy FlowCollector with OTEL TLS exporter and Loki disabled")
 		flow := Flowcollector{
-			Namespace:     namespace,
-			Template:      flowFixturePath,
-			LokiEnable:    "false",
-			LokiNamespace: namespace,
-			Exporters:     []string{config_str},
+			Namespace:       namespace,
+			Template:        flowFixturePath,
+			LokiEnable:      "false",
+			InstallDemoLoki: "false",
+			Exporters:       []string{config_str},
 		}
 
 		defer func() { _ = flow.DeleteFlowcollector(oc) }()

--- a/integration-tests/backend/test_flow_multitenancy.go
+++ b/integration-tests/backend/test_flow_multitenancy.go
@@ -1,0 +1,518 @@
+package e2etests
+
+import (
+	"fmt"
+	"os"
+	filePath "path/filepath"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[sig-netobserv] Network_Observability Multitenancy", g.Ordered, g.ContinueOnFailure, func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc = compat_otp.NewCLI("netobserv", compat_otp.KubeConfigPath())
+
+		kubeadminToken string
+		namespace      string
+
+		// Loki Operator variables
+		lokiDir         = filePath.Join(baseDir, "loki")
+		lokiPackageName = "loki-operator"
+		lokiCatalog     = "redhat-operators"
+		lokiSource      CatalogSourceObjects
+		ls              *lokiStack
+		Lokiexisting    = false
+		lokiStackNS     = "netobserv-loki"
+		LO              = SubscriptionObjects{
+			OperatorName:  "loki-operator-controller-manager",
+			Namespace:     loNS,
+			PackageName:   lokiPackageName,
+			Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
+			OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
+			CatalogSource: &lokiSource,
+		}
+
+		// LokiStack variables
+		ipStackType       string
+		lokiStackTemplate = filePath.Join(lokiDir, "lokistack-simple.yaml")
+		lokiTenant        = "openshift-network"
+
+		// For FlowCollectorSlice tests
+		flowSliceFixturePath = filePath.Join(baseDir, "flowcollectorSlice_v1alpha1_template.yaml")
+	)
+
+	g.BeforeAll(func() {
+		oc.SetNamespace(netobservNS)
+		namespace = oc.Namespace()
+
+		g.By("Get kubeadmin token")
+		kubeAdminPasswd := os.Getenv("QE_KUBEADMIN_PASSWORD")
+		if kubeAdminPasswd == "" {
+			g.Skip("no kubeAdminPasswd is provided in this profile, set QE_KUBEADMIN_PASSWORD env var")
+		}
+		serverURL, serverURLErr := oc.AsAdmin().WithoutNamespace().Run("whoami").Args("--show-server").Output()
+		o.Expect(serverURLErr).NotTo(o.HaveOccurred())
+		currentContext, currentContextErr := oc.WithoutNamespace().Run("config").Args("current-context").Output()
+		o.Expect(currentContextErr).NotTo(o.HaveOccurred())
+		kubeadminToken = getKubeAdminToken(oc, kubeAdminPasswd, serverURL, currentContext)
+		o.Expect(kubeadminToken).NotTo(o.BeEmpty())
+
+		ipStackType = checkIPStackType(oc)
+
+		g.By("Deploy loki operator")
+		if !validateInfraAndResourcesForLoki(oc, "10Gi", "6") {
+			g.Skip("Current platform does not have enough resources available for this test!")
+		}
+
+		// check if Loki Operator exists
+		var err error
+		Lokiexisting, err = CheckOperatorStatus(oc, LO.Namespace, LO.PackageName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		lokiChannel, err := getOperatorChannel(oc, lokiCatalog, lokiPackageName)
+		if err != nil || lokiChannel == "" {
+			g.Skip("Loki channel not found, skip this case")
+		}
+		lokiSource = CatalogSourceObjects{lokiChannel, lokiCatalog, "openshift-marketplace"}
+
+		if !Lokiexisting {
+			ensureOperatorDeployed(oc, LO, lokiSource, "name="+LO.OperatorName)
+		} else {
+			channelName, err := checkOperatorChannel(oc, LO.Namespace, LO.PackageName)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if channelName != lokiChannel {
+				e2e.Logf("found %s channel for loki operator, removing and reinstalling with %s channel instead", channelName, lokiSource.Channel)
+				LO.uninstallOperator(oc)
+				ensureOperatorDeployed(oc, LO, lokiSource, "name="+LO.OperatorName)
+				Lokiexisting = false
+			}
+		}
+
+		g.By("Deploy lokiStack")
+		sc, err := getStorageClassName(oc)
+		if err != nil || len(sc) == 0 {
+			g.Skip("StorageClass not found in cluster, skip this case")
+		}
+
+		objectStorageType := getStorageType(oc)
+		if len(objectStorageType) == 0 && ipStackType != "ipv6single" {
+			g.Skip("Current cluster doesn't have a proper object storage for this test!")
+		}
+
+		oc.CreateSpecifiedNamespaceAsAdmin(lokiStackNS)
+
+		ls = &lokiStack{
+			Name:          "lokistack",
+			Namespace:     lokiStackNS,
+			TSize:         "1x.demo",
+			StorageType:   objectStorageType,
+			StorageSecret: "objectstore-secret",
+			StorageClass:  sc,
+			BucketName:    "netobserv-loki-" + getInfrastructureName(oc),
+			Tenant:        lokiTenant,
+			Template:      lokiStackTemplate,
+		}
+
+		if ipStackType == "ipv6single" {
+			e2e.Logf("running IPv6 test")
+			ls.EnableIPV6 = "true"
+		}
+
+		err = ls.prepareResourcesForLokiStack(oc)
+		if err != nil {
+			g.Skip("Skipping test since LokiStack resources were not deployed")
+		}
+
+		err = ls.deployLokiStack(oc)
+		if err != nil {
+			g.Skip("Skipping test since LokiStack was not deployed")
+		}
+
+		lokiStackResource := Resource{"lokistack", ls.Name, ls.Namespace}
+		err = lokiStackResource.WaitForResourceToAppear(oc)
+		if err != nil {
+			g.Skip("Skipping test since LokiStack did not become ready")
+		}
+
+		err = ls.waitForLokiStackToBeReady(oc)
+		if err != nil {
+			g.Skip("Skipping test since LokiStack is not ready")
+		}
+		ls.Route = "https://" + getRouteAddress(oc, ls.Namespace, ls.Name)
+	})
+
+	g.AfterAll(func() {
+		if ls != nil {
+			ls.removeLokiStack(oc)
+			ls.removeObjectStorage(oc)
+		}
+		oc.DeleteSpecifiedNamespaceAsAdmin(lokiStackNS)
+		if !Lokiexisting {
+			LO.uninstallOperator(oc)
+		}
+	})
+
+	g.BeforeEach(func() {
+		namespace = oc.Namespace()
+	})
+
+	g.It("Author:memodi-NonPreRelease-Longduration-High-63839-Verify-multi-tenancy [Disruptive][Slow]", func() {
+		users, usersHTpassFile, htPassSecret := getNewUser(oc, 2)
+		defer userCleanup(oc, users, usersHTpassFile, htPassSecret)
+
+		g.By("Creating client server template and template CRBs for testusers")
+		// create templates for testuser to be used later
+		testUserstemplate := filePath.Join(baseDir, "testuser-client-server_template.yaml")
+		stdout, stderr, err := oc.AsAdmin().Run("apply").Args("-f", testUserstemplate).Outputs()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(stderr).To(o.BeEmpty())
+		templateResource := strings.Split(stdout, " ")[0]
+		templateName := strings.Split(templateResource, "/")[1]
+		defer removeTemplatePermissions(oc, users[0].Username)
+		addTemplatePermissions(oc, users[0].Username)
+
+		g.By("Deploy FlowCollector")
+		flow := Flowcollector{
+			Namespace:       namespace,
+			Template:        flowFixturePath,
+			LokiMode:        "LokiStack",
+			LokiNamespace:   lokiStackNS,
+			InstallDemoLoki: "false",
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Deploying test server and client pods")
+		serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
+		testServerTemplate := TestServerTemplate{
+			ServerNS: "test-server-63839",
+			Template: serverTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
+		err = testServerTemplate.createServer(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
+
+		clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
+
+		testClientTemplate := TestClientTemplate{
+			ServerNS: testServerTemplate.ServerNS,
+			ClientNS: "test-client-63839",
+			Template: clientTemplate,
+		}
+
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
+		err = testClientTemplate.createClient(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
+
+		// save original context
+		origContxt, contxtErr := oc.AsAdmin().WithoutNamespace().Run("config").Args("current-context").Output()
+		o.Expect(contxtErr).NotTo(o.HaveOccurred())
+		e2e.Logf("orginal context is %v", origContxt)
+		defer removeUserAsReader(oc, users[0].Username)
+		addUserAsReader(oc, users[0].Username)
+		origUser := oc.Username()
+
+		e2e.Logf("current user is %s", origUser)
+		defer func() { _ = oc.AsAdmin().WithoutNamespace().Run("config").Args("use-context", origContxt).Execute() }()
+		defer oc.ChangeUser(origUser)
+		oc.ChangeUser(users[0].Username)
+
+		curUser := oc.Username()
+		e2e.Logf("current user is %s", curUser)
+
+		o.Expect(err).NotTo(o.HaveOccurred())
+		user0Contxt, contxtErr := oc.WithoutNamespace().Run("config").Args("current-context").Output()
+		o.Expect(contxtErr).NotTo(o.HaveOccurred())
+
+		e2e.Logf("user0 context is %v", user0Contxt)
+
+		g.By("Deploying test server and client pods as user0")
+		var (
+			testUserServerNS = fmt.Sprintf("%s-server", users[0].Username)
+			testUserClientNS = fmt.Sprintf("%s-client", users[0].Username)
+		)
+
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testUserClientNS)
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testUserServerNS)
+		configFile := compat_otp.ProcessTemplate(oc, "--ignore-unknown-parameters=true", templateName, "-p", "SERVER_NS="+testUserServerNS, "-p", "CLIENT_NS="+testUserClientNS)
+		err = oc.WithoutNamespace().Run("create").Args("-f", configFile).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// only required to getFlowLogs
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: testUserServerNS,
+			DstK8SNamespace: testUserClientNS,
+			SrcK8SOwnerName: "nginx-service",
+			FlowDirection:   "0",
+		}
+
+		user0token, err := oc.WithoutNamespace().Run("whoami").Args("-t").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Wait for a min before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(60 * time.Second)
+
+		g.By("get flowlogs from loki")
+		flowRecords, err := lokilabels.getLokiFlowLogs(user0token, ls.Route, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords > 0")
+
+		g.By("verify no logs are fetched from an NS that user is not admin for")
+		lokilabels = Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: testClientTemplate.ServerNS,
+			DstK8SNamespace: testClientTemplate.ClientNS,
+			SrcK8SOwnerName: "nginx-service",
+			FlowDirection:   "0",
+			AllowEmpty:      true,
+		}
+		flowRecords, err = lokilabels.getLokiFlowLogs(user0token, ls.Route, startTime)
+		// Multi-tenancy verification: Loki Gateway returns permission errors for unauthorized namespace access
+		if err != nil {
+			o.Expect(err.Error()).To(o.ContainSubstring("permission"), "expected permission error for unauthorized namespace access, got: %v", err)
+		} else {
+			o.Expect(len(flowRecords)).To(o.Equal(0), "expected zero flowRecords for unauthorized namespace access")
+		}
+	})
+
+	g.It("Author:aramesha-NonPreRelease-Longduration-High-87145-Verify FlowCollectorSlices multi-tenancy [Disruptive][Slow]", func() {
+		g.By("Creating test users")
+		users, usersHTpassFile, htPassSecret := getNewUser(oc, 1)
+		defer userCleanup(oc, users, usersHTpassFile, htPassSecret)
+
+		g.By("Deploy FlowCollector with Slices enabled")
+		flow := Flowcollector{
+			Namespace:       namespace,
+			LokiMode:        "LokiStack",
+			LokiNamespace:   lokiStackNS,
+			InstallDemoLoki: "false",
+			CollectionMode:  "AllowList",
+			SlicesEnable:    "true",
+			NamespacesAllow: []string{"\"/openshift-.*/\""},
+			Template:        flowFixturePath,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Verify FlowCollectorSlices ClusterRoles exist")
+		clusterRoleOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterrole", "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(clusterRoleOutput).Should(o.ContainSubstring("flowcollectorslices.flows.netobserv.io-v1alpha1-admin"))
+		o.Expect(clusterRoleOutput).Should(o.ContainSubstring("flowcollectorslices.flows.netobserv.io-v1alpha1-edit"))
+		o.Expect(clusterRoleOutput).Should(o.ContainSubstring("flowcollectorslices.flows.netobserv.io-v1alpha1-view"))
+
+		g.By("Deploy test server and client pods for test-a namespace")
+		serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
+		testServerTemplateA := TestServerTemplate{
+			ServerNS: "test-a-server-87145",
+			Template: serverTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplateA.ServerNS)
+		err = testServerTemplateA.createServer(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testServerTemplateA.ServerNS)
+
+		clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
+		testClientTemplateA := TestClientTemplate{
+			ServerNS: testServerTemplateA.ServerNS,
+			ClientNS: "test-a-client-87145",
+			Template: clientTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplateA.ClientNS)
+		err = testClientTemplateA.createClient(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testClientTemplateA.ClientNS)
+
+		// Save original context
+		origContxt, contxtErr := oc.AsAdmin().WithoutNamespace().Run("config").Args("current-context").Output()
+		o.Expect(contxtErr).NotTo(o.HaveOccurred())
+		e2e.Logf("original context is %v", origContxt)
+		defer func() { _ = oc.AsAdmin().WithoutNamespace().Run("config").Args("use-context", origContxt).Execute() }()
+
+		origUser := oc.Username()
+		e2e.Logf("original user is %s", origUser)
+		defer oc.ChangeUser(origUser)
+
+		testUserName := users[0].Username
+		oc.ChangeUser(testUserName)
+		e2e.Logf("switched to user: %s", testUserName)
+
+		g.By("Create namespace test-a and grant testuser-0 admin permissions")
+		testNSA := testClientTemplateA.ClientNS
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("rolebinding", "testuser-0-admin",
+			"--clusterrole=flowcollectorslices.flows.netobserv.io-v1alpha1-admin",
+			"--user="+testUserName, "-n", testNSA).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Grant testuser admin access to the server namespace as well for flow visibility
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("rolebinding", "testuser-0-admin-server",
+			"--clusterrole=admin",
+			"--user="+testUserName, "-n", testServerTemplateA.ServerNS).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Grant testuser admin access to client namespace
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("rolebinding", "testuser-0-admin-client",
+			"--clusterrole=admin",
+			"--user="+testUserName, "-n", testNSA).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Grant loki reader access for multi-tenancy
+		defer removeUserAsReader(oc, testUserName)
+		addUserAsReader(oc, testUserName)
+
+		g.By("Verify testuser-0 can create flowcollectorslices in test-a")
+		canCreate, err := oc.WithoutNamespace().Run("auth").Args("can-i", "create", "flowcollectorslices", "-n", testNSA).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(canCreate).Should(o.ContainSubstring("yes"))
+
+		g.By("Create a FlowCollectorSlice in test-a namespace")
+		flowSliceA := FlowcollectorSlice{
+			Name:      "test-a-slice",
+			Namespace: testNSA,
+			Sampling:  "100",
+			Template:  flowSliceFixturePath,
+		}
+		defer func() { _ = flowSliceA.DeleteFlowcollectorSlice(oc) }()
+		flowSliceA.CreateFlowcollectorSlice(oc)
+		flowSliceA.WaitForFlowcollectorSliceReady(oc)
+
+		g.By("Verify testuser-0 can view the FlowCollectorSlice in test-a")
+		sliceOutput, err := oc.WithoutNamespace().Run("get").Args("flowcollectorslice", "-n", testNSA, "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sliceOutput).Should(o.ContainSubstring("test-a-slice"))
+
+		// Verify sampling value
+		samplingValue, err := oc.WithoutNamespace().Run("get").Args("flowcollectorslice", "test-a-slice", "-n", testNSA, "-o=jsonpath={.spec.sampling}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(samplingValue).Should(o.Equal("100"))
+
+		g.By("Verify testuser-0 can update the FlowCollectorSlice in test-a")
+		err = oc.WithoutNamespace().Run("patch").Args("flowcollectorslice", "test-a-slice", "-n", testNSA,
+			"--type=merge", "-p={\"spec\":{\"sampling\":2}}").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Verify sampling was updated
+		samplingValue, err = oc.WithoutNamespace().Run("get").Args("flowcollectorslice", "test-a-slice", "-n", testNSA, "-o=jsonpath={.spec.sampling}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(samplingValue).Should(o.Equal("2"))
+
+		g.By("Get testuser token for loki query")
+		user0token, err := oc.WithoutNamespace().Run("whoami").Args("-t").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Wait for flows to be collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(60 * time.Second)
+
+		g.By("Verify testuser-0 can access flows from test-a namespace")
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: testServerTemplateA.ServerNS,
+			DstK8SNamespace: testNSA,
+			SrcK8SOwnerName: "nginx-service",
+			FlowDirection:   "0",
+		}
+		flowRecords, err := lokilabels.getLokiFlowLogs(user0token, ls.Route, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected testuser to see flows from test-a namespace")
+
+		g.By("Create namespace test-b and create a FlowCollectorSlice as kubeadmin")
+		testServerTemplateB := TestServerTemplate{
+			ServerNS: "test-b-server-87145",
+			Template: serverTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplateB.ServerNS)
+
+		testClientTemplateB := TestClientTemplate{
+			ServerNS: testServerTemplateB.ServerNS,
+			ClientNS: "test-b-client-87145",
+			Template: clientTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplateB.ClientNS)
+
+		// Switch to admin to create test-b resources
+		oc.ChangeUser(origUser)
+		err = testServerTemplateB.createServer(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testServerTemplateB.ServerNS)
+
+		err = testClientTemplateB.createClient(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testClientTemplateB.ClientNS)
+
+		testNSB := testClientTemplateB.ClientNS
+		flowSliceB := FlowcollectorSlice{
+			Name:      "test-b-slice",
+			Namespace: testNSB,
+			Sampling:  "3",
+			Template:  flowSliceFixturePath,
+		}
+		defer func() { _ = flowSliceB.DeleteFlowcollectorSlice(oc) }()
+		flowSliceB.CreateFlowcollectorSlice(oc)
+		flowSliceB.WaitForFlowcollectorSliceReady(oc)
+
+		// Switch back to testuser
+		oc.ChangeUser(testUserName)
+
+		g.By("Verify testuser-0 cannot see test-b slice")
+		sliceOutputB, err := oc.WithoutNamespace().Run("get").Args("flowcollectorslice", "-n", testNSB).Output()
+		o.Expect(err).Should(o.HaveOccurred())
+		o.Expect(sliceOutputB).Should(o.MatchRegexp(`User ".*" cannot list resource "flowcollectorslices"`))
+
+		g.By("Verify testuser-0 cannot access flows from test-b namespace")
+		lokilabels = Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: testServerTemplateB.ServerNS,
+			DstK8SNamespace: testNSB,
+			SrcK8SOwnerName: "nginx-service",
+			FlowDirection:   "0",
+			AllowEmpty:      true,
+		}
+		flowRecords, err = lokilabels.getLokiFlowLogs(user0token, ls.Route, startTime)
+		// Multi-tenancy verification: Loki Gateway returns permission errors for unauthorized namespace access
+		if err != nil {
+			o.Expect(err.Error()).Should(o.ContainSubstring("permission"), "expected permission error for unauthorized namespace access, got: %v", err)
+		} else {
+			o.Expect(len(flowRecords)).Should(o.BeNumerically("==", 0), "expected testuser to NOT see flows from test-b namespace")
+		}
+
+		g.By("Add testuser-0 as viewer for test-b namespace")
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("rolebinding", "testuser-0-view",
+			"--clusterrole=flowcollectorslices.flows.netobserv.io-v1alpha1-view",
+			"--user="+testUserName, "-n", testNSB).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Verify testuser-0 can view FlowCollectorSlice in test-b")
+		sliceOutput, err = oc.WithoutNamespace().Run("get").Args("flowcollectorslice", "-n", testNSB, "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sliceOutput).Should(o.ContainSubstring("test-b-slice"))
+
+		g.By("Verify testuser-0 cannot update FlowCollectorSlice in test-b (view-only)")
+		patchOutput, err := oc.WithoutNamespace().Run("patch").Args("flowcollectorslice", "test-b-slice", "-n", testNSB,
+			"--type=merge", "-p={\"spec\":{\"sampling\":25}}").Output()
+		o.Expect(err).Should(o.HaveOccurred())
+		o.Expect(patchOutput).Should(o.MatchRegexp(`User ".*" cannot patch resource "flowcollectorslices"`))
+
+		g.By("Remove testuser-0's view access from test-b")
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("rolebinding", "testuser-0-view", "-n", testNSB).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Verify access to test-b FlowCollectorSlices is revoked")
+		sliceOutputRevoked, err := oc.WithoutNamespace().Run("get").Args("flowcollectorslice", "-n", testNSB).Output()
+		o.Expect(err).Should(o.HaveOccurred())
+		o.Expect(sliceOutputRevoked).Should(o.MatchRegexp(`User ".*" cannot list resource "flowcollectorslices"`))
+	})
+})

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -22,78 +22,26 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 
 	defer g.GinkgoRecover()
 	var (
-		oc = compat_otp.NewCLI("netobserv", compat_otp.KubeConfigPath())
-		// NetObserv Operator variables
-		NOcatSrc = Resource{"catsrc", "netobserv-konflux-fbc", netobservNS}
-		NOSource = CatalogSourceObjects{"stable", NOcatSrc.Name, NOcatSrc.Namespace}
-
-		// Template directories
-		baseDir, _      = filePath.Abs("testdata")
-		networkingDir   = filePath.Join(baseDir, "networking")
-		subscriptionDir = filePath.Join(baseDir, "subscription")
-		flowFixturePath = filePath.Join(baseDir, "flowcollector_v1beta2_template.yaml")
-
-		// Operator namespace object
-		OperatorNS = OperatorNamespace{
-			Name:              netobservNS,
-			NamespaceTemplate: filePath.Join(subscriptionDir, "namespace.yaml"),
-		}
-		NO = SubscriptionObjects{
-			OperatorName:  "netobserv-operator",
-			Namespace:     netobservNS,
-			PackageName:   NOPackageName,
-			Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
-			OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
-			CatalogSource: &NOSource,
-		}
-		imageDigest    = filePath.Join(subscriptionDir, "image-digest-mirror-set.yaml")
-		catSrcTemplate = filePath.Join(subscriptionDir, "catalog-source.yaml")
-		catalogSource  = os.Getenv("MULTISTAGE_PARAM_OVERRIDE_NETOBSERV_CS_IMAGE")
-
-		kubeadminToken string
-		namespace      string
+		oc            = compat_otp.NewCLI("netobserv", compat_otp.KubeConfigPath())
+		networkingDir = filePath.Join(baseDir, "networking")
+		namespace     string
+		ipStackType   string
 	)
 
 	g.BeforeEach(func() {
-		if strings.Contains(os.Getenv("E2E_RUN_TAGS"), "disconnected") {
-			g.Skip("Skipping tests for disconnected profiles")
-		}
 		namespace = oc.Namespace()
-
-		g.By("Get kubeadmin token")
-		kubeAdminPasswd := os.Getenv("QE_KUBEADMIN_PASSWORD")
-		if kubeAdminPasswd == "" {
-			g.Skip("no kubeAdminPasswd is provided in this profile, set QE_KUBEADMIN_PASSWORD env var")
-		}
-		serverURL, serverURLErr := oc.AsAdmin().WithoutNamespace().Run("whoami").Args("--show-server").Output()
-		o.Expect(serverURLErr).NotTo(o.HaveOccurred())
-		currentContext, currentContextErr := oc.WithoutNamespace().Run("config").Args("current-context").Output()
-		o.Expect(currentContextErr).NotTo(o.HaveOccurred())
-		defer func() {
-			rollbackCtxErr := oc.WithoutNamespace().Run("config").Args("set", "current-context", currentContext).Execute()
-			o.Expect(rollbackCtxErr).NotTo(o.HaveOccurred())
-		}()
-
-		kubeadminToken = getKubeAdminToken(oc, kubeAdminPasswd, serverURL, currentContext)
-		o.Expect(kubeadminToken).NotTo(o.BeEmpty())
-
-		isHypershift := compat_otp.IsHypershiftHostedCluster(oc)
-
-		OperatorNS.DeployOperatorNamespace(oc)
-		deployedUpstreamCatalogSource, catSrcErr := setupCatalogSource(oc, NOcatSrc, catSrcTemplate, imageDigest, catalogSource, isHypershift, &NOSource, &NO)
-		o.Expect(catSrcErr).NotTo(o.HaveOccurred())
-		ensureNetObservOperatorDeployed(oc, NO, NOSource, deployedUpstreamCatalogSource)
+		ipStackType = checkIPStackType(oc)
 	})
 
 	g.It("Author:memodi-NonPreRelease-Longduration-Medium-60664-Medium-61482-Alerts-with-NetObserv [Serial][Slow]", func() {
-		SkipIfOCPBelow("v4.10")
 		flpAlertRuleName := "flowlogs-pipeline-alert"
 		ebpfAlertRuleName := "ebpf-agent-prom-alert"
 
 		flow := Flowcollector{
-			Namespace:  namespace,
-			Template:   flowFixturePath,
-			LokiEnable: "false",
+			Namespace:       namespace,
+			Template:        flowFixturePath,
+			LokiEnable:      "false",
+			InstallDemoLoki: "false",
 		}
 		defer func() { _ = flow.DeleteFlowcollector(oc) }()
 		flow.CreateFlowcollector(oc)
@@ -142,33 +90,33 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		g.By("delete flowcollector")
 		_ = flow.DeleteFlowcollector(oc)
 
-		// verify alert firing.
+		// verify alert becomes pending.
 		// configure flowcollector with incorrect loki URL
-		// configure very low CacheMaxFlows to have ebpf alert fired.
+		// configure very low CacheMaxFlows to have ebpf alert triggered.
 		flow = Flowcollector{
-			Namespace:         namespace,
-			Template:          flowFixturePath,
-			CacheMaxFlows:     "100",
-			LokiMode:          "Monolithic",
-			MonolithicLokiURL: "http://loki.no-ns.svc:3100",
+			Namespace:       namespace,
+			Template:        flowFixturePath,
+			CacheMaxFlows:   "100",
+			LokiEnable:      "true",
+			InstallDemoLoki: "false",
 		}
 		g.By("Deploy flowcollector with incorrect loki URL and lower cacheMaxFlows value")
 		flow.CreateFlowcollector(oc)
 
-		g.By("Wait for alerts to be active")
-		waitForAlertToBeActive(oc, "NetObservLokiError")
+		g.By("Wait for alert to be pending")
+		waitForAlertToBePending(oc, "NetObservLokiError")
 	})
 
 	g.It("Author:memodi-Medium-63185-Verify NetOberv must-gather plugin [Serial]", func() {
-		SkipIfOCPBelow("v4.10")
 		mustgatherDir := "/tmp/must-gather-63185"
 		mustgatherImage := "quay.io/netobserv/must-gather"
 
 		g.By("Deploy FlowCollector")
 		flow := Flowcollector{
-			Namespace:  namespace,
-			Template:   flowFixturePath,
-			LokiEnable: "false",
+			Namespace:       namespace,
+			Template:        flowFixturePath,
+			LokiEnable:      "false",
+			InstallDemoLoki: "false",
 		}
 
 		defer func() { _ = flow.DeleteFlowcollector(oc) }()
@@ -247,7 +195,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 	})
 
 	g.It("Author:aramesha-NonPreRelease-Medium-72875-Verify nodeSelector and tolerations with netobserv components [Serial]", func() {
-		SkipIfOCPBelow("v4.12")
 
 		// verify tolerations
 		g.By("Get worker node of the cluster")
@@ -264,9 +211,10 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 
 		g.By("Deploy FlowCollector")
 		flow := Flowcollector{
-			Namespace:  namespace,
-			Template:   flowFixturePath,
-			LokiEnable: "false",
+			Namespace:       namespace,
+			Template:        flowFixturePath,
+			LokiEnable:      "false",
+			InstallDemoLoki: "false",
 		}
 
 		defer func() { _ = flow.DeleteFlowcollector(oc) }()
@@ -327,9 +275,10 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 
 		g.By("Deploy initial FlowCollector without additionalIncludeList")
 		flow := Flowcollector{
-			Namespace:  namespace,
-			Template:   flowFixturePath,
-			LokiEnable: "false",
+			Namespace:       namespace,
+			Template:        flowFixturePath,
+			LokiEnable:      "false",
+			InstallDemoLoki: "false",
 		}
 		defer func() { _ = flow.DeleteFlowcollector(oc) }()
 		flow.CreateFlowcollector(oc)
@@ -398,3314 +347,2330 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				expectedCount, len(baselineMetrics), len(additionalIncludeList), len(allMetrics), allMetrics))
 	})
 
-	g.Context("with Loki", func() {
-		var (
-			lokiDir, _ = filePath.Abs("testdata/loki")
-			// Loki Operator variables
-			lokiPackageName = "loki-operator"
-			lokiSource      CatalogSourceObjects
-			lokiCatalog     = "redhat-operators"
-			ls              *lokiStack
-			Lokiexisting    = false
-			lokiStackNS     = "netobserv-loki"
-			LO              = SubscriptionObjects{
-				OperatorName:  "loki-operator-controller-manager",
-				Namespace:     loNS,
-				PackageName:   lokiPackageName,
-				Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
-				OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
-				CatalogSource: &lokiSource,
-			}
-			// LokiStack variables
-			ipStackType       string
-			lokiStackTemplate = filePath.Join(lokiDir, "lokistack-simple.yaml")
-			lokiTenant        = "openshift-network"
-		)
+	g.Context("FLP, eBPF and Console metrics:", func() {
+		g.When("processor.metrics.TLS == Disabled and agent.ebpf.metrics.TLS == Disabled", func() {
+			g.It("Author:aramesha-Critical-50504-Critical-72959-Verify flowlogs-pipeline and eBPF metrics and health [Serial]", func() {
+				var (
+					flpPromSM  = "flowlogs-pipeline-monitor"
+					namespace  = oc.Namespace()
+					eBPFPromSM = "ebpf-agent-svc-monitor"
+					curlLive   = "http://localhost:8080/live"
+				)
 
-		g.BeforeEach(func() {
-			ipStackType = checkIPStackType(oc)
-
-			g.By("Deploy loki operator")
-			if !validateInfraAndResourcesForLoki(oc, "10Gi", "6") {
-				g.Skip("Current platform does not have enough resources available for this test!")
-			}
-
-			// check if Loki Operator exists
-			var err error
-			Lokiexisting, err = CheckOperatorStatus(oc, LO.Namespace, LO.PackageName)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			lokiChannel, err := getOperatorChannel(oc, lokiCatalog, lokiPackageName)
-			if err != nil || lokiChannel == "" {
-				g.Skip("Loki channel not found, skip this case")
-			}
-			lokiSource = CatalogSourceObjects{lokiChannel, lokiCatalog, "openshift-marketplace"}
-
-			// Don't delete if Loki Operator existed already before NetObserv
-			//  unless it is not using the 'stable' operator
-			// If Loki Operator was installed by NetObserv tests,
-			//  it will install and uninstall after each spec/test.
-			if !Lokiexisting {
-				g.DeferCleanup(LO.uninstallOperator, oc)
-				ensureOperatorDeployed(oc, LO, lokiSource, "name="+LO.OperatorName)
-			} else {
-				channelName, err := checkOperatorChannel(oc, LO.Namespace, LO.PackageName)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				if channelName != lokiChannel {
-					e2e.Logf("found %s channel for loki operator, removing and reinstalling with %s channel instead", channelName, lokiSource.Channel)
-					LO.uninstallOperator(oc)
-					g.DeferCleanup(LO.uninstallOperator, oc)
-					ensureOperatorDeployed(oc, LO, lokiSource, "name="+LO.OperatorName)
-					Lokiexisting = false
+				g.By("Deploy flowcollector")
+				flow := Flowcollector{
+					Namespace:              namespace,
+					Template:               flowFixturePath,
+					FLPMetricServerTLSType: "Disabled",
 				}
-			}
 
-			g.By("Deploy lokiStack")
-			// get storageClass Name
-			sc, err := getStorageClassName(oc)
-			if err != nil || len(sc) == 0 {
-				g.Skip("StorageClass not found in cluster, skip this case")
-			}
+				defer func() { _ = flow.DeleteFlowcollector(oc) }()
+				flow.CreateFlowcollector(oc)
 
-			objectStorageType := getStorageType(oc)
-			if len(objectStorageType) == 0 && ipStackType != "ipv6single" {
-				g.Skip("Current cluster doesn't have a proper object storage for this test!")
-			}
+				g.By("Verify flowlogs-pipeline metrics")
+				FLPpods, err := compat_otp.GetAllPodsWithLabel(oc, namespace, "app=flowlogs-pipeline")
+				o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.DeferCleanup(oc.DeleteSpecifiedNamespaceAsAdmin, lokiStackNS)
-			oc.CreateSpecifiedNamespaceAsAdmin(lokiStackNS)
-
-			ls = &lokiStack{
-				Name:          "lokistack",
-				Namespace:     lokiStackNS,
-				TSize:         "1x.demo",
-				StorageType:   objectStorageType,
-				StorageSecret: "objectstore-secret",
-				StorageClass:  sc,
-				BucketName:    "netobserv-loki-" + getInfrastructureName(oc),
-				Tenant:        lokiTenant,
-				Template:      lokiStackTemplate,
-			}
-
-			if ipStackType == "ipv6single" {
-				e2e.Logf("running IPv6 test")
-				ls.EnableIPV6 = "true"
-			}
-
-			g.DeferCleanup(ls.removeObjectStorage, oc)
-			err = ls.prepareResourcesForLokiStack(oc)
-			if err != nil {
-				g.Skip("Skipping test since LokiStack resources were not deployed")
-			}
-
-			g.DeferCleanup(ls.removeLokiStack, oc)
-			err = ls.deployLokiStack(oc)
-			if err != nil {
-				g.Skip("Skipping test since LokiStack was not deployed")
-			}
-
-			lokiStackResource := Resource{"lokistack", ls.Name, ls.Namespace}
-			err = lokiStackResource.WaitForResourceToAppear(oc)
-			if err != nil {
-				g.Skip("Skipping test since LokiStack did not become ready")
-			}
-
-			err = ls.waitForLokiStackToBeReady(oc)
-			if err != nil {
-				g.Skip("Skipping test since LokiStack is not ready")
-			}
-			ls.Route = "https://" + getRouteAddress(oc, ls.Namespace, ls.Name)
-		})
-
-		g.Context("FLP, eBPF and Console metrics:", func() {
-			g.When("processor.metrics.TLS == Disabled and agent.ebpf.metrics.TLS == Disabled", func() {
-				g.It("Author:aramesha-Critical-50504-Critical-72959-Verify flowlogs-pipeline and eBPF metrics and health [Serial]", func() {
-					SkipIfOCPBelow("v4.12")
-					var (
-						flpPromSM  = "flowlogs-pipeline-monitor"
-						namespace  = oc.Namespace()
-						eBPFPromSM = "ebpf-agent-svc-monitor"
-						curlLive   = "http://localhost:8080/live"
-					)
-
-					g.By("Deploy flowcollector")
-					flow := Flowcollector{
-						Namespace:              namespace,
-						Template:               flowFixturePath,
-						LokiNamespace:          lokiStackNS,
-						FLPMetricServerTLSType: "Disabled",
-					}
-
-					defer func() { _ = flow.DeleteFlowcollector(oc) }()
-					flow.CreateFlowcollector(oc)
-
-					g.By("Verify flowlogs-pipeline metrics")
-					FLPpods, err := compat_otp.GetAllPodsWithLabel(oc, namespace, "app=flowlogs-pipeline")
+				for _, pod := range FLPpods {
+					command := []string{"exec", "-n", namespace, pod, "--", "curl", "-s", curlLive}
+					output, err := oc.AsAdmin().WithoutNamespace().Run(command...).Args().Output()
 					o.Expect(err).NotTo(o.HaveOccurred())
+					o.Expect(output).To(o.Equal("{}"))
+				}
 
-					for _, pod := range FLPpods {
-						command := []string{"exec", "-n", namespace, pod, "--", "curl", "-s", curlLive}
-						output, err := oc.AsAdmin().WithoutNamespace().Run(command...).Args().Output()
-						o.Expect(err).NotTo(o.HaveOccurred())
-						o.Expect(output).To(o.Equal("{}"))
-					}
+				FLPtlsScheme, err := getMetricsScheme(oc, flpPromSM, flow.Namespace)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				FLPtlsScheme = strings.Trim(FLPtlsScheme, "'")
+				o.Expect(FLPtlsScheme).To(o.Equal("http"))
 
-					FLPtlsScheme, err := getMetricsScheme(oc, flpPromSM, flow.Namespace)
+				g.By("Wait for a min before scraping metrics")
+				time.Sleep(60 * time.Second)
+
+				g.By("Verify prometheus is able to scrape FLP metrics")
+				verifyFLPMetrics(oc)
+
+				g.By("Verify eBPF agent metrics")
+				eBPFpods, err := compat_otp.GetAllPodsWithLabel(oc, namespace, "app=netobserv-ebpf-agent")
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				for _, pod := range eBPFpods {
+					command := []string{"exec", "-n", namespace, pod, "--", "curl", "-s", curlLive}
+					output, err := oc.AsAdmin().WithoutNamespace().Run(command...).Args().Output()
 					o.Expect(err).NotTo(o.HaveOccurred())
-					FLPtlsScheme = strings.Trim(FLPtlsScheme, "'")
-					o.Expect(FLPtlsScheme).To(o.Equal("http"))
+					o.Expect(output).To(o.Equal("{}"))
+				}
 
-					g.By("Wait for a min before scraping metrics")
-					time.Sleep(60 * time.Second)
+				eBPFtlsScheme, err := getMetricsScheme(oc, eBPFPromSM, flow.Namespace+"-privileged")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				eBPFtlsScheme = strings.Trim(eBPFtlsScheme, "'")
+				o.Expect(eBPFtlsScheme).To(o.Equal("http"))
 
-					g.By("Verify prometheus is able to scrape FLP metrics")
-					verifyFLPMetrics(oc)
+				g.By("Wait for a min before scraping metrics")
+				time.Sleep(60 * time.Second)
 
-					g.By("Verify eBPF agent metrics")
-					eBPFpods, err := compat_otp.GetAllPodsWithLabel(oc, namespace, "app=netobserv-ebpf-agent")
-					o.Expect(err).NotTo(o.HaveOccurred())
-
-					for _, pod := range eBPFpods {
-						command := []string{"exec", "-n", namespace, pod, "--", "curl", "-s", curlLive}
-						output, err := oc.AsAdmin().WithoutNamespace().Run(command...).Args().Output()
-						o.Expect(err).NotTo(o.HaveOccurred())
-						o.Expect(output).To(o.Equal("{}"))
-					}
-
-					eBPFtlsScheme, err := getMetricsScheme(oc, eBPFPromSM, flow.Namespace+"-privileged")
-					o.Expect(err).NotTo(o.HaveOccurred())
-					eBPFtlsScheme = strings.Trim(eBPFtlsScheme, "'")
-					o.Expect(eBPFtlsScheme).To(o.Equal("http"))
-
-					g.By("Wait for a min before scraping metrics")
-					time.Sleep(60 * time.Second)
-
-					g.By("Verify prometheus is able to scrape eBPF metrics")
-					verifyEBPFMetrics(oc)
-				})
-			})
-
-			g.When("processor.metrics.TLS == Auto and ebpf.agent.metrics.TLS == Auto", func() {
-				g.It("Author:aramesha-Critical-54043-Critical-66031-Critical-72959-Verify flowlogs-pipeline, eBPF and Console metrics [Serial]", func() {
-					SkipIfOCPBelow("v4.12")
-					var (
-						flpPromSM  = "flowlogs-pipeline-monitor"
-						flpPromSA  = "flowlogs-pipeline-prom"
-						eBPFPromSM = "ebpf-agent-svc-monitor"
-						eBPFPromSA = "ebpf-agent-svc-prom"
-						namespace  = oc.Namespace()
-					)
-
-					flow := Flowcollector{
-						Namespace:               namespace,
-						Template:                flowFixturePath,
-						LokiNamespace:           lokiStackNS,
-						EBPFMetricServerTLSType: "Auto",
-					}
-
-					defer func() { _ = flow.DeleteFlowcollector(oc) }()
-					flow.CreateFlowcollector(oc)
-
-					g.By("Verify flowlogs-pipeline metrics")
-					FLPtlsScheme, err := getMetricsScheme(oc, flpPromSM, flow.Namespace)
-					o.Expect(err).NotTo(o.HaveOccurred())
-					FLPtlsScheme = strings.Trim(FLPtlsScheme, "'")
-					o.Expect(FLPtlsScheme).To(o.Equal("https"))
-
-					FLPserverName, err := getMetricsServerName(oc, flpPromSM, flow.Namespace)
-					FLPserverName = strings.Trim(FLPserverName, "'")
-					o.Expect(err).NotTo(o.HaveOccurred())
-					FLPexpectedServerName := fmt.Sprintf("%s.%s.svc", flpPromSA, namespace)
-					o.Expect(FLPserverName).To(o.Equal(FLPexpectedServerName))
-
-					g.By("Wait for a min before scraping metrics")
-					time.Sleep(60 * time.Second)
-
-					g.By("Verify prometheus is able to scrape FLP and Console metrics")
-					verifyFLPMetrics(oc)
-					query := fmt.Sprintf("process_start_time_seconds{namespace=\"%s\", job=\"netobserv-plugin-metrics\"}", namespace)
-					metrics, err := getMetric(oc, query)
-					o.Expect(err).NotTo(o.HaveOccurred())
-					o.Expect(popMetricValue(metrics)).Should(o.BeNumerically(">", 0))
-
-					g.By("Verify eBPF metrics")
-					eBPFtlsScheme, err := getMetricsScheme(oc, eBPFPromSM, flow.Namespace+"-privileged")
-					o.Expect(err).NotTo(o.HaveOccurred())
-					eBPFtlsScheme = strings.Trim(eBPFtlsScheme, "'")
-					o.Expect(eBPFtlsScheme).To(o.Equal("https"))
-
-					eBPFserverName, err := getMetricsServerName(oc, eBPFPromSM, flow.Namespace+"-privileged")
-					eBPFserverName = strings.Trim(eBPFserverName, "'")
-					o.Expect(err).NotTo(o.HaveOccurred())
-					eBPFexpectedServerName := fmt.Sprintf("%s.%s.svc", eBPFPromSA, namespace+"-privileged")
-					o.Expect(eBPFserverName).To(o.Equal(eBPFexpectedServerName))
-
-					g.By("Verify prometheus is able to scrape eBPF agent metrics")
-					verifyEBPFMetrics(oc)
-				})
+				g.By("Verify prometheus is able to scrape eBPF metrics")
+				verifyEBPFMetrics(oc)
 			})
 		})
 
-		g.It("Author:memodi-High-53595-High-49107-High-45304-High-54929-High-54840-High-68310-Verify flow correctness and metrics [Serial]", func() {
-			SkipIfOCPBelow("v4.11")
-			g.By("Deploying test server and client pods")
-			serverTemplatePath := filePath.Join(baseDir, "test-nginx-server_template.yaml")
-			testServer := TestServerTemplate{
-				ServerNS: "test-server-54929",
-				Template: serverTemplatePath,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testServer.ServerNS)
-			err := testServer.createServer(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testServer.ServerNS)
+		g.When("processor.metrics.TLS == Auto and ebpf.agent.metrics.TLS == Auto", func() {
+			g.It("Author:aramesha-Critical-54043-Critical-66031-Critical-72959-Verify flowlogs-pipeline, eBPF and Console metrics [Serial]", func() {
+				var (
+					flpPromSM  = "flowlogs-pipeline-monitor"
+					flpPromSA  = "flowlogs-pipeline-prom"
+					eBPFPromSM = "ebpf-agent-svc-monitor"
+					eBPFPromSA = "ebpf-agent-svc-prom"
+					namespace  = oc.Namespace()
+				)
 
-			clientTemplatePath := filePath.Join(baseDir, "test-nginx-client_template.yaml")
-			testClient := TestClientTemplate{
-				ServerNS:   testServer.ServerNS,
-				ClientNS:   "test-client-54929",
-				ObjectSize: "100K",
-				Template:   clientTemplatePath,
-			}
+				flow := Flowcollector{
+					Namespace:               namespace,
+					Template:                flowFixturePath,
+					EBPFMetricServerTLSType: "Auto",
+				}
 
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testClient.ClientNS)
-			err = testClient.createClient(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testClient.ClientNS)
+				defer func() { _ = flow.DeleteFlowcollector(oc) }()
+				flow.CreateFlowcollector(oc)
 
-			startTime := time.Now()
+				g.By("Verify flowlogs-pipeline metrics")
+				FLPtlsScheme, err := getMetricsScheme(oc, flpPromSM, flow.Namespace)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				FLPtlsScheme = strings.Trim(FLPtlsScheme, "'")
+				o.Expect(FLPtlsScheme).To(o.Equal("https"))
 
-			g.By("Deploy FlowCollector")
-			flow := Flowcollector{
-				Namespace:     namespace,
-				Template:      flowFixturePath,
-				LokiNamespace: lokiStackNS,
-			}
+				FLPserverName, err := getMetricsServerName(oc, flpPromSM, flow.Namespace)
+				FLPserverName = strings.Trim(FLPserverName, "'")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				FLPexpectedServerName := fmt.Sprintf("%s.%s.svc", flpPromSA, namespace)
+				o.Expect(FLPserverName).To(o.Equal(FLPexpectedServerName))
 
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
+				g.By("Wait for a min before scraping metrics")
+				time.Sleep(60 * time.Second)
 
-			g.By("get flowlogs from loki")
-			lokilabels := Lokilabels{
-				App:             "netobserv-flowcollector",
-				SrcK8SNamespace: testServer.ServerNS,
-				DstK8SNamespace: testClient.ClientNS,
-				SrcK8SOwnerName: "nginx-service",
-				FlowDirection:   "0",
-			}
+				g.By("Verify prometheus is able to scrape FLP and Console metrics")
+				verifyFLPMetrics(oc)
+				query := fmt.Sprintf("process_start_time_seconds{namespace=\"%s\", job=\"netobserv-plugin-metrics\"}", namespace)
+				metrics, err := getMetric(oc, query)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(popMetricValue(metrics)).Should(o.BeNumerically(">", 0))
 
-			g.By("Wait for 2 mins before logs gets collected and written to loki")
-			time.Sleep(120 * time.Second)
+				g.By("Verify eBPF metrics")
+				eBPFtlsScheme, err := getMetricsScheme(oc, eBPFPromSM, flow.Namespace+"-privileged")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				eBPFtlsScheme = strings.Trim(eBPFtlsScheme, "'")
+				o.Expect(eBPFtlsScheme).To(o.Equal("https"))
 
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords > 0")
+				eBPFserverName, err := getMetricsServerName(oc, eBPFPromSM, flow.Namespace+"-privileged")
+				eBPFserverName = strings.Trim(eBPFserverName, "'")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				eBPFexpectedServerName := fmt.Sprintf("%s.%s.svc", eBPFPromSA, namespace+"-privileged")
+				o.Expect(eBPFserverName).To(o.Equal(eBPFexpectedServerName))
 
-			// verify flow correctness
-			verifyFlowCorrectness(testClient.ObjectSize, flowRecords)
-
-			// verify inner metrics
-			query := fmt.Sprintf(`sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="%s"}[1m]))`, testClient.ClientNS)
-			metrics := pollMetrics(oc, query)
-
-			// verfy metric is between 270 and 330
-			o.Expect(metrics).Should(o.BeNumerically("~", 330, 270))
-		})
-
-		g.It("Author:aramesha-NonPreRelease-Longduration-High-60701-Verify connection tracking [Serial]", func() {
-			SkipIfOCPBelow("v4.10")
-			startTime := time.Now()
-
-			g.By("Deploying test server and client pods")
-			serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
-			testServerTemplate := TestServerTemplate{
-				ServerNS: "test-server-60701",
-				Template: serverTemplate,
-			}
-
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
-			err := testServerTemplate.createServer(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
-
-			clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
-
-			testClientTemplate := TestClientTemplate{
-				ServerNS: testServerTemplate.ServerNS,
-				ClientNS: "test-client-60701",
-				Template: clientTemplate,
-			}
-
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
-			err = testClientTemplate.createClient(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
-
-			g.By("Deploy FlowCollector with endConversations LogType")
-			flow := Flowcollector{
-				Namespace:     namespace,
-				Template:      flowFixturePath,
-				LogType:       "EndedConversations",
-				LokiNamespace: lokiStackNS,
-			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			// verify logs
-			g.By("Wait for a min before logs gets collected and written to loki")
-			time.Sleep(60 * time.Second)
-
-			lokilabels := Lokilabels{
-				App:             "netobserv-flowcollector",
-				SrcK8SNamespace: testClientTemplate.ClientNS,
-				DstK8SNamespace: testClientTemplate.ServerNS,
-				RecordType:      "endConnection",
-				DstK8SOwnerName: "nginx-service",
-			}
-
-			g.By("Verify endConnection Records from loki")
-			endConnectionRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(endConnectionRecords)).Should(o.BeNumerically(">", 0), "expected number of endConnectionRecords > 0")
-			verifyConversationRecordTime(endConnectionRecords)
-
-			g.By("Deploy FlowCollector with Conversations LogType")
-			_ = flow.DeleteFlowcollector(oc)
-
-			flow.LogType = "Conversations"
-			flow.CreateFlowcollector(oc)
-
-			g.By("Wait for a min before logs gets collected and written to loki")
-			startTime = time.Now()
-			time.Sleep(60 * time.Second)
-
-			g.By("Verify NewConnection Records from loki")
-			lokilabels.RecordType = "newConnection"
-
-			newConnectionRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(newConnectionRecords)).Should(o.BeNumerically(">", 0), "expected number of newConnectionRecords > 0")
-			verifyConversationRecordTime(newConnectionRecords)
-
-			g.By("Verify HeartbeatConnection Records from loki")
-			lokilabels.RecordType = "heartbeat"
-			heartbeatConnectionRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(heartbeatConnectionRecords)).Should(o.BeNumerically(">", 0), "expected number of heartbeatConnectionRecords > 0")
-			verifyConversationRecordTime(heartbeatConnectionRecords)
-
-			g.By("Verify EndConnection Records from loki")
-			lokilabels.RecordType = "endConnection"
-			endConnectionRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(endConnectionRecords)).Should(o.BeNumerically(">", 0), "expected number of endConnectionRecords > 0")
-			verifyConversationRecordTime(endConnectionRecords)
-		})
-
-		g.It("Author:memodi-NonPreRelease-Longduration-High-63839-Verify-multi-tenancy [Disruptive][Slow]", func() {
-			users, usersHTpassFile, htPassSecret := getNewUser(oc, 2)
-			defer userCleanup(oc, users, usersHTpassFile, htPassSecret)
-
-			g.By("Creating client server template and template CRBs for testusers")
-			// create templates for testuser to be used later
-			testUserstemplate := filePath.Join(baseDir, "testuser-client-server_template.yaml")
-			stdout, stderr, err := oc.AsAdmin().Run("apply").Args("-f", testUserstemplate).Outputs()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(stderr).To(o.BeEmpty())
-			templateResource := strings.Split(stdout, " ")[0]
-			templateName := strings.Split(templateResource, "/")[1]
-			defer removeTemplatePermissions(oc, users[0].Username)
-			addTemplatePermissions(oc, users[0].Username)
-
-			g.By("Deploy FlowCollector")
-			flow := Flowcollector{
-				Namespace:     namespace,
-				Template:      flowFixturePath,
-				LokiNamespace: lokiStackNS,
-			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			g.By("Deploying test server and client pods")
-			serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
-			testServerTemplate := TestServerTemplate{
-				ServerNS: "test-server-63839",
-				Template: serverTemplate,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
-			err = testServerTemplate.createServer(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
-
-			clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
-
-			testClientTemplate := TestClientTemplate{
-				ServerNS: testServerTemplate.ServerNS,
-				ClientNS: "test-client-63839",
-				Template: clientTemplate,
-			}
-
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
-			err = testClientTemplate.createClient(oc)
-			compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			// save original context
-			origContxt, contxtErr := oc.AsAdmin().WithoutNamespace().Run("config").Args("current-context").Output()
-			o.Expect(contxtErr).NotTo(o.HaveOccurred())
-			e2e.Logf("orginal context is %v", origContxt)
-			defer removeUserAsReader(oc, users[0].Username)
-			addUserAsReader(oc, users[0].Username)
-			origUser := oc.Username()
-
-			e2e.Logf("current user is %s", origUser)
-			defer func() { _ = oc.AsAdmin().WithoutNamespace().Run("config").Args("use-context", origContxt).Execute() }()
-			defer oc.ChangeUser(origUser)
-			oc.ChangeUser(users[0].Username)
-
-			curUser := oc.Username()
-			e2e.Logf("current user is %s", curUser)
-
-			o.Expect(err).NotTo(o.HaveOccurred())
-			user0Contxt, contxtErr := oc.WithoutNamespace().Run("config").Args("current-context").Output()
-			o.Expect(contxtErr).NotTo(o.HaveOccurred())
-
-			e2e.Logf("user0 context is %v", user0Contxt)
-
-			g.By("Deploying test server and client pods as user0")
-			var (
-				testUserServerNS = fmt.Sprintf("%s-server", users[0].Username)
-				testUserClientNS = fmt.Sprintf("%s-client", users[0].Username)
-			)
-
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testUserClientNS)
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testUserServerNS)
-			configFile := compat_otp.ProcessTemplate(oc, "--ignore-unknown-parameters=true", templateName, "-p", "SERVER_NS="+testUserServerNS, "-p", "CLIENT_NS="+testUserClientNS)
-			err = oc.WithoutNamespace().Run("create").Args("-f", configFile).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			// only required to getFlowLogs
-			lokilabels := Lokilabels{
-				App:             "netobserv-flowcollector",
-				SrcK8SNamespace: testUserServerNS,
-				DstK8SNamespace: testUserClientNS,
-				SrcK8SOwnerName: "nginx-service",
-				FlowDirection:   "0",
-			}
-
-			user0token, err := oc.WithoutNamespace().Run("whoami").Args("-t").Output()
-			e2e.Logf("token is %s", user0token)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("Wait for a min before logs gets collected and written to loki")
-			startTime := time.Now()
-			time.Sleep(60 * time.Second)
-
-			g.By("get flowlogs from loki")
-			flowRecords, err := lokilabels.getLokiFlowLogs(user0token, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords > 0")
-
-			g.By("verify no logs are fetched from an NS that user is not admin for")
-			lokilabels = Lokilabels{
-				App:             "netobserv-flowcollector",
-				SrcK8SNamespace: testClientTemplate.ServerNS,
-				DstK8SNamespace: testClientTemplate.ClientNS,
-				SrcK8SOwnerName: "nginx-service",
-				FlowDirection:   "0",
-			}
-			flowRecords, err = lokilabels.getLokiFlowLogs(user0token, ls.Route, startTime)
-			// Multi-tenancy verification: Loki Gateway returns permission errors for unauthorized namespace access
-			if err != nil {
-				o.Expect(err.Error()).To(o.ContainSubstring("permission"), "expected permission error for unauthorized namespace access, got: %v", err)
-			} else {
-				o.Expect(len(flowRecords)).To(o.Equal(0), "expected zero flowRecords for unauthorized namespace access")
-			}
-		})
-
-		g.It("Author:aramesha-NonPreRelease-Critical-59746-NetObserv upgrade testing [Serial]", func() {
-			// Uninstall operator even if test fails/passes
-			g.DeferCleanup(func() {
-				NO.uninstallOperator(oc)
-				oc.DeleteSpecifiedNamespaceAsAdmin(netobservNS)
+				g.By("Verify prometheus is able to scrape eBPF agent metrics")
+				verifyEBPFMetrics(oc)
 			})
+		})
+	})
 
-			g.By("Uninstall operator deployed by BeforeEach and delete operator NS")
+	g.It("Author:memodi-High-53595-High-49107-High-45304-High-54929-High-54840-High-68310-Verify flow correctness and metrics [Serial]", func() {
+		g.By("Deploying test server and client pods")
+		serverTemplatePath := filePath.Join(baseDir, "test-nginx-server_template.yaml")
+		testServer := TestServerTemplate{
+			ServerNS: "test-server-54929",
+			Template: serverTemplatePath,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServer.ServerNS)
+		err := testServer.createServer(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testServer.ServerNS)
+
+		clientTemplatePath := filePath.Join(baseDir, "test-nginx-client_template.yaml")
+		testClient := TestClientTemplate{
+			ServerNS:   testServer.ServerNS,
+			ClientNS:   "test-client-54929",
+			ObjectSize: "100K",
+			Template:   clientTemplatePath,
+		}
+
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClient.ClientNS)
+		err = testClient.createClient(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testClient.ClientNS)
+
+		startTime := time.Now()
+
+		g.By("Deploy FlowCollector")
+		flow := Flowcollector{
+			Namespace: namespace,
+			Template:  flowFixturePath,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("get flowlogs from loki")
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: testServer.ServerNS,
+			DstK8SNamespace: testClient.ClientNS,
+			SrcK8SOwnerName: "nginx-service",
+			FlowDirection:   "0",
+		}
+
+		g.By("Wait for 2 mins before logs gets collected and written to loki")
+		time.Sleep(120 * time.Second)
+
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords > 0")
+
+		// verify flow correctness
+		verifyFlowCorrectness(testClient.ObjectSize, flowRecords)
+
+		// verify inner metrics
+		query := fmt.Sprintf(`sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="%s"}[1m]))`, testClient.ClientNS)
+		metrics := pollMetrics(oc, query)
+
+		// verify metric is between 270 and 330
+		o.Expect(metrics).Should(o.BeNumerically("~", 300, 30))
+	})
+
+	g.It("Author:aramesha-NonPreRelease-Longduration-High-60701-Verify connection tracking [Serial]", func() {
+		startTime := time.Now()
+
+		g.By("Deploying test server and client pods")
+		serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
+		testServerTemplate := TestServerTemplate{
+			ServerNS: "test-server-60701",
+			Template: serverTemplate,
+		}
+
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
+		err := testServerTemplate.createServer(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
+
+		clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
+
+		testClientTemplate := TestClientTemplate{
+			ServerNS: testServerTemplate.ServerNS,
+			ClientNS: "test-client-60701",
+			Template: clientTemplate,
+		}
+
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
+		err = testClientTemplate.createClient(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
+
+		g.By("Deploy FlowCollector with endConversations LogType")
+		flow := Flowcollector{
+			Namespace:       namespace,
+			Template:        flowFixturePath,
+			LogType:         "EndedConversations",
+			DeploymentModel: "Direct",
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		// verify logs
+		g.By("Wait for a min before logs gets collected and written to loki")
+		time.Sleep(60 * time.Second)
+
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: testClientTemplate.ClientNS,
+			DstK8SNamespace: testClientTemplate.ServerNS,
+			RecordType:      "endConnection",
+			DstK8SOwnerName: "nginx-service",
+		}
+
+		g.By("Verify endConnection Records from loki")
+		endConnectionRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(endConnectionRecords)).Should(o.BeNumerically(">", 0), "expected number of endConnectionRecords > 0")
+		verifyConversationRecordTime(endConnectionRecords)
+
+		g.By("Deploy FlowCollector with Conversations LogType")
+		_ = flow.DeleteFlowcollector(oc)
+
+		flow.LogType = "Conversations"
+		flow.CreateFlowcollector(oc)
+
+		g.By("Wait for a min before logs gets collected and written to loki")
+		startTime = time.Now()
+		time.Sleep(60 * time.Second)
+
+		g.By("Verify NewConnection Records from loki")
+		lokilabels.RecordType = "newConnection"
+
+		newConnectionRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(newConnectionRecords)).Should(o.BeNumerically(">", 0), "expected number of newConnectionRecords > 0")
+		verifyConversationRecordTime(newConnectionRecords)
+
+		g.By("Verify HeartbeatConnection Records from loki")
+		lokilabels.RecordType = "heartbeat"
+		heartbeatConnectionRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(heartbeatConnectionRecords)).Should(o.BeNumerically(">", 0), "expected number of heartbeatConnectionRecords > 0")
+		verifyConversationRecordTime(heartbeatConnectionRecords)
+
+		g.By("Verify EndConnection Records from loki")
+		lokilabels.RecordType = "endConnection"
+		endConnectionRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(endConnectionRecords)).Should(o.BeNumerically(">", 0), "expected number of endConnectionRecords > 0")
+		verifyConversationRecordTime(endConnectionRecords)
+	})
+
+	g.It("Author:aramesha-NonPreRelease-Critical-59746-NetObserv upgrade testing [Serial]", func() {
+		// Uninstall operator even if test fails/passes, then redeploy for subsequent tests
+		g.DeferCleanup(func() {
 			NO.uninstallOperator(oc)
 			oc.DeleteSpecifiedNamespaceAsAdmin(netobservNS)
 			err := Resource{"namespace", netobservNS, ""}.WaitUntilResourceIsGone(oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("Deploy older version of netobserv operator")
-			NOReleasedcatSrc := Resource{"catsrc", "redhat-operators", "openshift-marketplace"}
-			NOReleasedSource := CatalogSourceObjects{"stable", NOReleasedcatSrc.Name, NOReleasedcatSrc.Namespace}
-
-			// Use local copy instead of modifying global NO
-			NOReleased := NO
-			NOReleased.CatalogSource = &NOReleasedSource
-
-			g.By(fmt.Sprintf("Subscribe operators to %s channel", NOReleasedSource.Channel))
+			isHypershift := compat_otp.IsHypershiftHostedCluster(oc)
 			OperatorNS.DeployOperatorNamespace(oc)
-			NOReleased.SubscribeOperator(oc)
-			// check if NO operator is deployed
-			WaitForPodsReadyWithLabel(oc, netobservNS, "app="+NO.OperatorName)
-			NOStatus, err := CheckOperatorStatus(oc, netobservNS, NOPackageName)
-			o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("found err %v", err))
-			o.Expect((NOStatus)).To(o.BeTrue())
-
-			// check if flowcollector API exists
-			flowcollectorAPIExists, err := isFlowCollectorAPIExists(oc)
-			o.Expect((flowcollectorAPIExists)).To(o.BeTrue())
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("Deploy FlowCollector")
-			flow := Flowcollector{
-				Namespace:     namespace,
-				Template:      flowFixturePath,
-				LokiNamespace: lokiStackNS,
-			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			g.By("Get NetObserv and components versions")
-			NOCSV, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[?(@.name=='OPERATOR_CONDITION_NAME')].value}").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			preUpgradeNOVersion := strings.Split(NOCSV, ".v")[1]
-			preUpgradeEBPFVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[0].value}").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			preUpgradeEBPFVersion = strings.Split(preUpgradeEBPFVersion, ":")[1]
-			preUpgradeFLPVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[1].value}").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			preUpgradeFLPVersion = strings.Split(preUpgradeFLPVersion, ":")[1]
-			preUpgradePluginVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[2].value}").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			preUpgradePluginVersion = strings.Split(preUpgradePluginVersion, ":")[1]
-
-			g.By("Deploy latest catalog and upgrade to latest version")
-			var catsrcErr error
-			if catalogSource != "" {
-				e2e.Logf("Using %s catalog", catalogSource)
-				catsrcErr = NOcatSrc.applyFromTemplate(oc, "-n", NOcatSrc.Namespace, "-f", catSrcTemplate, "-p", "NAMESPACE="+NOcatSrc.Namespace, "IMAGE="+catalogSource)
-			} else {
-				e2e.Logf("Using default ystream catalog")
-				catsrcErr = NOcatSrc.applyFromTemplate(oc, "-n", NOcatSrc.Namespace, "-f", catSrcTemplate, "-p", "NAMESPACE="+NOcatSrc.Namespace)
-			}
-			o.Expect(catsrcErr).NotTo(o.HaveOccurred())
-			_, _ = oc.AsAdmin().WithoutNamespace().Run("patch").Args("subscription", "netobserv-operator", "-n", netobservNS, "-p", `[{"op": "replace", "path": "/spec/source", "value": `+NOcatSrc.Name+`}, {"op": "replace", "path": "/spec/sourceNamespace", "value": `+NOcatSrc.Namespace+`}]`, "--type=json").Output()
-
-			g.By("Wait for a min for operator upgrade")
-			time.Sleep(60 * time.Second)
-
-			WaitForPodsReadyWithLabel(oc, netobservNS, "app=netobserv-operator")
-			NOStatus, err = CheckOperatorStatus(oc, netobservNS, NOPackageName)
-			o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("found err %v", err))
-			o.Expect((NOStatus)).To(o.BeTrue())
-
-			g.By("Get NetObserv operator and components versions")
-			NOCSV, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[?(@.name=='OPERATOR_CONDITION_NAME')].value}").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			postUpgradeNOVersion := strings.Split(NOCSV, ".v")[1]
-			postUpgradeEBPFVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[0].value}").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			postUpgradeEBPFVersion = strings.Split(postUpgradeEBPFVersion, ":")[1]
-			postUpgradeFLPVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[1].value}").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			postUpgradeFLPVersion = strings.Split(postUpgradeFLPVersion, ":")[1]
-			postUpgradePluginVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[2].value}").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			postUpgradePluginVersion = strings.Split(postUpgradePluginVersion, ":")[1]
-
-			g.By("Verify versions are updated")
-			o.Expect(preUpgradeNOVersion).NotTo(o.Equal(postUpgradeNOVersion))
-			o.Expect(preUpgradeEBPFVersion).NotTo(o.Equal(postUpgradeEBPFVersion))
-			o.Expect(preUpgradeFLPVersion).NotTo(o.Equal(postUpgradeFLPVersion))
-			o.Expect(preUpgradePluginVersion).NotTo(o.Equal(postUpgradePluginVersion))
-
-			// verify logs
-			g.By("Wait for a min before logs gets collected and written to loki")
-			startTime := time.Now()
-			time.Sleep(60 * time.Second)
-
-			g.By("Get flowlogs from loki")
-			err = verifyLokilogsTime(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
+			catSrcErr := setupCatalogSource(oc, NOcatSrc, catSrcTemplate, imageDigest, catalogSource, isHypershift, &NOSource, &NO)
+			o.Expect(catSrcErr).NotTo(o.HaveOccurred())
+			ensureNetObservOperatorDeployed(oc, NO, NOSource)
 		})
 
-		g.It("Author:aramesha-NonPreRelease-High-62989-Verify SCTP, ICMP, ICMPv6 traffic is observed [Disruptive]", func() {
-			SkipIfOCPBelow("v4.10")
-			var (
-				sctpClientPodTemplatePath = filePath.Join(networkingDir, "sctpclient.yaml")
-				sctpServerPodTemplatePath = filePath.Join(networkingDir, "sctpserver.yaml")
-				sctpServerPodname         = "sctpserver"
-				sctpClientPodname         = "sctpclient"
-			)
+		g.By("Uninstall operator deployed by BeforeSuite and delete operator NS")
+		NO.uninstallOperator(oc)
+		oc.DeleteSpecifiedNamespaceAsAdmin(netobservNS)
+		err := Resource{"namespace", netobservNS, ""}.WaitUntilResourceIsGone(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("install load-sctp-module in all workers")
-			prepareSCTPModule(oc)
+		g.By("Deploy older version of netobserv operator")
+		NOReleasedcatSrc := Resource{"catsrc", "redhat-operators", "openshift-marketplace"}
+		NOReleasedSource := CatalogSourceObjects{"stable", NOReleasedcatSrc.Name, NOReleasedcatSrc.Namespace}
 
-			g.By("Create netobserv-sctp NS")
-			SCTPns := "netobserv-sctp-62989"
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(SCTPns)
-			oc.CreateSpecifiedNamespaceAsAdmin(SCTPns)
-			_ = compat_otp.SetNamespacePrivileged(oc, SCTPns)
+		// Use local copy instead of modifying global NO
+		NOReleased := NO
+		NOReleased.CatalogSource = &NOReleasedSource
 
-			g.By("create sctpClientPod")
-			createResourceFromFile(oc, SCTPns, sctpClientPodTemplatePath)
-			WaitForPodsReadyWithLabel(oc, SCTPns, "name=sctpclient")
+		g.By(fmt.Sprintf("Subscribe operators to %s channel", NOReleasedSource.Channel))
+		OperatorNS.DeployOperatorNamespace(oc)
+		NOReleased.SubscribeOperator(oc)
+		// check if NO operator is deployed
+		WaitForPodsReadyWithLabel(oc, netobservNS, "app="+NO.OperatorName)
+		NOStatus, err := CheckOperatorStatus(oc, netobservNS, NOPackageName)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("found err %v", err))
+		o.Expect((NOStatus)).To(o.BeTrue())
 
-			g.By("create sctpServerPod")
-			createResourceFromFile(oc, SCTPns, sctpServerPodTemplatePath)
-			WaitForPodsReadyWithLabel(oc, SCTPns, "name=sctpserver")
+		// check if flowcollector API exists
+		flowcollectorAPIExists, err := isFlowCollectorAPIExists(oc)
+		o.Expect((flowcollectorAPIExists)).To(o.BeTrue())
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("Deploy FlowCollector")
-			flow := Flowcollector{
-				Namespace:     namespace,
-				Template:      flowFixturePath,
-				LokiNamespace: lokiStackNS,
+		g.By("Deploy FlowCollector")
+		flow := Flowcollector{
+			Namespace: namespace,
+			Template:  flowFixturePath,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Get NetObserv and components versions")
+		NOCSV, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[?(@.name=='OPERATOR_CONDITION_NAME')].value}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		preUpgradeNOVersion := strings.Split(NOCSV, ".v")[1]
+		preUpgradeEBPFVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[0].value}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		preUpgradeEBPFVersion = strings.Split(preUpgradeEBPFVersion, ":")[1]
+		preUpgradeFLPVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[1].value}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		preUpgradeFLPVersion = strings.Split(preUpgradeFLPVersion, ":")[1]
+		preUpgradePluginVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[2].value}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		preUpgradePluginVersion = strings.Split(preUpgradePluginVersion, ":")[1]
+
+		g.By("Deploy latest catalog and upgrade to latest version")
+		var catsrcErr error
+		if catalogSource != "" {
+			e2e.Logf("Using %s catalog", catalogSource)
+			catsrcErr = NOcatSrc.applyFromTemplate(oc, "-n", NOcatSrc.Namespace, "-f", catSrcTemplate, "-p", "NAMESPACE="+NOcatSrc.Namespace, "IMAGE="+catalogSource)
+		} else {
+			e2e.Logf("Using default ystream catalog")
+			catsrcErr = NOcatSrc.applyFromTemplate(oc, "-n", NOcatSrc.Namespace, "-f", catSrcTemplate, "-p", "NAMESPACE="+NOcatSrc.Namespace)
+		}
+		o.Expect(catsrcErr).NotTo(o.HaveOccurred())
+		_, _ = oc.AsAdmin().WithoutNamespace().Run("patch").Args("subscription", "netobserv-operator", "-n", netobservNS, "-p", `[{"op": "replace", "path": "/spec/source", "value": `+NOcatSrc.Name+`}, {"op": "replace", "path": "/spec/sourceNamespace", "value": `+NOcatSrc.Namespace+`}]`, "--type=json").Output()
+
+		g.By("Wait for a min for operator upgrade")
+		time.Sleep(60 * time.Second)
+
+		WaitForPodsReadyWithLabel(oc, netobservNS, "app=netobserv-operator")
+		NOStatus, err = CheckOperatorStatus(oc, netobservNS, NOPackageName)
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("found err %v", err))
+		o.Expect((NOStatus)).To(o.BeTrue())
+
+		g.By("Get NetObserv operator and components versions")
+		NOCSV, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[?(@.name=='OPERATOR_CONDITION_NAME')].value}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		postUpgradeNOVersion := strings.Split(NOCSV, ".v")[1]
+		postUpgradeEBPFVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[0].value}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		postUpgradeEBPFVersion = strings.Split(postUpgradeEBPFVersion, ":")[1]
+		postUpgradeFLPVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[1].value}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		postUpgradeFLPVersion = strings.Split(postUpgradeFLPVersion, ":")[1]
+		postUpgradePluginVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "app=netobserv-operator", "-n", netobservNS, "-o=jsonpath={.items[*].spec.containers[0].env[2].value}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		postUpgradePluginVersion = strings.Split(postUpgradePluginVersion, ":")[1]
+
+		g.By("Verify versions are updated")
+		o.Expect(preUpgradeNOVersion).NotTo(o.Equal(postUpgradeNOVersion))
+		o.Expect(preUpgradeEBPFVersion).NotTo(o.Equal(postUpgradeEBPFVersion))
+		o.Expect(preUpgradeFLPVersion).NotTo(o.Equal(postUpgradeFLPVersion))
+		o.Expect(preUpgradePluginVersion).NotTo(o.Equal(postUpgradePluginVersion))
+
+		// verify logs
+		g.By("Wait for a min before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(60 * time.Second)
+
+		g.By("Get flowlogs from loki")
+		err = verifyMonolithicLokilogsTime(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("Author:aramesha-NonPreRelease-High-62989-Verify SCTP, ICMP, ICMPv6 traffic is observed [Disruptive]", func() {
+		var (
+			sctpClientPodTemplatePath = filePath.Join(networkingDir, "sctpclient.yaml")
+			sctpServerPodTemplatePath = filePath.Join(networkingDir, "sctpserver.yaml")
+			sctpServerPodname         = "sctpserver"
+			sctpClientPodname         = "sctpclient"
+		)
+
+		g.By("install load-sctp-module in all workers")
+		prepareSCTPModule(oc)
+
+		g.By("Create netobserv-sctp NS")
+		SCTPns := "netobserv-sctp-62989"
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(SCTPns)
+		oc.CreateSpecifiedNamespaceAsAdmin(SCTPns)
+		_ = compat_otp.SetNamespacePrivileged(oc, SCTPns)
+
+		g.By("create sctpClientPod")
+		createResourceFromFile(oc, SCTPns, sctpClientPodTemplatePath)
+		WaitForPodsReadyWithLabel(oc, SCTPns, "name=sctpclient")
+
+		g.By("create sctpServerPod")
+		createResourceFromFile(oc, SCTPns, sctpServerPodTemplatePath)
+		WaitForPodsReadyWithLabel(oc, SCTPns, "name=sctpserver")
+
+		g.By("Deploy FlowCollector")
+		flow := Flowcollector{
+			Namespace: namespace,
+			Template:  flowFixturePath,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("get primary IP address of sctpServerPod")
+		sctpServerPodIP, _ := getPodIP(oc, SCTPns, sctpServerPodname, ipStackType)
+
+		g.By("sctpserver pod start to wait for sctp traffic")
+		cmd, _, _, _ := oc.AsAdmin().Run("exec").Args("-n", SCTPns, sctpServerPodname, "--", "/usr/bin/ncat", "-l", "30102", "--sctp").Background()
+		defer func() { _ = cmd.Process.Kill() }()
+		time.Sleep(5 * time.Second)
+
+		g.By("check sctp process enabled in the sctp server pod")
+		msg, err := e2eoutput.RunHostCmd(SCTPns, sctpServerPodname, "ps aux | grep sctp")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(strings.Contains(msg, "/usr/bin/ncat -l 30102 --sctp")).To(o.BeTrue())
+
+		g.By("sctpclient pod start to send sctp traffic")
+		startTime := time.Now()
+		_, _ = e2eoutput.RunHostCmd(SCTPns, sctpClientPodname, "echo 'Test traffic using sctp port from sctpclient to sctpserver' | { ncat -v "+sctpServerPodIP+" 30102 --sctp; }")
+
+		g.By("server sctp process will end after get sctp traffic from sctp client")
+		time.Sleep(5 * time.Second)
+		msg1, err1 := e2eoutput.RunHostCmd(SCTPns, sctpServerPodname, "ps aux | grep sctp")
+		o.Expect(err1).NotTo(o.HaveOccurred())
+		o.Expect(msg1).NotTo(o.ContainSubstring("/usr/bin/ncat -l 30102 --sctp"))
+
+		// verify logs
+		g.By("Wait for a min before logs gets collected and written to loki")
+		time.Sleep(60 * time.Second)
+
+		// Scenario1: Verify SCTP traffic
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: SCTPns,
+			DstK8SNamespace: SCTPns,
+		}
+
+		g.By("Verify SCTP flows are seen on loki")
+		parameters := []string{"Proto=\"132\"", "DstPort=\"30102\""}
+
+		SCTPflows, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(SCTPflows)).Should(o.BeNumerically(">", 0), "expected number of SCTP flows > 0")
+
+		// Scenario2: Verify ICMP traffic
+		g.By("sctpclient ping sctpserver")
+		_, _ = e2eoutput.RunHostCmd(SCTPns, sctpClientPodname, "ping -c 10 "+sctpServerPodIP)
+		ICMPEchoReq := 8
+		ICMPEchoRes := 0
+		if ipStackType == "ipv4single" {
+			parameters = []string{"Proto=\"1\""}
+		}
+		g.By("test ipv6 in ipv6 cluster or dualstack cluster")
+		if ipStackType == "ipv6single" || ipStackType == "dualstack" {
+			parameters = []string{"Proto=\"58\""}
+			ICMPEchoReq = 128
+			ICMPEchoRes = 129
+		}
+
+		g.By("Wait for a min before logs gets collected and written to loki")
+		time.Sleep(60 * time.Second)
+
+		ICMPflows, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(ICMPflows)).Should(o.BeNumerically(">", 0), "expected number of ICMP flows > 0")
+
+		nICMPFlows := 0
+		for _, r := range ICMPflows {
+			if r.Flowlog.IcmpType == ICMPEchoReq || r.Flowlog.IcmpType == ICMPEchoRes {
+				nICMPFlows++
 			}
+		}
+		o.Expect(nICMPFlows).Should(o.BeNumerically(">", 0), "expected number of ICMP flows of type 8/128 or 0/129 (echo request or reply) > 0")
+	})
 
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
+	g.It("Author:aramesha-NonPreRelease-High-68125-Verify DSCP with NetObserv [Serial]", func() {
+		g.By("Deploying test server and client pods")
+		serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
+		testServerTemplate := TestServerTemplate{
+			ServerNS: "test-server-68125",
+			Template: serverTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
+		err := testServerTemplate.createServer(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
 
-			g.By("get primary IP address of sctpServerPod")
-			sctpServerPodIP, _ := getPodIP(oc, SCTPns, sctpServerPodname, ipStackType)
+		clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
+		testClientTemplate := TestClientTemplate{
+			ServerNS: testServerTemplate.ServerNS,
+			ClientNS: "test-client-68125",
+			Template: clientTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
+		err = testClientTemplate.createClient(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
 
-			g.By("sctpserver pod start to wait for sctp traffic")
-			cmd, _, _, _ := oc.AsAdmin().Run("exec").Args("-n", SCTPns, sctpServerPodname, "--", "/usr/bin/ncat", "-l", "30102", "--sctp").Background()
-			defer func() { _ = cmd.Process.Kill() }()
-			time.Sleep(5 * time.Second)
+		compat_otp.By("Check cluster network type")
+		networkType := compat_otp.CheckNetworkType(oc)
+		o.Expect(networkType).NotTo(o.BeEmpty())
+		if networkType == "ovnkubernetes" {
+			g.By("Deploy egressQoS for OVN CNI")
+			clientDSCPPath := filePath.Join(networkingDir, "test-client-DSCP.yaml")
+			egressQoSPath := filePath.Join(networkingDir, "egressQoS.yaml")
+			g.By("Deploy nginx client pod and egressQoS")
+			createResourceFromFile(oc, testClientTemplate.ClientNS, clientDSCPPath)
+			createResourceFromFile(oc, testClientTemplate.ClientNS, egressQoSPath)
+		}
 
-			g.By("check sctp process enabled in the sctp server pod")
-			msg, err := e2eoutput.RunHostCmd(SCTPns, sctpServerPodname, "ps aux | grep sctp")
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(strings.Contains(msg, "/usr/bin/ncat -l 30102 --sctp")).To(o.BeTrue())
+		g.By("Deploy FlowCollector")
+		flow := Flowcollector{
+			Namespace: namespace,
+			Template:  flowFixturePath,
+		}
 
-			g.By("sctpclient pod start to send sctp traffic")
-			startTime := time.Now()
-			_, _ = e2eoutput.RunHostCmd(SCTPns, sctpClientPodname, "echo 'Test traffic using sctp port from sctpclient to sctpserver' | { ncat -v "+sctpServerPodIP+" 30102 --sctp; }")
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
 
-			g.By("server sctp process will end after get sctp traffic from sctp client")
-			time.Sleep(5 * time.Second)
-			msg1, err1 := e2eoutput.RunHostCmd(SCTPns, sctpServerPodname, "ps aux | grep sctp")
-			o.Expect(err1).NotTo(o.HaveOccurred())
-			o.Expect(msg1).NotTo(o.ContainSubstring("/usr/bin/ncat -l 30102 --sctp"))
+		// verify logs
+		g.By("Wait for a min before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(60 * time.Second)
 
-			// verify logs
-			g.By("Wait for a min before logs gets collected and written to loki")
-			time.Sleep(60 * time.Second)
+		// Scenario1: Verify default DSCP value=0
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: testClientTemplate.ClientNS,
+			DstK8SNamespace: testClientTemplate.ServerNS,
+		}
+		parameters := []string{"SrcK8S_Name=\"client\""}
 
-			// Scenario1: Verify SCTP traffic
-			lokilabels := Lokilabels{
-				App:             "netobserv-flowcollector",
-				SrcK8SNamespace: SCTPns,
-				DstK8SNamespace: SCTPns,
-			}
+		g.By("Verify DSCP value=0")
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows > 0")
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.Dscp).To(o.Equal(0))
+		}
 
-			g.By("Verify SCTP flows are seen on loki")
-			parameters := []string{"Proto=\"132\"", "DstPort=\"30102\""}
-
-			SCTPflows, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(SCTPflows)).Should(o.BeNumerically(">", 0), "expected number of SCTP flows > 0")
-
-			// Scenario2: Verify ICMP traffic
-			g.By("sctpclient ping sctpserver")
-			_, _ = e2eoutput.RunHostCmd(SCTPns, sctpClientPodname, "ping -c 10 "+sctpServerPodIP)
-			ICMPEchoReq := 8
-			ICMPEchoRes := 0
-			if ipStackType == "ipv4single" {
-				parameters = []string{"Proto=\"1\""}
-			}
-			g.By("test ipv6 in ipv6 cluster or dualstack cluster")
-			if ipStackType == "ipv6single" || ipStackType == "dualstack" {
-				parameters = []string{"Proto=\"58\""}
-				ICMPEchoReq = 128
-				ICMPEchoRes = 129
-			}
-
-			g.By("Wait for a min before logs gets collected and written to loki")
-			time.Sleep(60 * time.Second)
-
-			ICMPflows, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(ICMPflows)).Should(o.BeNumerically(">", 0), "expected number of ICMP flows > 0")
-
-			nICMPFlows := 0
-			for _, r := range ICMPflows {
-				if r.Flowlog.IcmpType == ICMPEchoReq || r.Flowlog.IcmpType == ICMPEchoRes {
-					nICMPFlows++
-				}
-			}
-			o.Expect(nICMPFlows).Should(o.BeNumerically(">", 0), "expected number of ICMP flows of type 8/128 or 0/129 (echo request or reply) > 0")
-		})
-
-		g.It("Author:aramesha-NonPreRelease-High-68125-Verify DSCP with NetObserv [Serial]", func() {
-			SkipIfOCPBelow("v4.14")
-			g.By("Deploying test server and client pods")
-			serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
-			testServerTemplate := TestServerTemplate{
-				ServerNS: "test-server-68125",
-				Template: serverTemplate,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
-			err := testServerTemplate.createServer(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
-
-			clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
-			testClientTemplate := TestClientTemplate{
-				ServerNS: testServerTemplate.ServerNS,
-				ClientNS: "test-client-68125",
-				Template: clientTemplate,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
-			err = testClientTemplate.createClient(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
-
-			compat_otp.By("Check cluster network type")
-			networkType := compat_otp.CheckNetworkType(oc)
-			o.Expect(networkType).NotTo(o.BeEmpty())
-			if networkType == "ovnkubernetes" {
-				g.By("Deploy egressQoS for OVN CNI")
-				clientDSCPPath := filePath.Join(networkingDir, "test-client-DSCP.yaml")
-				egressQoSPath := filePath.Join(networkingDir, "egressQoS.yaml")
-				g.By("Deploy nginx client pod and egressQoS")
-				createResourceFromFile(oc, testClientTemplate.ClientNS, clientDSCPPath)
-				createResourceFromFile(oc, testClientTemplate.ClientNS, egressQoSPath)
-			}
-
-			g.By("Deploy FlowCollector")
-			flow := Flowcollector{
-				Namespace:     namespace,
-				Template:      flowFixturePath,
-				LokiNamespace: lokiStackNS,
-			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			// verify logs
-			g.By("Wait for a min before logs gets collected and written to loki")
-			startTime := time.Now()
-			time.Sleep(60 * time.Second)
-
-			// Scenario1: Verify default DSCP value=0
-			lokilabels := Lokilabels{
-				App:             "netobserv-flowcollector",
-				SrcK8SNamespace: testClientTemplate.ClientNS,
-				DstK8SNamespace: testClientTemplate.ServerNS,
-			}
-			parameters := []string{"SrcK8S_Name=\"client\""}
-
-			g.By("Verify DSCP value=0")
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows > 0")
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.Dscp).To(o.Equal(0))
-			}
-
-			// Scenario2: Verify egress QoS feature for OVN CNI
-			if networkType == "ovnkubernetes" {
-				parameters = []string{"SrcK8S_Name=\"client-dscp\", Dscp=\"59\""}
-
-				g.By("Wait for a min before logs gets collected and written to loki")
-				time.Sleep(60 * time.Second)
-
-				g.By("Verify DSCP value=59 for flows from DSCP client pod")
-				flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows with DSCP value 59 should be > 0")
-
-				g.By("Verify DSCP value=0 for flows from pods other than DSCP client pod in test-client namespace")
-				parameters = []string{"SrcK8S_Name=\"client\", Dscp=\"0\""}
-
-				flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows with DSCP value 0 should be > 0")
-			}
-
-			// Scenario3: Explicitly passing QoS value in ping command
-			var destinationIP string
-			switch ipStackType {
-			case "ipv4single":
-				destinationIP = "1.1.1.1"
-			case "ipv6single":
-				destinationIP = "::1"
-			default:
-				destinationIP = "1.1.1.1"
-			}
-
-			g.By("Ping loopback address with custom QoS from client pod")
-			startTime = time.Now()
-			_, _ = e2eoutput.RunHostCmd(testClientTemplate.ClientNS, "client", "ping -c 10 -Q 0x80 "+destinationIP)
-
-			lokilabels = Lokilabels{
-				App:             "netobserv-flowcollector",
-				SrcK8SNamespace: testClientTemplate.ClientNS,
-			}
-			parameters = []string{"Dscp=\"32\", DstAddr=\"" + destinationIP + "\""}
+		// Scenario2: Verify egress QoS feature for OVN CNI
+		if networkType == "ovnkubernetes" {
+			parameters = []string{"SrcK8S_Name=\"client-dscp\", Dscp=\"59\""}
 
 			g.By("Wait for a min before logs gets collected and written to loki")
 			time.Sleep(60 * time.Second)
 
-			g.By("Verify DSCP value=32")
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
+			g.By("Verify DSCP value=59 for flows from DSCP client pod")
+			flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows with DSCP value 32 > 0")
-		})
+			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows with DSCP value 59 should be > 0")
 
-		g.It("Author:aramesha-NonPreRelease-High-69218-High-71291-Verify cluster ID and zone in multiCluster deployment [Serial]", func() {
-			SkipIfOCPBelow("v4.11")
-			g.By("Get clusterID of the cluster")
-			clusterID, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterversion", "-o=jsonpath={.items[].spec.clusterID}").Output()
+			g.By("Verify DSCP value=0 for flows from pods other than DSCP client pod in test-client namespace")
+			parameters = []string{"SrcK8S_Name=\"client\", Dscp=\"0\""}
+
+			flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
 			o.Expect(err).NotTo(o.HaveOccurred())
-			e2e.Logf("Cluster ID is %s", clusterID)
+			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows with DSCP value 0 should be > 0")
+		}
 
-			g.By("Deploy FlowCollector with multiCluster and addZone enabled")
-			flow := Flowcollector{
-				Namespace:              namespace,
-				MultiClusterDeployment: "true",
-				AddZone:                "true",
-				Template:               flowFixturePath,
-				LokiNamespace:          lokiStackNS,
-			}
+		// Scenario3: Explicitly passing QoS value in ping command
+		var destinationIP string
+		switch ipStackType {
+		case "ipv4single":
+			destinationIP = "1.1.1.1"
+		case "ipv6single":
+			destinationIP = "::1"
+		default:
+			destinationIP = "1.1.1.1"
+		}
 
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
+		g.By("Ping loopback address with custom QoS from client pod")
+		startTime = time.Now()
+		_, _ = e2eoutput.RunHostCmd(testClientTemplate.ClientNS, "client", "ping -c 10 -Q 0x80 "+destinationIP)
 
-			// verify logs
-			g.By("Wait for a min before logs gets collected and written to loki")
-			startTime := time.Now()
-			time.Sleep(60 * time.Second)
+		lokilabels = Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: testClientTemplate.ClientNS,
+		}
+		parameters = []string{"Dscp=\"32\", DstAddr=\"" + destinationIP + "\""}
 
-			g.By("Verify K8SClusterName = Cluster ID")
-			clusteridlabels := Lokilabels{
-				App:            "netobserv-flowcollector",
-				K8SClusterName: clusterID,
-			}
-			clusterIDFlowRecords, err := clusteridlabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
+		g.By("Wait for a min before logs gets collected and written to loki")
+		time.Sleep(60 * time.Second)
+
+		g.By("Verify DSCP value=32")
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows with DSCP value 32 > 0")
+	})
+
+	g.It("Author:aramesha-NonPreRelease-High-69218-High-71291-Verify cluster ID and zone in multiCluster deployment [Serial]", func() {
+		g.By("Get clusterID of the cluster")
+		clusterID, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterversion", "-o=jsonpath={.items[].spec.clusterID}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		e2e.Logf("Cluster ID is %s", clusterID)
+
+		g.By("Deploy FlowCollector with multiCluster and addZone enabled")
+		flow := Flowcollector{
+			Namespace:              namespace,
+			MultiClusterDeployment: "true",
+			AddZone:                "true",
+			Template:               flowFixturePath,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		// verify logs
+		g.By("Wait for a min before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(60 * time.Second)
+
+		g.By("Verify K8SClusterName = Cluster ID")
+		clusteridlabels := Lokilabels{
+			App:            "netobserv-flowcollector",
+			K8SClusterName: clusterID,
+		}
+		clusterIDFlowRecords, err := clusteridlabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(clusterIDFlowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows > 0")
+
+		g.By("Verify SrcK8S_Zone and DstK8S_Zone are present and have expected values")
+		zonelabels := Lokilabels{
+			App:        "netobserv-flowcollector",
+			SrcK8SType: "Node",
+			DstK8SType: "Node",
+		}
+
+		zoneFlowRecords, err := zonelabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		for _, r := range zoneFlowRecords {
+			expectedSrcK8SZone, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node/"+r.Flowlog.SrcK8SHostName, `-o=jsonpath={.metadata.labels.topology\.kubernetes\.io/zone}`).Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(clusterIDFlowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows > 0")
+			o.Expect(r.Flowlog.SrcK8SZone).To(o.Equal(expectedSrcK8SZone))
 
-			g.By("Verify SrcK8S_Zone and DstK8S_Zone are present and have expected values")
-			zonelabels := Lokilabels{
-				App:        "netobserv-flowcollector",
-				SrcK8SType: "Node",
-				DstK8SType: "Node",
-			}
-
-			zoneFlowRecords, err := zonelabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
+			expectedDstK8SZone, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node/"+r.Flowlog.DstK8SHostName, `-o=jsonpath={.metadata.labels.topology\.kubernetes\.io/zone}`).Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			for _, r := range zoneFlowRecords {
-				expectedSrcK8SZone, err := compat_otp.GetResourceSpecificLabelValue(oc, "node/"+r.Flowlog.SrcK8SHostName, "", `topology.kubernetes.io/zone`)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(r.Flowlog.SrcK8SZone).To(o.Equal(expectedSrcK8SZone))
+			o.Expect(r.Flowlog.DstK8SZone).To(o.Equal(expectedDstK8SZone))
+		}
+	})
 
-				expectedDstK8SZone, err := compat_otp.GetResourceSpecificLabelValue(oc, "node/"+r.Flowlog.DstK8SHostName, "", `topology.kubernetes.io/zone`)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(r.Flowlog.DstK8SZone).To(o.Equal(expectedDstK8SZone))
+	g.It("Author:aramesha-NonPreRelease-Longduration-High-73175-Verify eBPF agent filtering [Serial]", func() {
+		g.By("Deploy test server and client pods")
+		serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
+		testServerTemplate := TestServerTemplate{
+			ServerNS: "test-server-73175",
+			Template: serverTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
+		err := testServerTemplate.createServer(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
+
+		clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
+		testClientTemplate := TestClientTemplate{
+			ServerNS: testServerTemplate.ServerNS,
+			ClientNS: "test-client-73175",
+			Template: clientTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
+		err = testClientTemplate.createClient(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
+
+		clientServiceInfo, err := getClientServerInfo(oc, testClientTemplate.ServerNS, testClientTemplate.ClientNS, ipStackType)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Scenario 1:
+		// Accept TCP flows between client pod and nginx-service
+		// Accept ICMP flows between client and nginx pod
+		// Default Reject all other flows
+		g.By("Deploy FlowCollector with eBPF filter")
+		filterRulesConfig := []map[string]interface{}{
+			{
+				"action":   "Accept",
+				"cidr":     clientServiceInfo["service"]["ip"] + "/32",
+				"peerIP":   clientServiceInfo["client"]["ip"],
+				"protocol": "TCP",
+				"ports":    "80",
+				"sampling": 2,
+			},
+			{
+				"action":   "Accept",
+				"cidr":     clientServiceInfo["client"]["ip"] + "/32",
+				"peerCIDR": clientServiceInfo["server"]["ip"] + "/32",
+				"protocol": "ICMP",
+				"icmpType": 8,
+				"sampling": 3,
+			},
+		}
+
+		config, err := json.Marshal(filterRulesConfig)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		filter := string(config)
+
+		flow := Flowcollector{
+			Namespace:       namespace,
+			Template:        flowFixturePath,
+			EBPFFilterRules: filter,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Ping nginx pod from client pod")
+		startTime := time.Now()
+		_, _ = e2eoutput.RunHostCmd(testClientTemplate.ClientNS, clientServiceInfo["client"]["name"], "ping -c 10 "+clientServiceInfo["server"]["ip"])
+
+		g.By("Wait for a min before logs gets collected and written to loki")
+		time.Sleep(60 * time.Second)
+
+		lokilabels := Lokilabels{
+			App: "netobserv-flowcollector",
+		}
+
+		g.By("Verify number of flows with on UDP Protcol with SrcPort 53 = 0")
+		lokilabels.AllowEmpty = true
+		lokiParams := []string{"Proto=\"17\"", "SrcPort=\"53\""}
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically("==", 0), "expected number of flows on UDP with SrcPort 53 = 0")
+		lokilabels.AllowEmpty = false
+
+		g.By("Verify flows from client pod to nginx pod > 0")
+		lokilabels.SrcK8SNamespace = testClientTemplate.ClientNS
+		lokilabels.DstK8SNamespace = testClientTemplate.ServerNS
+		lokiParams = []string{"SrcAddr=" + "\"" + clientServiceInfo["client"]["ip"] + "\"", "DstAddr=" + "\"" + clientServiceInfo["server"]["ip"] + "\""}
+
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows from client pod to nginx pod > 0")
+
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.Proto).Should(o.BeNumerically("==", 1))
+			o.Expect(r.Flowlog.IcmpType).Should(o.BeNumerically("==", 8))
+			o.Expect(r.Flowlog.Sampling).Should(o.BeNumerically("==", 3))
+		}
+
+		g.By("Verify flows from client pod to nginx-service > 0")
+		lokilabels.DstK8SType = "Service"
+
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows from client pod to nginx-service > 0")
+
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.Proto).Should(o.BeNumerically("==", 6))
+			o.Expect(r.Flowlog.Sampling).Should(o.BeNumerically("==", 2))
+		}
+
+		g.By("Verify prometheus is able to scrape eBPF metrics")
+		verifyEBPFFilterMetrics(oc, "FilterAccept")
+		verifyEBPFFilterMetrics(oc, "FilterNoMatch")
+
+		// Scenario2:
+		// Accept only flows with drops
+		g.By("Deploy flowcollector with eBPF filter for flows with drops")
+		filterRulesConfig = []map[string]interface{}{
+			{
+				"action":   "Accept",
+				"cidr":     "172.30.0.0/16",
+				"pktDrops": true,
+			},
+		}
+
+		config, err = json.Marshal(filterRulesConfig)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		filter = string(config)
+
+		_ = flow.DeleteFlowcollector(oc)
+		flow.EBPFPrivileged = "true"
+		flow.EBPFeatures = []string{"\"PacketDrop\""}
+		flow.EBPFFilterRules = filter
+		flow.CreateFlowcollector(oc)
+
+		g.By("Wait for a min before logs gets collected and written to loki")
+		startTime = time.Now()
+		time.Sleep(60 * time.Second)
+
+		lokilabels = Lokilabels{
+			App: "netobserv-flowcollector",
+		}
+		lokiParams = []string{"Proto=\"6\""}
+
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows with drops > 0")
+
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.PktDropPackets).Should(o.BeNumerically(">", 0))
+		}
+	})
+
+	g.It("Author:memodi-Critical-53844-Sanity Test NetObserv [Serial]", func() {
+		g.By("Deploy FlowCollector")
+		flow := Flowcollector{
+			Namespace: namespace,
+			Template:  flowFixturePath,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Wait for a min before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(60 * time.Second)
+
+		lokilabels := Lokilabels{
+			App: "netobserv-flowcollector",
+		}
+
+		g.By("Verify flows are written to loki")
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows written to loki > 0")
+	})
+
+	g.It("Author:aramesha-High-67782-Verify large volume downloads [Serial]", func() {
+		g.By("Deploy FlowCollector")
+		flow := Flowcollector{
+			Namespace:              namespace,
+			Template:               flowFixturePath,
+			EBPFCacheActiveTimeout: "30s",
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Deploy test server and client pods")
+		serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
+		testServerTemplate := TestServerTemplate{
+			ServerNS:  "test-server-67782",
+			Template:  serverTemplate,
+			LargeBlob: "yes",
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
+		err := testServerTemplate.createServer(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
+
+		clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
+		testClientTemplate := TestClientTemplate{
+			ServerNS:   testServerTemplate.ServerNS,
+			ClientNS:   "test-client-67782",
+			ObjectSize: "100M",
+			Template:   clientTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
+		err = testClientTemplate.createClient(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
+
+		g.By("Wait for 2 mins before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(120 * time.Second)
+
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: testClientTemplate.ServerNS,
+			DstK8SNamespace: testClientTemplate.ClientNS,
+			SrcK8SOwnerName: "nginx-service",
+			FlowDirection:   "0",
+		}
+
+		g.By("Verify flows are written to loki")
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows written to loki > 0")
+
+		g.By("Verify flow correctness")
+		verifyFlowCorrectness(testClientTemplate.ObjectSize, flowRecords)
+	})
+
+	g.It("Author:aramesha-High-75656-Verify TCP flags [Disruptive]", func() {
+		SYNFloodMetricsPath := filePath.Join(baseDir, "SYN_flood_metrics_template.yaml")
+		SYNFloodAlertsPath := filePath.Join(baseDir, "SYN_flood_alert_template.yaml")
+
+		g.By("Deploy flowcollector with eBPF filter to Reject flows with tcpFlags SYN-ACK and TCP Protocol")
+		filterRulesConfig := []map[string]string{
+			{
+				"action":   "Reject",
+				"cidr":     "0.0.0.0/0",
+				"protocol": "TCP",
+				"tcpFlags": "SYN-ACK",
+			},
+		}
+
+		config, err := json.Marshal(filterRulesConfig)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		filter := string(config)
+
+		flow := Flowcollector{
+			Namespace:       namespace,
+			Template:        flowFixturePath,
+			EBPFFilterRules: filter,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Ensure flowcollector is ready with Reject flowFilter")
+		flowPatch, err := oc.AsAdmin().Run("get").Args("flowcollector", "cluster", "-o", "jsonpath='{.spec.agent.ebpf.flowFilter.rules[0].action}'").Output()
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(flowPatch).To(o.Equal(`'Reject'`))
+
+		g.By("Deploy custom metrics to detect SYN flooding")
+		customMetrics := CustomMetrics{
+			Namespace: namespace,
+			Template:  SYNFloodMetricsPath,
+		}
+
+		curv, err := getResourceVersion(oc, "cm", "flowlogs-pipeline-config-dynamic", namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		customMetrics.createCustomMetrics(oc)
+		waitForResourceGenerationUpdate(oc, "cm", "flowlogs-pipeline-config-dynamic", "resourceVersion", curv, namespace)
+
+		g.By("Deploy SYN flooding alert rule")
+		defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("alertingrule.monitoring.openshift.io", "netobserv-syn-alerts", "-n", "openshift-monitoring")
+		configFile := compat_otp.ProcessTemplate(oc, "--ignore-unknown-parameters=true", "-f", SYNFloodAlertsPath, "-p", "Namespace=openshift-monitoring")
+		err = oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", configFile).Execute()
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		g.By("Deploy test client pod to induce SYN flooding")
+		template := filePath.Join(baseDir, "test-SYN-flood-client_template.yaml")
+		testTemplate := TestClientTemplate{
+			ClientNS: "test-client-75656",
+			Template: template,
+		}
+
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testTemplate.ClientNS)
+		configFile = compat_otp.ProcessTemplate(oc, "--ignore-unknown-parameters=true", "-f", testTemplate.Template, "-p", "CLIENT_NS="+testTemplate.ClientNS)
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", configFile).Execute()
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		g.By("Wait for a min before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(60 * time.Second)
+
+		lokilabels := Lokilabels{
+			App: "netobserv-flowcollector",
+		}
+
+		g.By("Verify no flows with SYN_ACK TCP flag")
+		parameters := []string{"Flags=\"SYN_ACK\""}
+
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		// Loop needed since even flows with flags SYN, ACK are matched
+		for _, r := range flowRecords {
+			for _, f := range r.Flowlog.Flags {
+				o.Expect(f).ToNot(o.Equal("SYN_ACK"), "expected no flows with SYN_ACK TCPFlag")
 			}
-		})
-
-		g.It("Author:aramesha-NonPreRelease-Longduration-High-73175-Verify eBPF agent filtering [Serial]", func() {
-			SkipIfOCPBelow("v4.14")
-			g.By("Deploy test server and client pods")
-			serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
-			testServerTemplate := TestServerTemplate{
-				ServerNS: "test-server-73175",
-				Template: serverTemplate,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
-			err := testServerTemplate.createServer(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
-
-			clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
-			testClientTemplate := TestClientTemplate{
-				ServerNS: testServerTemplate.ServerNS,
-				ClientNS: "test-client-73175",
-				Template: clientTemplate,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
-			err = testClientTemplate.createClient(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
-
-			clientServiceInfo, err := getClientServerInfo(oc, testClientTemplate.ServerNS, testClientTemplate.ClientNS, ipStackType)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			// Scenario 1:
-			// Accept TCP flows between client pod and nginx-service
-			// Accept ICMP flows between client and nginx pod
-			// Default Reject all other flows
-			g.By("Deploy FlowCollector with eBPF filter")
-			filterRulesConfig := []map[string]interface{}{
-				{
-					"action":   "Accept",
-					"cidr":     clientServiceInfo["service"]["ip"] + "/32",
-					"peerIP":   clientServiceInfo["client"]["ip"],
-					"protocol": "TCP",
-					"ports":    "80",
-					"sampling": 2,
-				},
-				{
-					"action":   "Accept",
-					"cidr":     clientServiceInfo["client"]["ip"] + "/32",
-					"peerCIDR": clientServiceInfo["server"]["ip"] + "/32",
-					"protocol": "ICMP",
-					"icmpType": 8,
-					"sampling": 3,
-				},
-			}
-
-			config, err := json.Marshal(filterRulesConfig)
-			o.Expect(err).ToNot(o.HaveOccurred())
-			filter := string(config)
-
-			flow := Flowcollector{
-				Namespace:       namespace,
-				Template:        flowFixturePath,
-				LokiNamespace:   lokiStackNS,
-				EBPFFilterRules: filter,
-			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			g.By("Ping nginx pod from client pod")
-			startTime := time.Now()
-			_, _ = e2eoutput.RunHostCmd(testClientTemplate.ClientNS, clientServiceInfo["client"]["name"], "ping -c 10 "+clientServiceInfo["server"]["ip"])
-
-			g.By("Wait for a min before logs gets collected and written to loki")
-			time.Sleep(60 * time.Second)
-
-			lokilabels := Lokilabels{
-				App: "netobserv-flowcollector",
-			}
-
-			g.By("Verify number of flows with on UDP Protcol with SrcPort 53 = 0")
-			lokiParams := []string{"Proto=\"17\"", "SrcPort=\"53\""}
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically("==", 0), "expected number of flows on UDP with SrcPort 53 = 0")
-
-			g.By("Verify flows from client pod to nginx pod > 0")
-			lokilabels.SrcK8SNamespace = testClientTemplate.ClientNS
-			lokilabels.DstK8SNamespace = testClientTemplate.ServerNS
-			lokiParams = []string{"SrcAddr=" + "\"" + clientServiceInfo["client"]["ip"] + "\"", "DstAddr=" + "\"" + clientServiceInfo["server"]["ip"] + "\""}
-
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows from client pod to nginx pod > 0")
-
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.Proto).Should(o.BeNumerically("==", 1))
-				o.Expect(r.Flowlog.IcmpType).Should(o.BeNumerically("==", 8))
-				o.Expect(r.Flowlog.Sampling).Should(o.BeNumerically("==", 3))
-			}
-
-			g.By("Verify flows from client pod to nginx-service > 0")
-			lokilabels.DstK8SType = "Service"
-
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows from client pod to nginx-service > 0")
-
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.Proto).Should(o.BeNumerically("==", 6))
-				o.Expect(r.Flowlog.Sampling).Should(o.BeNumerically("==", 2))
-			}
-
-			g.By("Verify prometheus is able to scrape eBPF metrics")
-			verifyEBPFFilterMetrics(oc, "FilterAccept")
-			verifyEBPFFilterMetrics(oc, "FilterNoMatch")
-
-			// Scenario2:
-			// Accept only flows with drops
-			g.By("Deploy flowcollector with eBPF filter for flows with drops")
-			filterRulesConfig = []map[string]interface{}{
-				{
-					"action":   "Accept",
-					"cidr":     "172.30.0.0/16",
-					"pktDrops": true,
-				},
-			}
-
-			config, err = json.Marshal(filterRulesConfig)
-			o.Expect(err).ToNot(o.HaveOccurred())
-			filter = string(config)
-
-			_ = flow.DeleteFlowcollector(oc)
-			flow.EBPFPrivileged = "true"
-			flow.EBPFeatures = []string{"\"PacketDrop\""}
-			flow.EBPFFilterRules = filter
-			flow.CreateFlowcollector(oc)
-
-			g.By("Wait for a min before logs gets collected and written to loki")
-			startTime = time.Now()
-			time.Sleep(60 * time.Second)
-
-			lokilabels = Lokilabels{
-				App: "netobserv-flowcollector",
-			}
-			lokiParams = []string{"Proto=\"6\""}
-
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows with drops > 0")
-
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.PktDropBytes).Should(o.BeNumerically(">", 0))
-				o.Expect(r.Flowlog.PktDropPackets).Should(o.BeNumerically(">", 0))
-			}
-		})
-
-		g.It("Author:memodi-Critical-53844-Sanity Test NetObserv [Serial]", func() {
-			SkipIfOCPBelow("v4.11")
-			g.By("Deploy FlowCollector")
-			flow := Flowcollector{
-				Namespace:     namespace,
-				Template:      flowFixturePath,
-				LokiNamespace: lokiStackNS,
-			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			g.By("Wait for a min before logs gets collected and written to loki")
-			startTime := time.Now()
-			time.Sleep(60 * time.Second)
-
-			lokilabels := Lokilabels{
-				App: "netobserv-flowcollector",
-			}
-
-			g.By("Verify flows are written to loki")
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows written to loki > 0")
-		})
-
-		g.It("Author:aramesha-High-67782-Verify large volume downloads [Serial]", func() {
-			SkipIfOCPBelow("v4.11")
-			g.By("Deploy FlowCollector")
-			flow := Flowcollector{
-				Namespace:              namespace,
-				Template:               flowFixturePath,
-				LokiNamespace:          lokiStackNS,
-				EBPFCacheActiveTimeout: "30s",
-			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			g.By("Deploy test server and client pods")
-			serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
-			testServerTemplate := TestServerTemplate{
-				ServerNS:  "test-server-67782",
-				Template:  serverTemplate,
-				LargeBlob: "yes",
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
-			err := testServerTemplate.createServer(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
-
-			clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
-			testClientTemplate := TestClientTemplate{
-				ServerNS:   testServerTemplate.ServerNS,
-				ClientNS:   "test-client-67782",
-				ObjectSize: "100M",
-				Template:   clientTemplate,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
-			err = testClientTemplate.createClient(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
-
-			g.By("Wait for 2 mins before logs gets collected and written to loki")
-			startTime := time.Now()
-			time.Sleep(120 * time.Second)
-
-			lokilabels := Lokilabels{
-				App:             "netobserv-flowcollector",
-				SrcK8SNamespace: testClientTemplate.ServerNS,
-				DstK8SNamespace: testClientTemplate.ClientNS,
-				SrcK8SOwnerName: "nginx-service",
-				FlowDirection:   "0",
-			}
-
-			g.By("Verify flows are written to loki")
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows written to loki > 0")
-
-			g.By("Verify flow correctness")
-			verifyFlowCorrectness(testClientTemplate.ObjectSize, flowRecords)
-		})
-
-		g.It("Author:aramesha-High-75656-Verify TCP flags [Disruptive]", func() {
-			SkipIfOCPBelow("v4.13")
-			SYNFloodMetricsPath := filePath.Join(baseDir, "SYN_flood_metrics_template.yaml")
-			SYNFloodAlertsPath := filePath.Join(baseDir, "SYN_flood_alert_template.yaml")
-
-			g.By("Deploy flowcollector with eBPF filter to Reject flows with tcpFlags SYN-ACK and TCP Protocol")
-			filterRulesConfig := []map[string]string{
-				{
-					"action":   "Reject",
-					"cidr":     "0.0.0.0/0",
-					"protocol": "TCP",
-					"tcpFlags": "SYN-ACK",
-				},
-			}
-
-			config, err := json.Marshal(filterRulesConfig)
-			o.Expect(err).ToNot(o.HaveOccurred())
-			filter := string(config)
-
-			flow := Flowcollector{
-				Namespace:       namespace,
-				Template:        flowFixturePath,
-				LokiNamespace:   lokiStackNS,
-				EBPFFilterRules: filter,
-			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			g.By("Ensure flowcollector is ready with Reject flowFilter")
-			flowPatch, err := oc.AsAdmin().Run("get").Args("flowcollector", "cluster", "-o", "jsonpath='{.spec.agent.ebpf.flowFilter.rules[0].action}'").Output()
-			o.Expect(err).ToNot(o.HaveOccurred())
-			o.Expect(flowPatch).To(o.Equal(`'Reject'`))
-
-			g.By("Deploy custom metrics to detect SYN flooding")
-			customMetrics := CustomMetrics{
-				Namespace: namespace,
-				Template:  SYNFloodMetricsPath,
-			}
-
-			curv, err := getResourceVersion(oc, "cm", "flowlogs-pipeline-config-dynamic", namespace)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			customMetrics.createCustomMetrics(oc)
-			waitForResourceGenerationUpdate(oc, "cm", "flowlogs-pipeline-config-dynamic", "resourceVersion", curv, namespace)
-
-			g.By("Deploy SYN flooding alert rule")
-			defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("alertingrule.monitoring.openshift.io", "netobserv-syn-alerts", "-n", "openshift-monitoring")
-			configFile := compat_otp.ProcessTemplate(oc, "--ignore-unknown-parameters=true", "-f", SYNFloodAlertsPath, "-p", "Namespace=openshift-monitoring")
-			err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", configFile).Execute()
-			o.Expect(err).ToNot(o.HaveOccurred())
-
-			g.By("Deploy test client pod to induce SYN flooding")
-			template := filePath.Join(baseDir, "test-SYN-flood-client_template.yaml")
-			testTemplate := TestClientTemplate{
-				ClientNS: "test-client-75656",
-				Template: template,
-			}
-
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testTemplate.ClientNS)
-			configFile = compat_otp.ProcessTemplate(oc, "--ignore-unknown-parameters=true", "-f", testTemplate.Template, "-p", "CLIENT_NS="+testTemplate.ClientNS)
-			err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", configFile).Execute()
-			o.Expect(err).ToNot(o.HaveOccurred())
-
-			g.By("Wait for a min before logs gets collected and written to loki")
-			startTime := time.Now()
-			time.Sleep(60 * time.Second)
-
-			lokilabels := Lokilabels{
-				App: "netobserv-flowcollector",
-			}
-
-			g.By("Verify no flows with SYN_ACK TCP flag")
-			parameters := []string{"Flags=\"SYN_ACK\""}
-
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			// Loop needed since even flows with flags SYN, ACK are matched
-			count := 0
-			for _, r := range flowRecords {
-				for _, f := range r.Flowlog.Flags {
-					o.Expect(f).ToNot(o.Equal("SYN_ACK"))
-				}
-			}
-			o.Expect(count).Should(o.BeNumerically("==", 0), "expected number of flows with SYN_ACK TCPFlag = 0")
-			verifyEBPFFilterMetrics(oc, "FilterReject")
-
-			g.By("Verify SYN flooding flows")
-			parameters = []string{"Flags=\"SYN\"", "DstAddr=\"192.168.1.159\""}
-
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of SYN flows > 0")
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.Bytes).Should(o.BeNumerically("==", 54))
-			}
-
-			g.By("Wait for alerts to be active")
-			waitForAlertToBeActive(oc, "NetObserv-SYNFlood-out")
-			waitForAlertToBeActive(oc, "NetObserv-SYNFlood-in")
-		})
-
-		g.It("Author:aramesha-NonPreRelease-Longduration-Medium-78480-NetObserv with sampling 50 [Serial][Slow]", func() {
-			g.By("Deploy DNS pods")
-			DNSTemplate := filePath.Join(baseDir, "DNS-pods.yaml")
-			DNSNamespace := "dns-traffic"
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(DNSNamespace)
-			ApplyResourceFromFile(oc, DNSNamespace, DNSTemplate)
-			compat_otp.AssertAllPodsToBeReady(oc, DNSNamespace)
-
-			g.By("Deploy test server and client pods")
-			servertemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
-			testServerTemplate := TestServerTemplate{
-				ServerNS: "test-server-78480",
-				Template: servertemplate,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
-			err := testServerTemplate.createServer(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
-
-			clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
-			testClientTemplate := TestClientTemplate{
-				ServerNS: testServerTemplate.ServerNS,
-				ClientNS: "test-client-78480",
-				Template: clientTemplate,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
-			err = testClientTemplate.createClient(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
-
-			g.By("Deploy FlowCollector with all features enabled with sampling 50")
-			flow := Flowcollector{
-				Namespace:      namespace,
-				EBPFPrivileged: "true",
-				EBPFeatures:    []string{"\"DNSTracking\", \"PacketDrop\", \"FlowRTT\", \"PacketTranslation\""},
-				Sampling:       "50",
-				LokiNamespace:  lokiStackNS,
-				Template:       flowFixturePath,
-			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			g.By("Wait for 4 mins before logs gets collected and written to loki")
-			startTime := time.Now()
-			time.Sleep(240 * time.Second)
-
-			lokilabels := Lokilabels{
-				App: "netobserv-flowcollector",
-			}
-
-			g.By("Verify Packet Drop flows")
-			lokiParams := []string{"PktDropLatestState=\"TCP_INVALID_STATE\"", "Proto=\"6\""}
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of TCP Invalid State flows > 0")
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.PktDropLatestDropCause).NotTo(o.BeEmpty())
-				o.Expect(r.Flowlog.PktDropBytes).Should(o.BeNumerically(">", 0))
-				o.Expect(r.Flowlog.PktDropPackets).Should(o.BeNumerically(">", 0))
-			}
-
-			lokiParams = []string{"PktDropLatestDropCause=\"SKB_DROP_REASON_NO_SOCKET\"", "Proto=\"6\""}
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of No Socket TCP flows > 0")
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.PktDropLatestState).NotTo(o.BeEmpty())
-				o.Expect(r.Flowlog.PktDropBytes).Should(o.BeNumerically(">", 0))
-				o.Expect(r.Flowlog.PktDropPackets).Should(o.BeNumerically(">", 0))
-			}
-
-			g.By("Verify flowRTT flows")
-			lokiParams = []string{"Proto=\"6\""}
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of TCP flows > 0")
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.TimeFlowRttNs).Should(o.BeNumerically(">=", 0))
-			}
-
-			g.By("Verify TCP DNS flows")
-			lokilabels.DstK8SNamespace = DNSNamespace
-			lokiParams = []string{"DnsFlagsResponseCode=\"NoError\"", "SrcPort=\"53\"", "DstK8S_Name=\"dnsutils1\"", "Proto=\"6\""}
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of TCP DNS flows > 0")
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.DNSLatencyMs).Should(o.BeNumerically(">=", 0))
-			}
-
-			g.By("Verify UDP DNS flows")
-			lokiParams = []string{"DnsFlagsResponseCode=\"NoError\"", "SrcPort=\"53\"", "Proto=\"17\""}
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of UDP DNS flows > 0")
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.DNSLatencyMs).Should(o.BeNumerically(">=", 0))
-			}
-
-			g.By("Verify Packet Translation flows")
-			lokilabels = Lokilabels{
-				App:             "netobserv-flowcollector",
-				DstK8SOwnerName: "nginx-service",
-				DstK8SNamespace: testClientTemplate.ServerNS,
-				SrcK8SNamespace: testClientTemplate.ClientNS,
-				SrcK8SOwnerName: "client",
-			}
-
-			clientServiceInfo, err := getClientServerInfo(oc, testClientTemplate.ServerNS, testClientTemplate.ClientNS, ipStackType)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("Verify PacketTranslation flows")
-			lokiParams = []string{
-				fmt.Sprintf(`XlatDstAddr="%s"`, clientServiceInfo["server"]["ip"]),
-				fmt.Sprintf(`XlatDstK8S_Name="%s"`, clientServiceInfo["server"]["name"]),
-				`XlatDstK8S_Type="Pod"`,
-				`DstPort="80"`,
-				`XlatDstPort="8080"`,
-				fmt.Sprintf(`XlatSrcAddr="%s"`, clientServiceInfo["client"]["ip"]),
-				`XlatSrcK8S_Name="client"`,
-			}
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of PacketTranslation flows > 0")
-
-			g.By("Verify eBPF feature metrics")
-			verifyEBPFFeatureMetrics(oc, "pktdropsmap")
-			verifyEBPFFeatureMetrics(oc, "additionalmap") // for RTT/IPSec map size
-			verifyEBPFFeatureMetrics(oc, "dnsmap")
-			verifyEBPFFeatureMetrics(oc, "xlatmap")
-		})
-
-		g.It("Author:aramesha-NonPreRelease-High-79015-Verify PacketTranslation feature [Serial]", func() {
-			g.By("Deploy test server and client pods")
-			servertemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
-			testServerTemplate := TestServerTemplate{
-				ServerNS:    "test-server-79015",
-				ServiceType: "ClusterIP",
-				Template:    servertemplate,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
-			err := testServerTemplate.createServer(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
-
-			clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
-			testClientTemplate := TestClientTemplate{
-				ServerNS: testServerTemplate.ServerNS,
-				ClientNS: "test-client-79015",
-				Template: clientTemplate,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
-			err = testClientTemplate.createClient(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
-
-			clientServiceInfo, err := getClientServerInfo(oc, testClientTemplate.ServerNS, testClientTemplate.ClientNS, ipStackType)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("Deploy FlowCollector with PacketTranslation feature enabled")
-			flow := Flowcollector{
-				Namespace:     namespace,
-				EBPFeatures:   []string{"\"PacketTranslation\""},
-				LokiNamespace: lokiStackNS,
-				Template:      flowFixturePath,
-			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			g.By("Wait for 2 mins before logs gets collected and written to loki")
-			startTime := time.Now()
-			time.Sleep(120 * time.Second)
-
-			lokilabels := Lokilabels{
-				App:             "netobserv-flowcollector",
-				DstK8SOwnerName: "nginx-service",
-				DstK8SNamespace: testClientTemplate.ServerNS,
-				SrcK8SNamespace: testClientTemplate.ClientNS,
-				SrcK8SOwnerName: "client",
-			}
-
-			g.By("Verify PacketTranslation flows")
-			lokiParams := []string{
-				fmt.Sprintf(`XlatDstAddr="%s"`, clientServiceInfo["server"]["ip"]),
-				fmt.Sprintf(`XlatDstK8S_Name="%s"`, clientServiceInfo["server"]["name"]),
-				`XlatDstK8S_Type="Pod"`,
-				`DstPort="80"`,
-				`XlatDstPort="8080"`,
-				fmt.Sprintf(`XlatSrcAddr="%s"`, clientServiceInfo["client"]["ip"]),
-				`XlatSrcK8S_Name="client"`,
-			}
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of PacketTranslation flows > 0")
-		})
-
-		// NetworkEvents ebpf hook only supported for OCP >= 4.19
-		g.It("Author:memodi-NonPreRelease-Medium-77894-TechPreview Network Policies Correlation [Serial]", func() {
-			SkipIfOCPBelow("v4.19")
-			if !compat_otp.IsTechPreviewNoUpgrade(oc) {
-				g.Skip("Skipping because the TechPreviewNoUpgrade is not enabled on the cluster.")
-			}
-
-			g.By("Deploy client-server pods in 2 client NS and one Server NS")
-			serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
-			testServerTemplate := TestServerTemplate{
-				ServerNS: "test-server-77894",
-				Template: serverTemplate,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
-			err := testServerTemplate.createServer(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
-
-			client1Template := filePath.Join(baseDir, "test-nginx-client_template.yaml")
-			testClient1Template := TestClientTemplate{
-				ServerNS: testServerTemplate.ServerNS,
-				ClientNS: "test-client1-77894",
-				Template: client1Template,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testClient1Template.ClientNS)
-			err = testClient1Template.createClient(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testClient1Template.ClientNS)
-
-			testClient2Template := TestClientTemplate{
-				ServerNS: testServerTemplate.ServerNS,
-				ClientNS: "test-client2-77894",
-				Template: client1Template,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testClient2Template.ClientNS)
-			err = testClient2Template.createClient(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testClient2Template.ClientNS)
-
-			// create flowcollector with NWEvents.
-			flow := Flowcollector{
-				Namespace:      namespace,
-				Template:       flowFixturePath,
-				LokiNamespace:  lokiStackNS,
-				EBPFeatures:    []string{"\"NetworkEvents\""},
-				EBPFPrivileged: "true",
-			}
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			g.By("Wait for 60 secs before logs gets collected and written to loki")
-			time.Sleep(60 * time.Second)
-
-			g.By("get flowlogs from loki")
-			lokilabels := Lokilabels{
-				App:             "netobserv-flowcollector",
-				DstK8SNamespace: testClient1Template.ServerNS,
-				DstK8SType:      "Pod",
-				SrcK8SType:      "Pod",
-			}
-			lokiParams := []string{"FlowDirection!=1"}
-			lokilabels.SrcK8SNamespace = testClient1Template.ClientNS
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, time.Now().Add(-2*time.Minute), lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords with 'flowDirection != 1' > 0")
-
-			g.By("deploy BANP policy")
-			banpTemplate := filePath.Join(baseDir, "networking", "baselineadminnetworkPolicy.yaml")
-			banpParameters := []string{"--ignore-unknown-parameters=true", "-p", "SERVER_NS=" + testClient1Template.ServerNS, "CLIENT1_NS=" + testClient1Template.ClientNS, "CLIENT2_NS=" + testClient2Template.ClientNS, "-f", banpTemplate}
-
-			// banp is a cluster scoped resource so passing empty string for NS arg.
-			defer deleteResource(oc, "banp", "default", "")
-			err = compat_otp.ApplyClusterResourceFromTemplateWithError(oc, banpParameters...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("Wait for 60 secs before logs gets collected and written to loki")
-			time.Sleep(60 * time.Second)
-
-			g.By("check flows have NW Events")
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, time.Now().Add(-45*time.Second), lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords with 'flowDirection != 1' > 0")
-			verifyNetworkEvents(flowRecords, Drop, "BaselineAdminNetworkPolicy", "Ingress")
-
-			g.By("deploy NetworkPolicy")
-			netpolTemplate := filePath.Join(baseDir, "networking", "networkPolicy.yaml")
-			netpolName := "allow-ingress"
-			netPolParameters := []string{"--ignore-unknown-parameters=true", "-p", "NAME=" + netpolName, "SERVER_NS=" + testClient1Template.ServerNS, "ALLOW_NS=" + testClient1Template.ClientNS, "-f", netpolTemplate}
-			defer deleteResource(oc, "netpol", netpolName, testClient1Template.ServerNS)
-			err = compat_otp.ApplyClusterResourceFromTemplateWithError(oc, netPolParameters...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("Wait for 60 secs before logs gets collected and written to loki")
-			time.Sleep(60 * time.Second)
-
-			g.By("check flows from server to client1")
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, time.Now().Add(-1*time.Minute), lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords with 'flowDirection != 1' > 0")
-			verifyNetworkEvents(flowRecords, AllowRelated, "NetworkPolicy", "Ingress")
-
-			g.By("check flows from server to client2")
-			lokilabels.SrcK8SNamespace = testClient2Template.ClientNS
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, time.Now().Add(-1*time.Minute), lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords with 'flowDirection != 1' > 0")
-			verifyNetworkEvents(flowRecords, Drop, "NetpolNamespace", "Ingress")
-
-			g.By("deploy ANP policy")
-			anpTemplate := filePath.Join(baseDir, "networking", "adminnetworkPolicy.yaml")
-			anpName := "server-ns"
-			anpParameters := []string{"--ignore-unknown-parameters=true", "-p", "NAM=" + anpName, "SERVER_NS=" + testClient1Template.ServerNS, "ALLOW_NS=" + testClient2Template.ClientNS, "DENY_NS=" + testClient1Template.ClientNS, "-f", anpTemplate}
-			defer deleteResource(oc, "anp", anpName, "")
-			err = compat_otp.ApplyClusterResourceFromTemplateWithError(oc, anpParameters...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("Wait for 60 secs before logs gets collected and written to loki")
-			time.Sleep(60 * time.Second)
-
-			g.By("check flows from server to client2")
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, time.Now().Add(-1*time.Minute), lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords with 'flowDirection != 1' > 0")
-			verifyNetworkEvents(flowRecords, AllowRelated, "AdminNetworkPolicy", "Ingress")
-
-			g.By("check flows from server to client1")
-			lokilabels.SrcK8SNamespace = testClient1Template.ClientNS
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, time.Now().Add(-1*time.Minute), lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords with 'flowDirection != 1' > 0")
-			verifyNetworkEvents(flowRecords, Drop, "AdminNetworkPolicy", "Ingress")
-		})
-
-		g.It("Author:aramesha-NonPreRelease-High-80090-Verify FLP tail-based filtering [Serial]", func() {
-			// Accept flows with Source Namespace = < namespace > and
-			// Source Name containing 'flowlogs-pipeline-' and
-			// NOT Source Port 9401 and
-			// having field TimeFlowRttNs
-			g.By("Deploy FlowCollector with FLP tail-based filter and FlowRTT enabled")
-			FLPFiltersConfig := []map[string]any{
-				{
-					"query":        fmt.Sprintf(`SrcK8S_Namespace="%s" and SrcK8S_Name=~"flowlogs-pipeline-*" and SrcPort!=9401 and with(TimeFlowRttNs)`, namespace),
-					"outputTarget": "Loki",
-					"sampling":     2,
-				},
-			}
-
-			config, err := json.Marshal(FLPFiltersConfig)
-			o.Expect(err).ToNot(o.HaveOccurred())
-			FLPFilter := string(config)
-
-			flow := Flowcollector{
-				Namespace:     namespace,
-				Template:      flowFixturePath,
-				Sampling:      "2",
-				LokiNamespace: lokiStackNS,
-				EBPFeatures:   []string{`"FlowRTT"`},
-				FLPFilters:    FLPFilter,
-			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			// verify logs
-			g.By("Wait for a min before logs gets collected and written to loki")
-			startTime := time.Now()
-			time.Sleep(60 * time.Second)
-
-			lokilabels := Lokilabels{
-				App:             "netobserv-flowcollector",
-				SrcK8SNamespace: namespace,
-			}
-
-			g.By("Verify number of flows > 0")
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows > 0")
-
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.SrcK8SName).Should(o.ContainSubstring("flowlogs-pipeline-"))
-				o.Expect(r.Flowlog.SrcPort).ShouldNot(o.BeNumerically("==", 9401))
-				o.Expect(r.Flowlog.TimeFlowRttNs).Should(o.BeNumerically(">", 0))
-				o.Expect(r.Flowlog.Sampling).Should(o.BeNumerically("==", 4))
-			}
-		})
-
-		g.It("Author:aramesha-High-81677-Validate UDN with NetObserv [Serial]", func() {
-			SkipIfOCPBelow("v4.18")
-			var (
-				namespace           = oc.Namespace()
-				networkingUDNDir, _ = filePath.Abs("testdata/networking/udn")
-				udnPodTemplate      = filePath.Join(networkingUDNDir, "udn_test_pod_template.yaml")
-				matchLabelKey       = "test.io"
-				matchValue          = "netobserv-cudn-" + getRandomString()
-				cudnName            = "cudn-network-81677"
-				udnName             = "udn-network-81677"
-				cudnNS              = []string{"netobserv-cudn1-81677", "netobserv-cudn2-81677"}
-				udnNS               = "netobserv-udn-81677"
-			)
-
-			g.By("Create three namespaces, 2 for CUDN, 1 for UDN")
-			defer deleteNamespace(oc, cudnNS[0])
-			defer deleteNamespace(oc, cudnNS[1])
-			oc.CreateSpecificNamespaceUDN(cudnNS[0])
-			oc.CreateSpecificNamespaceUDN(cudnNS[1])
-			for _, ns := range cudnNS {
-				defer func() {
-					_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("ns", ns, fmt.Sprintf("%s-", matchLabelKey)).Execute()
-				}()
-				err := oc.AsAdmin().WithoutNamespace().Run("label").Args("ns", ns, fmt.Sprintf("%s=%s", matchLabelKey, matchValue)).Execute()
-				o.Expect(err).NotTo(o.HaveOccurred())
-			}
-
-			defer deleteNamespace(oc, udnNS)
-			oc.CreateSpecificNamespaceUDN(udnNS)
-
-			g.By("Deploy CUDN in CUDNns")
-			var cidr, ipv4cidr, ipv6cidr string
-			if ipStackType == "ipv4single" {
-				cidr = "10.150.0.0/16"
-			} else {
-				if ipStackType == "ipv6single" {
-					cidr = "2010:100:200::0/60"
-				} else {
-					ipv4cidr = "10.150.0.0/16"
-					ipv6cidr = "2010:100:200::0/60"
-				}
-			}
-			defer removeResource(oc, true, true, "clusteruserdefinednetwork", cudnName)
-			_, err := applyCUDNtoMatchLabelNS(oc, matchLabelKey, matchValue, cudnName, ipv4cidr, ipv6cidr, cidr, "layer3")
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("Deploy UDN in UDNns")
-			if ipStackType == "ipv4single" {
-				cidr = "10.151.0.0/16"
-			} else {
-				if ipStackType == "ipv6single" {
-					cidr = "2011:100:200::0/48"
-				} else {
-					ipv4cidr = "10.151.0.0/16"
-					ipv6cidr = "2011:100:200::0/48"
-				}
-			}
-			createGeneralUDNCRD(oc, udnNS, udnName, ipv4cidr, ipv6cidr, cidr, "layer2")
-
-			g.By("Deploy a pod in each CUDN namespace")
-			CUDNpods := make([]udnPodResource, 2)
-			for i, ns := range cudnNS {
-				CUDNpods[i] = udnPodResource{
-					name:      "hello-pod-" + ns,
-					namespace: ns,
-					label:     "hello-pod",
-					template:  udnPodTemplate,
-				}
-				defer removeResource(oc, true, true, "pod", CUDNpods[i].name, "-n", CUDNpods[i].namespace)
-				CUDNpods[i].createUdnPod(oc)
-				compat_otp.AssertAllPodsToBeReady(oc, CUDNpods[i].namespace)
-			}
-
-			g.By("Deploy 2 pods in UDN namespace")
-			UDNpods := make([]udnPodResource, 2)
-			for j := range UDNpods {
-				UDNpods[j] = udnPodResource{
-					name:      fmt.Sprintf("hello-pod-%s-%d", udnNS, j),
-					namespace: udnNS,
-					label:     "hello-pod",
-					template:  udnPodTemplate,
-				}
-				defer removeResource(oc, true, true, "pod", UDNpods[j].name, "-n", UDNpods[j].namespace)
-				UDNpods[j].createUdnPod(oc)
-			}
-			compat_otp.AssertAllPodsToBeReady(oc, udnNS)
-
-			g.By("Deploy FlowCollector with UDNMapping feature enabled with eBPF in privileged mode")
-			flow := Flowcollector{
-				Namespace:      namespace,
-				EBPFPrivileged: "true",
-				EBPFeatures:    []string{"\"UDNMapping\""},
-				LokiNamespace:  lokiStackNS,
-				Template:       flowFixturePath,
-			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			startTime := time.Now()
-
-			g.By("Validate isolation from an UDN pod to a CUDN pod")
-			CurlPod2PodFailUDN(oc, udnNS, UDNpods[1].name, CUDNpods[0].namespace, CUDNpods[0].name)
-			//default network connectivity is isolated
-			CurlPod2PodFail(oc, udnNS, UDNpods[1].name, CUDNpods[0].namespace, CUDNpods[0].name, ipStackType)
-
-			g.By("Validate isolation from a CUDN pod to an UDN pod")
-			CurlPod2PodFailUDN(oc, CUDNpods[1].namespace, CUDNpods[1].name, udnNS, UDNpods[1].name)
-			//default network connectivity is isolated
-			CurlPod2PodFail(oc, CUDNpods[1].namespace, CUDNpods[1].name, udnNS, UDNpods[1].name, ipStackType)
-
-			g.By("Validate connection among CUDN pods")
-			CurlPod2PodPassUDN(oc, CUDNpods[0].namespace, CUDNpods[0].name, CUDNpods[1].namespace, CUDNpods[1].name)
-			//default network connectivity is isolated
-			CurlPod2PodFail(oc, CUDNpods[0].namespace, CUDNpods[0].name, CUDNpods[1].namespace, CUDNpods[1].name, ipStackType)
-
-			g.By("Validate connection among UDN pods")
-			CurlPod2PodPassUDN(oc, udnNS, UDNpods[0].name, udnNS, UDNpods[1].name)
-			//default network connectivity is isolated
-			CurlPod2PodFail(oc, udnNS, UDNpods[1].name, udnNS, UDNpods[0].name, ipStackType)
-
-			g.By("Wait for 3 mins before logs gets collected and written to loki")
-			time.Sleep(180 * time.Second)
-
-			g.By("Verify CUDN flows")
-			lokilabels := Lokilabels{
-				App:             "netobserv-flowcollector",
-				DstK8SNamespace: cudnNS[1],
-				DstK8SOwnerName: CUDNpods[1].name,
-				SrcK8SNamespace: cudnNS[0],
-				SrcK8SOwnerName: CUDNpods[0].name,
-			}
-
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of CUDN flows > 0")
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.Udns).Should(o.ContainElement(cudnName))
-				o.Expect(r.Flowlog.DstK8SNetworkName).Should(o.ContainSubstring(cudnName))
-				o.Expect(r.Flowlog.SrcK8SNetworkName).Should(o.ContainSubstring(cudnName))
-			}
-
-			g.By("Verify UDN flows")
-			lokilabels = Lokilabels{
-				App:             "netobserv-flowcollector",
-				DstK8SNamespace: udnNS,
-				DstK8SOwnerName: UDNpods[1].name,
-				SrcK8SNamespace: udnNS,
-				SrcK8SOwnerName: UDNpods[0].name,
-			}
-
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of UDN flows > 0")
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.Udns).Should(o.ContainElement(fmt.Sprintf("%s/%s", udnNS, udnName)))
-				o.Expect(r.Flowlog.DstK8SNetworkName).Should(o.ContainSubstring(fmt.Sprintf("%s/%s", udnNS, udnName)))
-				o.Expect(r.Flowlog.SrcK8SNetworkName).Should(o.ContainSubstring(fmt.Sprintf("%s/%s", udnNS, udnName)))
-			}
-		})
-
-		g.It("Author:aramesha-High-83022-Validate CUDN with Localnet [Serial]", func() {
-			SkipIfOCPBelow("v4.19")
-			var (
-				namespace                = oc.Namespace()
-				opNamespace              = "openshift-nmstate"
-				buildPruningBaseDir, _   = filePath.Abs("testdata/networking/nmstate")
-				testDataDirUDN, _        = filePath.Abs("testdata/networking/udn")
-				nmstateCRTemplate        = filePath.Join(buildPruningBaseDir, "nmstate-cr-template.yaml")
-				ovnMappingPolicyTemplate = filePath.Join(buildPruningBaseDir, "ovn-mapping-policy-template.yaml")
-				matchLabelKey            = "test.io"
-				matchValue               = "cudn-network-" + getRandomString()
-				secondaryCUDNName        = "secondary-localnet-83022"
-				nodeSelectLabel          = "node-role.kubernetes.io/worker"
-				udnStatefulSetTemplate   = filePath.Join(testDataDirUDN, "udn_statefulset_template.yaml")
-				cudnNS                   = []string{"netobserv-cudn1-83022", "netobserv-cudn2-83022"}
-			)
-
-			g.By("Check the platform and network plugin type if it is suitable for running the test")
-			networkType := checkNetworkType(oc)
-			if !(isPlatformSuitableForNMState(oc)) || !strings.Contains(networkType, "ovn") {
-				g.Skip("Skipping for unsupported platform or non-OVN network plugin type!")
-			}
-			installNMstateOperator(oc)
-
-			workerNode, getNodeErr := compat_otp.GetFirstWorkerNode(oc)
-			o.Expect(getNodeErr).NotTo(o.HaveOccurred())
-			o.Expect(workerNode).NotTo(o.BeEmpty())
-
-			compat_otp.By("Create NMState CR")
-			nmstateCR := nmstateCRResource{
-				name:     "nmstate",
-				template: nmstateCRTemplate,
-			}
-			defer deleteNMStateCR(oc, nmstateCR)
-			result, crErr := createNMStateCR(oc, nmstateCR, opNamespace)
-			compat_otp.AssertWaitPollNoErr(crErr, "create nmstate cr failed")
-			o.Expect(result).To(o.BeTrue())
-			e2e.Logf("SUCCESS - NMState CR Created")
-
-			compat_otp.By("Configure NNCP for creating OvnMapping NMstate Feature")
-			ovnMappingPolicy := ovnMappingPolicyResource{
-				name:       "bridge-mapping-83022",
-				nodelabel:  nodeSelectLabel,
-				labelvalue: "",
-				localnet1:  "mylocalnet",
-				bridge1:    "br-ex",
-				template:   ovnMappingPolicyTemplate,
-			}
-			defer deleteNNCP(oc, ovnMappingPolicy.name)
+		}
+		verifyEBPFFilterMetrics(oc, "FilterReject")
+
+		g.By("Verify SYN flooding flows")
+		parameters = []string{"Flags=\"SYN\"", "DstAddr=\"192.168.1.159\""}
+
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of SYN flows > 0")
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.Bytes).Should(o.BeNumerically("==", 54))
+		}
+
+		g.By("Wait for alerts to be pending")
+		waitForAlertToBePending(oc, "NetObserv-SYNFlood-out")
+		waitForAlertToBePending(oc, "NetObserv-SYNFlood-in")
+	})
+
+	g.It("Author:aramesha-NonPreRelease-Longduration-Medium-78480-NetObserv with sampling 50 [Serial][Slow]", func() {
+		g.By("Deploy DNS pods")
+		DNSTemplate := filePath.Join(baseDir, "DNS-pods.yaml")
+		DNSNamespace := "dns-traffic"
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(DNSNamespace)
+		ApplyResourceFromFile(oc, DNSNamespace, DNSTemplate)
+		compat_otp.AssertAllPodsToBeReady(oc, DNSNamespace)
+
+		g.By("Deploy test server and client pods")
+		servertemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
+		testServerTemplate := TestServerTemplate{
+			ServerNS: "test-server-78480",
+			Template: servertemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
+		err := testServerTemplate.createServer(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
+
+		clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
+		testClientTemplate := TestClientTemplate{
+			ServerNS: testServerTemplate.ServerNS,
+			ClientNS: "test-client-78480",
+			Template: clientTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
+		err = testClientTemplate.createClient(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
+
+		g.By("Deploy FlowCollector with all features enabled with sampling 50")
+		flow := Flowcollector{
+			Namespace:      namespace,
+			EBPFPrivileged: "true",
+			EBPFeatures:    []string{"\"DNSTracking\", \"PacketDrop\", \"FlowRTT\", \"PacketTranslation\""},
+			Sampling:       "50",
+			Template:       flowFixturePath,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Wait for 4 mins before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(240 * time.Second)
+
+		lokilabels := Lokilabels{
+			App: "netobserv-flowcollector",
+		}
+
+		g.By("Verify Packet Drop flows")
+		lokiParams := []string{"PktDropLatestState=\"TCP_INVALID_STATE\"", "Proto=\"6\""}
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of TCP Invalid State flows > 0")
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.PktDropLatestDropCause).NotTo(o.BeEmpty())
+			o.Expect(r.Flowlog.PktDropBytes).Should(o.BeNumerically(">", 0))
+			o.Expect(r.Flowlog.PktDropPackets).Should(o.BeNumerically(">", 0))
+		}
+
+		lokiParams = []string{"PktDropLatestDropCause=\"SKB_DROP_REASON_NO_SOCKET\"", "Proto=\"6\""}
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of No Socket TCP flows > 0")
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.PktDropLatestState).NotTo(o.BeEmpty())
+			o.Expect(r.Flowlog.PktDropBytes).Should(o.BeNumerically(">", 0))
+			o.Expect(r.Flowlog.PktDropPackets).Should(o.BeNumerically(">", 0))
+		}
+
+		g.By("Verify flowRTT flows")
+		lokiParams = []string{"Proto=\"6\""}
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of TCP flows > 0")
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.TimeFlowRttNs).Should(o.BeNumerically(">=", 0))
+		}
+
+		g.By("Verify TCP DNS flows")
+		lokilabels.DstK8SNamespace = DNSNamespace
+		lokiParams = []string{"DnsFlagsResponseCode=\"NoError\"", "SrcPort=\"53\"", "DstK8S_Name=\"dnsutils1\"", "Proto=\"6\""}
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of TCP DNS flows > 0")
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.DNSLatencyMs).Should(o.BeNumerically(">=", 0))
+		}
+
+		g.By("Verify UDP DNS flows")
+		lokiParams = []string{"DnsFlagsResponseCode=\"NoError\"", "SrcPort=\"53\"", "Proto=\"17\""}
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of UDP DNS flows > 0")
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.DNSLatencyMs).Should(o.BeNumerically(">=", 0))
+		}
+
+		g.By("Verify Packet Translation flows")
+		lokilabels = Lokilabels{
+			App:             "netobserv-flowcollector",
+			DstK8SOwnerName: "nginx-service",
+			DstK8SNamespace: testClientTemplate.ServerNS,
+			SrcK8SNamespace: testClientTemplate.ClientNS,
+			SrcK8SOwnerName: "client",
+		}
+
+		clientServiceInfo, err := getClientServerInfo(oc, testClientTemplate.ServerNS, testClientTemplate.ClientNS, ipStackType)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Verify PacketTranslation flows")
+		lokiParams = []string{
+			fmt.Sprintf(`XlatDstAddr="%s"`, clientServiceInfo["server"]["ip"]),
+			fmt.Sprintf(`XlatDstK8S_Name="%s"`, clientServiceInfo["server"]["name"]),
+			`XlatDstK8S_Type="Pod"`,
+			`DstPort="80"`,
+			`XlatDstPort="8080"`,
+			fmt.Sprintf(`XlatSrcAddr="%s"`, clientServiceInfo["client"]["ip"]),
+			`XlatSrcK8S_Name="client"`,
+		}
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of PacketTranslation flows > 0")
+
+		g.By("Verify eBPF feature metrics")
+		verifyEBPFFeatureMetrics(oc, "pktdropsmap")
+		verifyEBPFFeatureMetrics(oc, "additionalmap") // for RTT/IPSec map size
+		verifyEBPFFeatureMetrics(oc, "dnsmap")
+		verifyEBPFFeatureMetrics(oc, "xlatmap")
+	})
+
+	g.It("Author:aramesha-NonPreRelease-High-79015-Verify PacketTranslation feature [Serial]", func() {
+		g.By("Deploy test server and client pods")
+		servertemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
+		testServerTemplate := TestServerTemplate{
+			ServerNS:    "test-server-79015",
+			ServiceType: "ClusterIP",
+			Template:    servertemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
+		err := testServerTemplate.createServer(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
+
+		clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
+		testClientTemplate := TestClientTemplate{
+			ServerNS: testServerTemplate.ServerNS,
+			ClientNS: "test-client-79015",
+			Template: clientTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
+		err = testClientTemplate.createClient(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
+
+		clientServiceInfo, err := getClientServerInfo(oc, testClientTemplate.ServerNS, testClientTemplate.ClientNS, ipStackType)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Deploy FlowCollector with PacketTranslation feature enabled")
+		flow := Flowcollector{
+			Namespace:   namespace,
+			EBPFeatures: []string{"\"PacketTranslation\""},
+			Template:    flowFixturePath,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Wait for 2 mins before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(120 * time.Second)
+
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			DstK8SOwnerName: "nginx-service",
+			DstK8SNamespace: testClientTemplate.ServerNS,
+			SrcK8SNamespace: testClientTemplate.ClientNS,
+			SrcK8SOwnerName: "client",
+		}
+
+		g.By("Verify PacketTranslation flows")
+		lokiParams := []string{
+			fmt.Sprintf(`XlatDstAddr="%s"`, clientServiceInfo["server"]["ip"]),
+			fmt.Sprintf(`XlatDstK8S_Name="%s"`, clientServiceInfo["server"]["name"]),
+			`XlatDstK8S_Type="Pod"`,
+			`DstPort="80"`,
+			`XlatDstPort="8080"`,
+			fmt.Sprintf(`XlatSrcAddr="%s"`, clientServiceInfo["client"]["ip"]),
+			`XlatSrcK8S_Name="client"`,
+		}
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of PacketTranslation flows > 0")
+	})
+
+	// NetworkEvents ebpf hook only supported for OCP >= 4.19
+	g.It("Author:memodi-NonPreRelease-Medium-77894-TechPreview Network Policies Correlation [Serial]", func() {
+		SkipIfOCPBelow("v4.19")
+		if !compat_otp.IsTechPreviewNoUpgrade(oc) {
+			g.Skip("Skipping because the TechPreviewNoUpgrade is not enabled on the cluster.")
+		}
+
+		g.By("Deploy client-server pods in 2 client NS and one Server NS")
+		serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
+		testServerTemplate := TestServerTemplate{
+			ServerNS: "test-server-77894",
+			Template: serverTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
+		err := testServerTemplate.createServer(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
+
+		client1Template := filePath.Join(baseDir, "test-nginx-client_template.yaml")
+		testClient1Template := TestClientTemplate{
+			ServerNS: testServerTemplate.ServerNS,
+			ClientNS: "test-client1-77894",
+			Template: client1Template,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClient1Template.ClientNS)
+		err = testClient1Template.createClient(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testClient1Template.ClientNS)
+
+		testClient2Template := TestClientTemplate{
+			ServerNS: testServerTemplate.ServerNS,
+			ClientNS: "test-client2-77894",
+			Template: client1Template,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClient2Template.ClientNS)
+		err = testClient2Template.createClient(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testClient2Template.ClientNS)
+
+		// create flowcollector with NWEvents.
+		flow := Flowcollector{
+			Namespace:      namespace,
+			Template:       flowFixturePath,
+			EBPFeatures:    []string{"\"NetworkEvents\""},
+			EBPFPrivileged: "true",
+		}
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Wait for 60 secs before logs gets collected and written to loki")
+		time.Sleep(60 * time.Second)
+
+		g.By("get flowlogs from loki")
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			DstK8SNamespace: testClient1Template.ServerNS,
+			DstK8SType:      "Pod",
+			SrcK8SType:      "Pod",
+		}
+		lokiParams := []string{"FlowDirection!=1"}
+		lokilabels.SrcK8SNamespace = testClient1Template.ClientNS
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, time.Now().Add(-2*time.Minute), lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords with 'flowDirection != 1' > 0")
+
+		g.By("deploy BANP policy")
+		banpTemplate := filePath.Join(baseDir, "networking", "baselineadminnetworkPolicy.yaml")
+		banpParameters := []string{"--ignore-unknown-parameters=true", "-p", "SERVER_NS=" + testClient1Template.ServerNS, "CLIENT1_NS=" + testClient1Template.ClientNS, "CLIENT2_NS=" + testClient2Template.ClientNS, "-f", banpTemplate}
+
+		// banp is a cluster scoped resource so passing empty string for NS arg.
+		defer deleteResource(oc, "banp", "default", "")
+		err = compat_otp.ApplyClusterResourceFromTemplateWithError(oc, banpParameters...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Wait for 60 secs before logs gets collected and written to loki")
+		time.Sleep(60 * time.Second)
+
+		g.By("check flows have NW Events")
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, time.Now().Add(-45*time.Second), lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords with 'flowDirection != 1' > 0")
+		verifyNetworkEvents(flowRecords, Drop, "BaselineAdminNetworkPolicy", "Ingress")
+
+		g.By("deploy NetworkPolicy")
+		netpolTemplate := filePath.Join(baseDir, "networking", "networkPolicy.yaml")
+		netpolName := "allow-ingress"
+		netPolParameters := []string{"--ignore-unknown-parameters=true", "-p", "NAME=" + netpolName, "SERVER_NS=" + testClient1Template.ServerNS, "ALLOW_NS=" + testClient1Template.ClientNS, "-f", netpolTemplate}
+		defer deleteResource(oc, "netpol", netpolName, testClient1Template.ServerNS)
+		err = compat_otp.ApplyClusterResourceFromTemplateWithError(oc, netPolParameters...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Wait for 60 secs before logs gets collected and written to loki")
+		time.Sleep(60 * time.Second)
+
+		g.By("check flows from server to client1")
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, time.Now().Add(-1*time.Minute), lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords with 'flowDirection != 1' > 0")
+		verifyNetworkEvents(flowRecords, AllowRelated, "NetworkPolicy", "Ingress")
+
+		g.By("check flows from server to client2")
+		lokilabels.SrcK8SNamespace = testClient2Template.ClientNS
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, time.Now().Add(-1*time.Minute), lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords with 'flowDirection != 1' > 0")
+		verifyNetworkEvents(flowRecords, Drop, "NetpolNamespace", "Ingress")
+
+		g.By("deploy ANP policy")
+		anpTemplate := filePath.Join(baseDir, "networking", "adminnetworkPolicy.yaml")
+		anpName := "server-ns"
+		anpParameters := []string{"--ignore-unknown-parameters=true", "-p", "NAM=" + anpName, "SERVER_NS=" + testClient1Template.ServerNS, "ALLOW_NS=" + testClient2Template.ClientNS, "DENY_NS=" + testClient1Template.ClientNS, "-f", anpTemplate}
+		defer deleteResource(oc, "anp", anpName, "")
+		err = compat_otp.ApplyClusterResourceFromTemplateWithError(oc, anpParameters...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Wait for 60 secs before logs gets collected and written to loki")
+		time.Sleep(60 * time.Second)
+
+		g.By("check flows from server to client2")
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, time.Now().Add(-1*time.Minute), lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords with 'flowDirection != 1' > 0")
+		verifyNetworkEvents(flowRecords, AllowRelated, "AdminNetworkPolicy", "Ingress")
+
+		g.By("check flows from server to client1")
+		lokilabels.SrcK8SNamespace = testClient1Template.ClientNS
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, time.Now().Add(-1*time.Minute), lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flowRecords with 'flowDirection != 1' > 0")
+		verifyNetworkEvents(flowRecords, Drop, "AdminNetworkPolicy", "Ingress")
+	})
+
+	g.It("Author:aramesha-NonPreRelease-High-80090-Verify FLP tail-based filtering [Serial]", func() {
+		// Accept flows with Source Namespace = < namespace > and
+		// Source Name containing 'flowlogs-pipeline-' and
+		// NOT Source Port 9401 and
+		// having field TimeFlowRttNs
+		g.By("Deploy FlowCollector with FLP tail-based filter and FlowRTT enabled")
+		FLPFiltersConfig := []map[string]any{
+			{
+				"query":        fmt.Sprintf(`SrcK8S_Namespace="%s" and SrcK8S_Name=~"flowlogs-pipeline.*" and SrcPort!=9401 and with(TimeFlowRttNs)`, namespace),
+				"outputTarget": "Loki",
+				"sampling":     2,
+			},
+		}
+
+		config, err := json.Marshal(FLPFiltersConfig)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		FLPFilter := string(config)
+
+		flow := Flowcollector{
+			Namespace:   namespace,
+			Template:    flowFixturePath,
+			Sampling:    "2",
+			EBPFeatures: []string{`"FlowRTT"`},
+			FLPFilters:  FLPFilter,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		// verify logs
+		g.By("Wait for a min before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(60 * time.Second)
+
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: namespace,
+		}
+
+		g.By("Verify number of flows > 0")
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows > 0")
+
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.SrcK8SName).Should(o.ContainSubstring("flowlogs-pipeline"))
+			o.Expect(r.Flowlog.SrcPort).ShouldNot(o.BeNumerically("==", 9401))
+			o.Expect(r.Flowlog.TimeFlowRttNs).Should(o.BeNumerically(">", 0))
+			o.Expect(r.Flowlog.Sampling).Should(o.BeNumerically("==", 4))
+		}
+	})
+
+	g.It("Author:aramesha-High-81677-Validate UDN with NetObserv [Serial]", func() {
+		SkipIfOCPBelow("v4.18")
+		var (
+			namespace           = oc.Namespace()
+			networkingUDNDir, _ = filePath.Abs("testdata/networking/udn")
+			udnPodTemplate      = filePath.Join(networkingUDNDir, "udn_test_pod_template.yaml")
+			matchLabelKey       = "test.io"
+			matchValue          = "netobserv-cudn-" + getRandomString()
+			cudnName            = "cudn-network-81677"
+			udnName             = "udn-network-81677"
+			cudnNS              = []string{"netobserv-cudn1-81677", "netobserv-cudn2-81677"}
+			udnNS               = "netobserv-udn-81677"
+		)
+
+		g.By("Create three namespaces, 2 for CUDN, 1 for UDN")
+		defer deleteNamespace(oc, cudnNS[0])
+		defer deleteNamespace(oc, cudnNS[1])
+		oc.CreateSpecificNamespaceUDN(cudnNS[0])
+		oc.CreateSpecificNamespaceUDN(cudnNS[1])
+		for _, ns := range cudnNS {
 			defer func() {
-				ovnmapping, deferErr := compat_otp.DebugNodeWithChroot(oc, workerNode, "ovs-vsctl", "get", "Open_vSwitch", ".", "external_ids:ovn-bridge-mappings")
-				o.Expect(deferErr).NotTo(o.HaveOccurred())
-				if strings.Contains(ovnmapping, ovnMappingPolicy.localnet1) {
-					// ovs-vsctl can only use "set" to reserve some fields
-					_, err := compat_otp.DebugNodeWithChroot(oc, workerNode, "ovs-vsctl", "set", "Open_vSwitch", ".", "external_ids:ovn-bridge-mappings=\"physnet:br-ex\"")
-					o.Expect(err).NotTo(o.HaveOccurred())
-				}
+				_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("ns", ns, fmt.Sprintf("%s-", matchLabelKey)).Execute()
 			}()
-			configErr3 := ovnMappingPolicy.configNNCP(oc)
-			o.Expect(configErr3).NotTo(o.HaveOccurred())
-			nncpErr3 := checkNNCPStatus(oc, ovnMappingPolicy.name, "Available")
-			compat_otp.AssertWaitPollNoErr(nncpErr3, fmt.Sprintf("%s policy applied failed", ovnMappingPolicy.name))
+			err := oc.AsAdmin().WithoutNamespace().Run("label").Args("ns", ns, fmt.Sprintf("%s=%s", matchLabelKey, matchValue)).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
 
-			compat_otp.By("Create two namespaces and label them")
-			for _, ns := range cudnNS {
-				defer oc.DeleteSpecifiedNamespaceAsAdmin(ns)
-				oc.CreateSpecifiedNamespaceAsAdmin(ns)
-				err := oc.AsAdmin().WithoutNamespace().Run("label").Args("ns", ns, fmt.Sprintf("%s=%s", matchLabelKey, matchValue)).Execute()
+		defer deleteNamespace(oc, udnNS)
+		oc.CreateSpecificNamespaceUDN(udnNS)
+
+		g.By("Deploy CUDN in CUDNns")
+		var cidr, ipv4cidr, ipv6cidr string
+		if ipStackType == "ipv4single" {
+			cidr = "10.150.0.0/16"
+		} else {
+			if ipStackType == "ipv6single" {
+				cidr = "2010:100:200::0/60"
+			} else {
+				ipv4cidr = "10.150.0.0/16"
+				ipv6cidr = "2010:100:200::0/60"
+			}
+		}
+		defer removeResource(oc, true, true, "clusteruserdefinednetwork", cudnName)
+		_, err := applyCUDNtoMatchLabelNS(oc, matchLabelKey, matchValue, cudnName, ipv4cidr, ipv6cidr, cidr, "layer3")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Deploy UDN in UDNns")
+		if ipStackType == "ipv4single" {
+			cidr = "10.151.0.0/16"
+		} else {
+			if ipStackType == "ipv6single" {
+				cidr = "2011:100:200::0/48"
+			} else {
+				ipv4cidr = "10.151.0.0/16"
+				ipv6cidr = "2011:100:200::0/48"
+			}
+		}
+		createGeneralUDNCRD(oc, udnNS, udnName, ipv4cidr, ipv6cidr, cidr, "layer2")
+
+		g.By("Deploy a pod in each CUDN namespace")
+		CUDNpods := make([]udnPodResource, 2)
+		for i, ns := range cudnNS {
+			CUDNpods[i] = udnPodResource{
+				name:      "hello-pod-" + ns,
+				namespace: ns,
+				label:     "hello-pod",
+				template:  udnPodTemplate,
+			}
+			defer removeResource(oc, true, true, "pod", CUDNpods[i].name, "-n", CUDNpods[i].namespace)
+			CUDNpods[i].createUdnPod(oc)
+			compat_otp.AssertAllPodsToBeReady(oc, CUDNpods[i].namespace)
+		}
+
+		g.By("Deploy 2 pods in UDN namespace")
+		UDNpods := make([]udnPodResource, 2)
+		for j := range UDNpods {
+			UDNpods[j] = udnPodResource{
+				name:      fmt.Sprintf("hello-pod-%s-%d", udnNS, j),
+				namespace: udnNS,
+				label:     "hello-pod",
+				template:  udnPodTemplate,
+			}
+			defer removeResource(oc, true, true, "pod", UDNpods[j].name, "-n", UDNpods[j].namespace)
+			UDNpods[j].createUdnPod(oc)
+		}
+		compat_otp.AssertAllPodsToBeReady(oc, udnNS)
+
+		g.By("Deploy FlowCollector with UDNMapping feature enabled with eBPF in privileged mode")
+		flow := Flowcollector{
+			Namespace:      namespace,
+			EBPFPrivileged: "true",
+			EBPFeatures:    []string{"\"UDNMapping\""},
+			Template:       flowFixturePath,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		startTime := time.Now()
+
+		g.By("Validate isolation from an UDN pod to a CUDN pod")
+		CurlPod2PodFailUDN(oc, udnNS, UDNpods[1].name, CUDNpods[0].namespace, CUDNpods[0].name)
+		//default network connectivity is isolated
+		CurlPod2PodFail(oc, udnNS, UDNpods[1].name, CUDNpods[0].namespace, CUDNpods[0].name, ipStackType)
+
+		g.By("Validate isolation from a CUDN pod to an UDN pod")
+		CurlPod2PodFailUDN(oc, CUDNpods[1].namespace, CUDNpods[1].name, udnNS, UDNpods[1].name)
+		//default network connectivity is isolated
+		CurlPod2PodFail(oc, CUDNpods[1].namespace, CUDNpods[1].name, udnNS, UDNpods[1].name, ipStackType)
+
+		g.By("Validate connection among CUDN pods")
+		CurlPod2PodPassUDN(oc, CUDNpods[0].namespace, CUDNpods[0].name, CUDNpods[1].namespace, CUDNpods[1].name)
+		//default network connectivity is isolated
+		CurlPod2PodFail(oc, CUDNpods[0].namespace, CUDNpods[0].name, CUDNpods[1].namespace, CUDNpods[1].name, ipStackType)
+
+		g.By("Validate connection among UDN pods")
+		CurlPod2PodPassUDN(oc, udnNS, UDNpods[0].name, udnNS, UDNpods[1].name)
+		//default network connectivity is isolated
+		CurlPod2PodFail(oc, udnNS, UDNpods[1].name, udnNS, UDNpods[0].name, ipStackType)
+
+		g.By("Wait for 3 mins before logs gets collected and written to loki")
+		time.Sleep(180 * time.Second)
+
+		g.By("Verify CUDN flows")
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			DstK8SNamespace: cudnNS[1],
+			DstK8SOwnerName: CUDNpods[1].name,
+			SrcK8SNamespace: cudnNS[0],
+			SrcK8SOwnerName: CUDNpods[0].name,
+		}
+
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of CUDN flows > 0")
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.Udns).Should(o.ContainElement(cudnName))
+			o.Expect(r.Flowlog.DstK8SNetworkName).Should(o.ContainSubstring(cudnName))
+			o.Expect(r.Flowlog.SrcK8SNetworkName).Should(o.ContainSubstring(cudnName))
+		}
+
+		g.By("Verify UDN flows")
+		lokilabels = Lokilabels{
+			App:             "netobserv-flowcollector",
+			DstK8SNamespace: udnNS,
+			DstK8SOwnerName: UDNpods[1].name,
+			SrcK8SNamespace: udnNS,
+			SrcK8SOwnerName: UDNpods[0].name,
+		}
+
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of UDN flows > 0")
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.Udns).Should(o.ContainElement(fmt.Sprintf("%s/%s", udnNS, udnName)))
+			o.Expect(r.Flowlog.DstK8SNetworkName).Should(o.ContainSubstring(fmt.Sprintf("%s/%s", udnNS, udnName)))
+			o.Expect(r.Flowlog.SrcK8SNetworkName).Should(o.ContainSubstring(fmt.Sprintf("%s/%s", udnNS, udnName)))
+		}
+	})
+
+	g.It("Author:aramesha-High-83022-Validate CUDN with Localnet [Serial]", func() {
+		SkipIfOCPBelow("v4.19")
+		var (
+			namespace                = oc.Namespace()
+			opNamespace              = "openshift-nmstate"
+			buildPruningBaseDir, _   = filePath.Abs("testdata/networking/nmstate")
+			testDataDirUDN, _        = filePath.Abs("testdata/networking/udn")
+			nmstateCRTemplate        = filePath.Join(buildPruningBaseDir, "nmstate-cr-template.yaml")
+			ovnMappingPolicyTemplate = filePath.Join(buildPruningBaseDir, "ovn-mapping-policy-template.yaml")
+			matchLabelKey            = "test.io"
+			matchValue               = "cudn-network-" + getRandomString()
+			secondaryCUDNName        = "secondary-localnet-83022"
+			nodeSelectLabel          = "node-role.kubernetes.io/worker"
+			udnStatefulSetTemplate   = filePath.Join(testDataDirUDN, "udn_statefulset_template.yaml")
+			cudnNS                   = []string{"netobserv-cudn1-83022", "netobserv-cudn2-83022"}
+		)
+
+		g.By("Check the platform and network plugin type if it is suitable for running the test")
+		networkType := checkNetworkType(oc)
+		if !(isPlatformSuitableForNMState(oc)) || !strings.Contains(networkType, "ovn") {
+			g.Skip("Skipping for unsupported platform or non-OVN network plugin type!")
+		}
+		nmstateCatsrc := Resource{"catalogsource", "redhat-operators", "openshift-marketplace"}
+		nmstateSource := CatalogSourceObjects{"stable", nmstateCatsrc.Name, nmstateCatsrc.Namespace}
+		NMS := SubscriptionObjects{
+			OperatorName:  "kubernetes-nmstate-operator",
+			Namespace:     opNamespace,
+			PackageName:   "kubernetes-nmstate-operator",
+			Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
+			OperatorGroup: filePath.Join(subscriptionDir, "singlenamespace-og.yaml"),
+			CatalogSource: &nmstateSource,
+		}
+		ensureOperatorDeployed(oc, NMS, nmstateSource, "name="+NMS.OperatorName)
+
+		workerNode, getNodeErr := compat_otp.GetFirstWorkerNode(oc)
+		o.Expect(getNodeErr).NotTo(o.HaveOccurred())
+		o.Expect(workerNode).NotTo(o.BeEmpty())
+
+		compat_otp.By("Create NMState CR")
+		nmstateCR := nmstateCRResource{
+			name:     "nmstate",
+			template: nmstateCRTemplate,
+		}
+		defer deleteNMStateCR(oc, nmstateCR)
+		result, crErr := createNMStateCR(oc, nmstateCR, opNamespace)
+		compat_otp.AssertWaitPollNoErr(crErr, "create nmstate cr failed")
+		o.Expect(result).To(o.BeTrue())
+		e2e.Logf("SUCCESS - NMState CR Created")
+
+		compat_otp.By("Configure NNCP for creating OvnMapping NMstate Feature")
+		ovnMappingPolicy := ovnMappingPolicyResource{
+			name:       "bridge-mapping-83022",
+			nodelabel:  nodeSelectLabel,
+			labelvalue: "",
+			localnet1:  "mylocalnet",
+			bridge1:    "br-ex",
+			template:   ovnMappingPolicyTemplate,
+		}
+		defer deleteNNCP(oc, ovnMappingPolicy.name)
+		defer func() {
+			ovnmapping, deferErr := compat_otp.DebugNodeWithChroot(oc, workerNode, "ovs-vsctl", "get", "Open_vSwitch", ".", "external_ids:ovn-bridge-mappings")
+			o.Expect(deferErr).NotTo(o.HaveOccurred())
+			if strings.Contains(ovnmapping, ovnMappingPolicy.localnet1) {
+				// ovs-vsctl can only use "set" to reserve some fields
+				_, err := compat_otp.DebugNodeWithChroot(oc, workerNode, "ovs-vsctl", "set", "Open_vSwitch", ".", "external_ids:ovn-bridge-mappings=\"physnet:br-ex\"")
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
+		}()
+		configErr3 := ovnMappingPolicy.configNNCP(oc)
+		o.Expect(configErr3).NotTo(o.HaveOccurred())
+		nncpErr3 := checkNNCPStatus(oc, ovnMappingPolicy.name, "Available")
+		compat_otp.AssertWaitPollNoErr(nncpErr3, fmt.Sprintf("%s policy applied failed", ovnMappingPolicy.name))
 
-			compat_otp.By("Create secondary localnet CUDN")
-			defer removeResource(oc, true, true, "clusteruserdefinednetwork", secondaryCUDNName)
-			_, err := applyLocalnetCUDNtoMatchLabelNS(oc, matchLabelKey, matchValue, secondaryCUDNName, "mylocalnet", "192.168.100.0/24", "192.168.100.1/32", false)
+		compat_otp.By("Create two namespaces and label them")
+		for _, ns := range cudnNS {
+			defer oc.DeleteSpecifiedNamespaceAsAdmin(ns)
+			oc.CreateSpecifiedNamespaceAsAdmin(ns)
+			err := oc.AsAdmin().WithoutNamespace().Run("label").Args("ns", ns, fmt.Sprintf("%s=%s", matchLabelKey, matchValue)).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
+		}
 
-			compat_otp.By("Deploy statefulset in both cudnNS")
-			for _, ns := range cudnNS {
-				defer removeResource(oc, true, true, "statefulset", "hello", "-n", ns)
-				compat_otp.ApplyNsResourceFromTemplate(oc, ns, "-f", udnStatefulSetTemplate, "NETWORK_NAME="+secondaryCUDNName)
-				compat_otp.AssertAllPodsToBeReady(oc, ns)
-			}
+		compat_otp.By("Create secondary localnet CUDN")
+		defer removeResource(oc, true, true, "clusteruserdefinednetwork", secondaryCUDNName)
+		_, err := applyLocalnetCUDNtoMatchLabelNS(oc, matchLabelKey, matchValue, secondaryCUDNName, "mylocalnet", "192.168.100.0/24", "192.168.100.1/32", false)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("Deploy FlowCollector with UDNMapping feature enabled with eBPF in privileged mode")
-			flow := Flowcollector{
-				Namespace:      namespace,
-				EBPFPrivileged: "true",
-				EBPFeatures:    []string{"\"UDNMapping\""},
-				LokiNamespace:  lokiStackNS,
-				Template:       flowFixturePath,
-			}
+		compat_otp.By("Deploy statefulset in both cudnNS")
+		for _, ns := range cudnNS {
+			defer removeResource(oc, true, true, "statefulset", "hello", "-n", ns)
+			compat_otp.ApplyNsResourceFromTemplate(oc, ns, "-f", udnStatefulSetTemplate, "NETWORK_NAME="+secondaryCUDNName)
+			compat_otp.AssertAllPodsToBeReady(oc, ns)
+		}
 
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
+		g.By("Deploy FlowCollector with UDNMapping feature enabled with eBPF in privileged mode")
+		flow := Flowcollector{
+			Namespace:      namespace,
+			EBPFPrivileged: "true",
+			EBPFeatures:    []string{"\"UDNMapping\""},
+			Template:       flowFixturePath,
+		}
 
-			g.By("Validate connection among CUDN pods")
-			cudn1Pods, err := compat_otp.GetAllPods(oc, cudnNS[0])
-			o.Expect(err).NotTo(o.HaveOccurred())
-			cudn2Pods, err := compat_otp.GetAllPods(oc, cudnNS[1])
-			o.Expect(err).NotTo(o.HaveOccurred())
-			startTime := time.Now()
-			CurlPod2PodPassUDN(oc, cudnNS[0], cudn1Pods[0], cudnNS[1], cudn2Pods[0])
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
 
-			g.By("Wait for 2 mins before logs gets collected and written to loki")
-			time.Sleep(120 * time.Second)
+		g.By("Validate connection among CUDN pods")
+		cudn1Pods, err := compat_otp.GetAllPods(oc, cudnNS[0])
+		o.Expect(err).NotTo(o.HaveOccurred())
+		cudn2Pods, err := compat_otp.GetAllPods(oc, cudnNS[1])
+		o.Expect(err).NotTo(o.HaveOccurred())
+		startTime := time.Now()
+		CurlPod2PodPassUDN(oc, cudnNS[0], cudn1Pods[0], cudnNS[1], cudn2Pods[0])
 
-			g.By("Verify CUDN Localnet flows")
-			lokilabels := Lokilabels{
-				App:             "netobserv-flowcollector",
-				DstK8SNamespace: cudnNS[1],
-				DstK8SOwnerName: "hello",
-				SrcK8SNamespace: cudnNS[0],
-				SrcK8SOwnerName: "hello",
-			}
+		g.By("Wait for 2 mins before logs gets collected and written to loki")
+		time.Sleep(120 * time.Second)
 
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of CUDN Localnet flows > 0")
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.Udns).Should(o.ContainElement(secondaryCUDNName))
-				o.Expect(r.Flowlog.DstK8SNetworkName).Should(o.ContainSubstring(secondaryCUDNName))
-				o.Expect(r.Flowlog.SrcK8SNetworkName).Should(o.ContainSubstring(secondaryCUDNName))
-			}
-		})
+		g.By("Verify CUDN Localnet flows")
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			DstK8SNamespace: cudnNS[1],
+			DstK8SOwnerName: "hello",
+			SrcK8SNamespace: cudnNS[0],
+			SrcK8SOwnerName: "hello",
+		}
 
-		g.It("Author:aramesha-NonPreRelease-Longduration-Medium-81410-NetObserv with eBPF manager [Serial][Slow]", func() {
-			SkipIfOCPBelow("v4.18")
-			g.By("Deploy eBPF manager operator")
-			// eBPF manager operator variables
-			bpfDir, _ := filePath.Abs("testdata/bpfman")
-			bpfIDMS := filePath.Join(bpfDir, "image-digest-mirror-set.yaml")
-			bpfCatSrcTemplate := filePath.Join(bpfDir, "catalog-source.yaml")
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of CUDN Localnet flows > 0")
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.Udns).Should(o.ContainElement(secondaryCUDNName))
+			o.Expect(r.Flowlog.DstK8SNetworkName).Should(o.ContainSubstring(secondaryCUDNName))
+			o.Expect(r.Flowlog.SrcK8SNetworkName).Should(o.ContainSubstring(secondaryCUDNName))
+		}
+	})
 
-			bpfNS := OperatorNamespace{
-				Name:              "bpfman",
-				NamespaceTemplate: filePath.Join(bpfDir, "namespace.yaml"),
-			}
-			bpfCatSrc := Resource{"catsrc", "bpfman-konflux-fbc", bpfNS.Name}
-			bpfSource := CatalogSourceObjects{"stable", bpfCatSrc.Name, bpfNS.Name}
+	g.It("Author:aramesha-NonPreRelease-Longduration-Medium-81410-NetObserv with eBPF manager [Serial][Slow]", func() {
+		SkipIfOCPBelow("v4.18")
+		g.By("Deploy eBPF manager operator")
+		// eBPF manager operator variables
+		bpfDir, _ := filePath.Abs("testdata/bpfman")
+		bpfIDMS := filePath.Join(bpfDir, "image-digest-mirror-set.yaml")
+		bpfCatSrcTemplate := filePath.Join(bpfDir, "catalog-source.yaml")
 
-			g.By("Deploy bpfman konflux FBC and ImageDigestMirrorSet")
-			bpfNS.DeployOperatorNamespace(oc)
-			catsrcErr := bpfCatSrc.applyFromTemplate(oc, "-n", bpfNS.Name, "-f", bpfCatSrcTemplate, "-p", "NAMESPACE="+bpfNS.Name)
-			o.Expect(catsrcErr).NotTo(o.HaveOccurred())
-			bpfCatSrc.WaitUntilCatSrcReady(oc)
-			ApplyResourceFromFile(oc, bpfNS.Name, bpfIDMS)
+		bpfNS := OperatorNamespace{
+			Name:              "bpfman",
+			NamespaceTemplate: filePath.Join(bpfDir, "namespace.yaml"),
+		}
+		bpfCatSrc := Resource{"catsrc", "bpfman-konflux-fbc", bpfNS.Name}
+		bpfSource := CatalogSourceObjects{"stable", bpfCatSrc.Name, bpfNS.Name}
 
-			BPF := SubscriptionObjects{
-				OperatorName:  "bpfman-operator",
-				Namespace:     "bpfman",
-				PackageName:   "bpfman-operator",
-				Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
-				OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
-				CatalogSource: &bpfSource,
-			}
+		g.By("Deploy bpfman konflux FBC and ImageDigestMirrorSet")
+		bpfNS.DeployOperatorNamespace(oc)
+		catsrcErr := bpfCatSrc.applyFromTemplate(oc, "-n", bpfNS.Name, "-f", bpfCatSrcTemplate, "-p", "NAMESPACE="+bpfNS.Name)
+		o.Expect(catsrcErr).NotTo(o.HaveOccurred())
+		bpfCatSrc.WaitUntilCatSrcReady(oc)
+		ApplyResourceFromFile(oc, bpfNS.Name, bpfIDMS)
 
-			bpfExisting, err := CheckOperatorStatus(oc, BPF.Namespace, BPF.PackageName)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			// Deploy eBPF manager operator if not present
-			if !bpfExisting {
-				ensureOperatorDeployed(oc, BPF, bpfSource, "name=bpfman-daemon")
-			}
+		BPF := SubscriptionObjects{
+			OperatorName:  "bpfman-operator",
+			Namespace:     "bpfman",
+			PackageName:   "bpfman-operator",
+			Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
+			OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
+			CatalogSource: &bpfSource,
+		}
 
-			g.By("Deploy FlowCollector with PacketDrop and Ebpfmanager enabled")
-			flow := Flowcollector{
-				Namespace:     namespace,
-				EBPFeatures:   []string{"\"PacketDrop\", \"EbpfManager\""},
-				LokiNamespace: lokiStackNS,
-				Template:      flowFixturePath,
-			}
+		bpfExisting, err := CheckOperatorStatus(oc, BPF.Namespace, BPF.PackageName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		// Deploy eBPF manager operator if not present
+		if !bpfExisting {
+			ensureOperatorDeployed(oc, BPF, bpfSource, "name=bpfman-daemon")
+		}
 
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
+		g.By("Deploy FlowCollector with PacketDrop and Ebpfmanager enabled")
+		flow := Flowcollector{
+			Namespace:   namespace,
+			EBPFeatures: []string{"\"PacketDrop\", \"EbpfManager\""},
+			Template:    flowFixturePath,
+		}
 
-			g.By("Wait for 4 mins before logs gets collected and written to loki")
-			startTime := time.Now()
-			time.Sleep(240 * time.Second)
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
 
-			lokilabels := Lokilabels{
-				App: "netobserv-flowcollector",
-			}
+		g.By("Wait for 4 mins before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(240 * time.Second)
 
-			g.By("Verify Packet Drop flows")
-			lokiParams := []string{"PktDropLatestState=\"TCP_INVALID_STATE\"", "Proto=\"6\""}
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of TCP Invalid State flows > 0")
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.PktDropLatestDropCause).NotTo(o.BeEmpty())
-				o.Expect(r.Flowlog.PktDropBytes).Should(o.BeNumerically(">", 0))
-				o.Expect(r.Flowlog.PktDropPackets).Should(o.BeNumerically(">", 0))
-			}
+		lokilabels := Lokilabels{
+			App: "netobserv-flowcollector",
+		}
 
-			lokiParams = []string{"PktDropLatestDropCause=\"SKB_DROP_REASON_NO_SOCKET\"", "Proto=\"6\""}
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of No Socket TCP flows > 0")
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.PktDropLatestState).NotTo(o.BeEmpty())
-				o.Expect(r.Flowlog.PktDropBytes).Should(o.BeNumerically(">", 0))
-				o.Expect(r.Flowlog.PktDropPackets).Should(o.BeNumerically(">", 0))
-			}
-		})
+		g.By("Verify Packet Drop flows")
+		lokiParams := []string{"PktDropLatestState=\"TCP_INVALID_STATE\"", "Proto=\"6\""}
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of TCP Invalid State flows > 0")
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.PktDropLatestDropCause).NotTo(o.BeEmpty())
+			o.Expect(r.Flowlog.PktDropBytes).Should(o.BeNumerically(">", 0))
+			o.Expect(r.Flowlog.PktDropPackets).Should(o.BeNumerically(">", 0))
+		}
 
-		g.It("Author:memodi-NonPreRelease-High-82637-Verify IPSec feature [Disruptive]", func() {
-			SkipIfOCPBelow("v4.16")
-			compat_otp.By("Check if IPSec is enabled in the cluster")
-			ipsecEnabled, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("networks.operator.openshift.io", "cluster", "-ojsonpath='{.spec.defaultNetwork.ovnKubernetesConfig.ipsecConfig.mode}'").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			ipsecEnabled = strings.Trim(ipsecEnabled, "'")
-			if ipsecEnabled != "Full" {
-				g.Skip("IPSec is not enabled in Full mode, skipping test")
-			}
+		lokiParams = []string{"PktDropLatestDropCause=\"SKB_DROP_REASON_NO_SOCKET\"", "Proto=\"6\""}
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of No Socket TCP flows > 0")
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.PktDropLatestState).NotTo(o.BeEmpty())
+			o.Expect(r.Flowlog.PktDropBytes).Should(o.BeNumerically(">", 0))
+			o.Expect(r.Flowlog.PktDropPackets).Should(o.BeNumerically(">", 0))
+		}
+	})
 
-			g.By("Deploy FlowCollector IPSec enabled")
-			flow := Flowcollector{
-				Namespace:     namespace,
-				EBPFeatures:   []string{"\"IPSec\""},
-				LokiNamespace: lokiStackNS,
-				Template:      flowFixturePath,
-			}
+	g.It("Author:memodi-NonPreRelease-High-82637-Verify IPSec feature [Disruptive]", func() {
+		compat_otp.By("Check if IPSec is enabled in the cluster")
+		ipsecEnabled, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("networks.operator.openshift.io", "cluster", "-ojsonpath='{.spec.defaultNetwork.ovnKubernetesConfig.ipsecConfig.mode}'").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		ipsecEnabled = strings.Trim(ipsecEnabled, "'")
+		if ipsecEnabled != "Full" {
+			g.Skip("IPSec is not enabled in Full mode, skipping test")
+		}
 
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
+		g.By("Deploy FlowCollector IPSec enabled")
+		flow := Flowcollector{
+			Namespace:   namespace,
+			EBPFeatures: []string{"\"IPSec\""},
+			Template:    flowFixturePath,
+		}
 
-			g.By("Wait for 2 mins before logs gets collected and written to loki")
-			startTime := time.Now()
-			time.Sleep(120 * time.Second)
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
 
-			lokilabels := Lokilabels{
-				App: "netobserv-flowcollector",
-			}
-			g.By("Verify IPSec flows")
-			lokiParams := []string{"IPSecStatus=\"success\""}
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of IPSecStatus==success flows > 0")
-			metrics, err := getMetric(oc, "sum(netobserv_node_ipsec_flows_total{IPSecStatus=\"success\"})")
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(popMetricValue(metrics)).Should(o.BeNumerically(">", 0))
-			o.Expect(err).NotTo(o.HaveOccurred())
-			verifyEBPFFeatureMetrics(oc, "additionalmap") // additionalMap for RTT/IPSec map size
-		})
+		g.By("Wait for 2 mins before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(120 * time.Second)
 
-		g.It("Author:kapjain-NonPreRelease-Longduration-High-85953-Verify FlowCollector Service deployment model [Serial][Slow]", func() {
-			SkipIfOCPBelow("v4.14")
-			g.By("Deploy FlowCollector with Service deployment model")
-			flow := Flowcollector{
-				Namespace:       namespace,
-				DeploymentModel: "Service",
-				Template:        flowFixturePath,
-				LokiNamespace:   lokiStackNS,
-			}
+		lokilabels := Lokilabels{
+			App: "netobserv-flowcollector",
+		}
+		g.By("Verify IPSec flows")
+		lokiParams := []string{"IPSecStatus=\"success\""}
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of IPSecStatus==success flows > 0")
+		metrics, err := getMetric(oc, "sum(netobserv_node_ipsec_flows_total{IPSecStatus=\"success\"})")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(popMetricValue(metrics)).Should(o.BeNumerically(">", 0))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		verifyEBPFFeatureMetrics(oc, "additionalmap") // additionalMap for RTT/IPSec map size
+	})
 
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
+	g.It("Author:kapjain-NonPreRelease-Longduration-High-85953-Verify FlowCollector Service deployment model [Serial][Slow]", func() {
+		g.By("Deploy FlowCollector with Service deployment model")
+		flow := Flowcollector{
+			Namespace:       namespace,
+			DeploymentModel: "Service",
+			Template:        flowFixturePath,
+		}
 
-			g.By("Wait for pods to fully start and emit startup logs")
-			time.Sleep(30 * time.Second)
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
 
-			g.By("Verify FLP logs show 'Starting GRPC server with TLS'")
-			FLPpods, err := compat_otp.GetAllPodsWithLabel(oc, flow.Namespace, "app=flowlogs-pipeline")
-			o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("Wait for pods to fully start and emit startup logs")
+		time.Sleep(30 * time.Second)
 
-			g.By("Get FLP pod logs to check GRPC server startup message")
-			flpLogs, err := oc.AsAdmin().WithoutNamespace().Run("logs").Args("-n", flow.Namespace, FLPpods[0], "--tail=100").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(flpLogs).To(o.ContainSubstring("Starting GRPC server with TLS"), "FLP logs should contains 'Starting GRPC server with TLS'")
+		g.By("Verify FLP logs show 'Starting GRPC server with TLS'")
+		FLPpods, err := compat_otp.GetAllPodsWithLabel(oc, flow.Namespace, "app=flowlogs-pipeline")
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("Verify agent logs show 'Starting GRPC client with TLS'")
-			agentPods, err := compat_otp.GetAllPodsWithLabel(oc, flow.Namespace+"-privileged", "app=netobserv-ebpf-agent")
-			o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("Get FLP pod logs to check GRPC server startup message")
+		flpLogs, err := oc.AsAdmin().WithoutNamespace().Run("logs").Args("-n", flow.Namespace, FLPpods[0], "--tail=100").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(flpLogs).To(o.ContainSubstring("Starting GRPC server with TLS"), "FLP logs should contains 'Starting GRPC server with TLS'")
 
-			g.By("Get agent pod logs to check GRPC client startup message")
-			agentLogs, err := oc.AsAdmin().WithoutNamespace().Run("logs").Args("-n", flow.Namespace+"-privileged", agentPods[0], "--tail=100").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(agentLogs).To(o.ContainSubstring("Starting GRPC client with TLS"), "Agent logs should contains 'Starting GRPC client with TLS'")
+		g.By("Verify agent logs show 'Starting GRPC client with TLS'")
+		agentPods, err := compat_otp.GetAllPodsWithLabel(oc, flow.Namespace+"-privileged", "app=netobserv-ebpf-agent")
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("Wait for a min before logs gets collected and written to loki in TLS mode")
-			startTime := time.Now()
-			time.Sleep(60 * time.Second)
+		g.By("Get agent pod logs to check GRPC client startup message")
+		agentLogs, err := oc.AsAdmin().WithoutNamespace().Run("logs").Args("-n", flow.Namespace+"-privileged", agentPods[0], "--tail=100").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(agentLogs).To(o.ContainSubstring("Starting GRPC client with TLS"), "Agent logs should contains 'Starting GRPC client with TLS'")
 
-			g.By("Get flowlogs from loki")
-			err = verifyLokilogsTime(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("Wait for a min before logs gets collected and written to loki in TLS mode")
+		startTime := time.Now()
+		time.Sleep(60 * time.Second)
 
-			g.By("Verify default FLP Deployment is created with 3 pods")
-			result := verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 3, "")
-			o.Expect(result).To(o.BeTrue(), "By default the replica count should be 3")
+		g.By("Get flowlogs from loki")
+		err = verifyMonolithicLokilogsTime(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("Verify Service is created with correct port configuration")
-			service, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("service", "flowlogs-pipeline", "-n", flow.Namespace, "-o", "jsonpath='{.spec.ports[0].port}'").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			service = strings.Trim(service, "'")
-			o.Expect(service).To(o.Equal("2055"))
+		g.By("Verify default FLP Deployment is created with 3 pods")
+		result := verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 3, "")
+		o.Expect(result).To(o.BeTrue(), "By default the replica count should be 3")
 
-			targetPort, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("service", "flowlogs-pipeline", "-n", flow.Namespace, "-o", "jsonpath='{.spec.ports[0].targetPort}'").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			targetPort = strings.Trim(targetPort, "'")
-			o.Expect(targetPort).To(o.Equal("2055"))
+		g.By("Verify Service is created with correct port configuration")
+		service, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("service", "flowlogs-pipeline", "-n", flow.Namespace, "-o", "jsonpath='{.spec.ports[0].port}'").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		service = strings.Trim(service, "'")
+		o.Expect(service).To(o.Equal("2055"))
 
-			// Test replica management with unmanagedReplicas: False by default
-			g.By("Verify deployment does not upscale when unmanagedReplicas is false or not set")
-			err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("deployment", "flowlogs-pipeline", "-n", flow.Namespace, "--replicas=4").Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 3, "")
-			o.Expect(result).To(o.BeTrue(), "Deployment should not scale when unmanagedReplicas is false or not set")
+		targetPort, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("service", "flowlogs-pipeline", "-n", flow.Namespace, "-o", "jsonpath='{.spec.ports[0].targetPort}'").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		targetPort = strings.Trim(targetPort, "'")
+		o.Expect(targetPort).To(o.Equal("2055"))
 
-			g.By("Verify deployment does not downscale when unmanagedReplicas is false or not set")
-			err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("deployment", "flowlogs-pipeline", "-n", flow.Namespace, "--replicas=2").Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 3, "")
-			o.Expect(result).To(o.BeTrue(), "Deployment should not scale when unmanagedReplicas is false or not set")
+		// Test replica management with unmanagedReplicas: False by default
+		g.By("Verify deployment does not upscale when unmanagedReplicas is false or not set")
+		err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("deployment", "flowlogs-pipeline", "-n", flow.Namespace, "--replicas=4").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 3, "")
+		o.Expect(result).To(o.BeTrue(), "Deployment should not scale when unmanagedReplicas is false or not set")
 
-			g.By("Verify deployment scales via consumerReplicas when unmanagedReplicas is false or not set - upscale to 4")
-			err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=merge", "-p", `{"spec":{"processor":{"consumerReplicas":4}}}`).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 4, "")
-			o.Expect(result).To(o.BeTrue(), "Deployment should scale via consumerReplicas when unmanagedReplicas is false or not set")
+		g.By("Verify deployment does not downscale when unmanagedReplicas is false or not set")
+		err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("deployment", "flowlogs-pipeline", "-n", flow.Namespace, "--replicas=2").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 3, "")
+		o.Expect(result).To(o.BeTrue(), "Deployment should not scale when unmanagedReplicas is false or not set")
 
-			g.By("Verify deployment scales via consumerReplicas when unmanagedReplicas is false or not set - downscale to 2")
-			err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=merge", "-p", `{"spec":{"processor":{"consumerReplicas":2}}}`).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 2, "")
-			o.Expect(result).To(o.BeTrue(), "Deployment should scale via consumerReplicas when unmanagedReplicas is false or not set")
+		g.By("Verify deployment scales via consumerReplicas when unmanagedReplicas is false or not set - upscale to 4")
+		err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=merge", "-p", `{"spec":{"processor":{"consumerReplicas":4}}}`).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 4, "")
+		o.Expect(result).To(o.BeTrue(), "Deployment should scale via consumerReplicas when unmanagedReplicas is false or not set")
 
-			// Test replica management with unmanagedReplicas: True
-			g.By("Enable unmanagedReplicas and set consumerReplicas to 3")
-			err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=merge", "-p", `{"spec":{"processor":{"unmanagedReplicas":true,"consumerReplicas":3}}}`).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("Verify deployment scales via consumerReplicas when unmanagedReplicas is false or not set - downscale to 2")
+		err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=merge", "-p", `{"spec":{"processor":{"consumerReplicas":2}}}`).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 2, "")
+		o.Expect(result).To(o.BeTrue(), "Deployment should scale via consumerReplicas when unmanagedReplicas is false or not set")
 
-			g.By("Verify deployment upscales when unmanagedReplicas is true")
-			err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("deployment", "flowlogs-pipeline", "-n", flow.Namespace, "--replicas=4").Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 4, "")
-			o.Expect(result).To(o.BeTrue(), "Deployment should scale when unmanagedReplicas is true")
+		// Test replica management with unmanagedReplicas: True
+		g.By("Enable unmanagedReplicas and set consumerReplicas to 3")
+		err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=merge", "-p", `{"spec":{"processor":{"unmanagedReplicas":true,"consumerReplicas":3}}}`).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("Verify deployment downscales when unmanagedReplicas is true")
-			err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("deployment", "flowlogs-pipeline", "-n", flow.Namespace, "--replicas=1").Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 1, "")
-			o.Expect(result).To(o.BeTrue(), "Deployment should scale when unmanagedReplicas is true")
+		g.By("Verify deployment upscales when unmanagedReplicas is true")
+		err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("deployment", "flowlogs-pipeline", "-n", flow.Namespace, "--replicas=4").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 4, "")
+		o.Expect(result).To(o.BeTrue(), "Deployment should scale when unmanagedReplicas is true")
 
-			g.By("Verify consumerReplicas change does not scale deployment when unmanagedReplicas is true")
-			err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=merge", "-p", `{"spec":{"processor":{"consumerReplicas":4}}}`).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 1, "")
-			o.Expect(result).To(o.BeTrue(), "Deployment should not scale via consumerReplicas when unmanagedReplicas is true")
+		g.By("Verify deployment downscales when unmanagedReplicas is true")
+		err = oc.AsAdmin().WithoutNamespace().Run("scale").Args("deployment", "flowlogs-pipeline", "-n", flow.Namespace, "--replicas=1").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 1, "")
+		o.Expect(result).To(o.BeTrue(), "Deployment should scale when unmanagedReplicas is true")
 
-			g.By("Verify HPA scales the deployment when unmanagedReplicas is true")
-			hpaYAML := filePath.Join(baseDir, "flowlogs_pipeline_hpa_template.yaml")
-			hpaFile := compat_otp.ProcessTemplate(oc, "--ignore-unknown-parameters=true", "-f", hpaYAML, "-p", "NAMESPACE="+namespace)
-			defer func() {
-				_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("hpa", "flowlogs-pipeline-hpa", "-n", flow.Namespace).Execute()
-			}()
-			err = oc.WithoutNamespace().Run("create").Args("-f", hpaFile).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 4, ">")
-			o.Expect(result).To(o.BeTrue(), "HPA should scale deployment above 4 replicas when unmanagedReplicas is true")
+		g.By("Verify consumerReplicas change does not scale deployment when unmanagedReplicas is true")
+		err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=merge", "-p", `{"spec":{"processor":{"consumerReplicas":4}}}`).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 1, "")
+		o.Expect(result).To(o.BeTrue(), "Deployment should not scale via consumerReplicas when unmanagedReplicas is true")
 
-			g.By("Verify HPA does not scale deployment when unmanagedReplicas is false")
-			err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=merge", "-p", `{"spec":{"processor":{"unmanagedReplicas":false,"consumerReplicas":2}}}`).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 2, "")
-			o.Expect(result).To(o.BeTrue(), "Deployment should be reconciled to consumerReplicas=2 when unmanagedReplicas is false")
-		})
+		g.By("Verify HPA scales the deployment when unmanagedReplicas is true")
+		hpaYAML := filePath.Join(baseDir, "flowlogs_pipeline_hpa_template.yaml")
+		hpaFile := compat_otp.ProcessTemplate(oc, "--ignore-unknown-parameters=true", "-f", hpaYAML, "-p", "NAMESPACE="+namespace)
+		defer func() {
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("hpa", "flowlogs-pipeline-hpa", "-n", flow.Namespace).Execute()
+		}()
+		err = oc.WithoutNamespace().Run("create").Args("-f", hpaFile).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 4, ">")
+		o.Expect(result).To(o.BeTrue(), "HPA should scale deployment above 4 replicas when unmanagedReplicas is true")
 
-		g.It("Author:kapjain-Medium-86372-Verify Gateway API three-level owner metadata [Serial]", func() {
-			SkipIfOCPBelow("v4.19")
-			startTime := time.Now()
-			g.By("Deploy flowcollector")
-			gatewayAPITemplate := filePath.Join(baseDir, "gateway-api-template.yaml")
-			flow := Flowcollector{
-				Namespace:     namespace,
-				Template:      flowFixturePath,
-				LokiNamespace: lokiStackNS,
-			}
+		g.By("Verify HPA does not scale deployment when unmanagedReplicas is false")
+		err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("flowcollector", "cluster", "--type=merge", "-p", `{"spec":{"processor":{"unmanagedReplicas":false,"consumerReplicas":2}}}`).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		result = verifyDeploymentReplicas(oc, "flowlogs-pipeline", flow.Namespace, 2, "")
+		o.Expect(result).To(o.BeTrue(), "Deployment should be reconciled to consumerReplicas=2 when unmanagedReplicas is false")
+	})
 
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
+	g.It("Author:kapjain-Medium-86372-Verify Gateway API three-level owner metadata [Serial]", func() {
+		SkipIfOCPBelow("v4.19")
+		startTime := time.Now()
+		g.By("Deploy flowcollector")
+		gatewayAPITemplate := filePath.Join(baseDir, "gateway-api-template.yaml")
+		flow := Flowcollector{
+			Namespace: namespace,
+			Template:  flowFixturePath,
+		}
 
-			g.By("Deploying Gateway API resources from template")
-			gatewayNS := "netobserv-gateway-test"
-			gatewayName := "test-gateway-owner"
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(gatewayNS)
-			err := applyResourceFromTemplateByAdmin(oc, "-f", gatewayAPITemplate)
-			o.Expect(err).NotTo(o.HaveOccurred())
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
 
-			g.By("Verifying Gateway Deployment exists")
-			// The Gateway controller creates a Deployment named gateway-name + gatewayclass-name
-			deploymentName := gatewayName + "-openshift-default"
-			WaitForDeploymentPodsToBeReady(oc, gatewayNS, deploymentName)
+		g.By("Deploying Gateway API resources from template")
+		gatewayNS := "netobserv-gateway-test"
+		gatewayName := "test-gateway-owner"
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(gatewayNS)
+		err := applyResourceFromTemplateByAdmin(oc, "-f", gatewayAPITemplate)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("Verifying Pods are created by Gateway")
-			pods, err := compat_otp.GetAllPodsWithLabel(oc, gatewayNS, fmt.Sprintf("gateway.networking.k8s.io/gateway-name=%s", gatewayName))
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(pods)).Should(o.BeNumerically(">", 0), "expected at least one Gateway pod")
+		g.By("Verifying Gateway Deployment exists")
+		// The Gateway controller creates a Deployment named gateway-name + gatewayclass-name
+		deploymentName := gatewayName + "-openshift-default"
+		WaitForDeploymentPodsToBeReady(oc, gatewayNS, deploymentName)
 
-			g.By("Waiting for flow data to be collected and written to Loki")
-			time.Sleep(120 * time.Second)
+		g.By("Verifying Pods are created by Gateway")
+		pods, err := compat_otp.GetAllPodsWithLabel(oc, gatewayNS, fmt.Sprintf("gateway.networking.k8s.io/gateway-name=%s", gatewayName))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(pods)).Should(o.BeNumerically(">", 0), "expected at least one Gateway pod")
 
-			g.By("Querying flow data from Loki for Gateway pods")
-			lokilabels := Lokilabels{
-				SrcK8SNamespace: "netobserv-gateway-test",
-			}
-			parameters := []string{"SrcK8S_OwnerType=\"Gateway\""}
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of Gateway Owner flows > 0")
-		})
-		g.It("Author:kapjain-Medium-88334-Pause Network Observability functions [Serial]", func() {
-			SkipIfOCPBelow("v4.14")
-			g.By("Create a FlowCollector")
-			flow := Flowcollector{
-				Namespace:       namespace,
-				Template:        flowFixturePath,
-				LokiNamespace:   lokiStackNS,
-				DeploymentModel: "Service",
-				SlicesEnable:    "true",
-			}
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-			flow.WaitForFlowcollectorReady(oc)
+		g.By("Waiting for flow data to be collected and written to Loki")
+		time.Sleep(120 * time.Second)
 
-			g.By("Get all netobserv-managed components before pause (excluding pods with dynamic IDs)")
-			componentsBeforePause, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
-				"service,deployment,daemonset,serviceaccount,networkpolicy,configmap,secret",
-				"-A", "-l", "netobserv-managed=true", "-o", "name",
-			).Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			e2e.Logf("Components before pause (stable names): %s", componentsBeforePause)
+		g.By("Querying flow data from Loki for Gateway pods")
+		lokilabels := Lokilabels{
+			SrcK8SNamespace: "netobserv-gateway-test",
+		}
+		parameters := []string{"SrcK8S_OwnerType=\"Gateway\""}
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of Gateway Owner flows > 0")
+	})
+	g.It("Author:kapjain-Medium-88334-Pause Network Observability functions [Serial]", func() {
+		g.By("Create a FlowCollector")
+		flow := Flowcollector{
+			Namespace:       namespace,
+			Template:        flowFixturePath,
+			DeploymentModel: "Service",
+			SlicesEnable:    "true",
+		}
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+		flow.WaitForFlowcollectorReady(oc)
 
-			g.By("Pause the FlowCollector")
-			err = oc.AsAdmin().WithoutNamespace().Run("patch").Args(
-				"flowcollector", "cluster",
-				"--type=merge",
-				"-p", `{"spec":{"execution":{"mode":"OnHold"}}}`,
-			).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("Get all netobserv-managed components before pause (excluding pods with dynamic IDs)")
+		componentsBeforePause, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"service,deployment,daemonset,serviceaccount,networkpolicy,configmap,secret",
+			"-A", "-l", "netobserv-managed=true", "-o", "name",
+		).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		e2e.Logf("Components before pause (stable names): %s", componentsBeforePause)
 
-			g.By("Wait for FlowCollector status to show 'on hold' message")
-			err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 150*time.Second, false, func(context.Context) (done bool, err error) {
-				onHoldConditions, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
-					"flowcollector", "cluster",
-					"-o", `jsonpath={.status.conditions[?(@.message=="FlowCollector is on hold")]}`,
-				).Output()
-				if err != nil {
-					e2e.Logf("Error getting FlowCollector status: %v", err)
-					return false, nil
-				}
-				if onHoldConditions != "" {
-					e2e.Logf("FlowCollector status shows 'on hold'")
-					return true, nil
-				}
-				e2e.Logf("Waiting for FlowCollector to show 'on hold' status...")
-				return false, nil
-			})
-			o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("Pause the FlowCollector")
+		err = oc.AsAdmin().WithoutNamespace().Run("patch").Args(
+			"flowcollector", "cluster",
+			"--type=merge",
+			"-p", `{"spec":{"execution":{"mode":"OnHold"}}}`,
+		).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("Verify except for netobserv-plugin-static and network policies and persistent configmaps, all components are deleted")
-			componentsAfterPause, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
-				"service,deployment,daemonset,serviceaccount,networkpolicy,configmap,secret",
-				"-A", "-l", "netobserv-managed=true", "-o", "name",
-			).Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			e2e.Logf("Components after pause: %s", componentsAfterPause)
-
-			// Components with stable names that should remain when paused
-			// Common components across all OCP versions
-			componentsShouldRemain := []string{
-				"configmap/lokistack-ca-bundle",
-				"configmap/lokistack-gateway-ca-bundle",
-				"configmap/grafana-dashboard-netobserv-health",
-				"configmap/netobserv-main",
-				"secret/lokistack-query-frontend-http",
-			}
-			// Static plugin and network policy are only available on OCP 4.15+
-			if IsOCPVersionAtLeast("v4.15") {
-				componentsShouldRemain = append(componentsShouldRemain,
-					"deployment.apps/netobserv-plugin-static",
-					"service/netobserv-plugin-static",
-					"networkpolicy.networking.k8s.io/netobserv",
-				)
-			}
-			verifyComponentsExist(componentsAfterPause, componentsShouldRemain)
-
-			// Verify netobserv-plugin-static pod exists and other pods are deleted (using pattern since pod names have dynamic IDs)
-			podsAfterPause, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
-				"pod", "-A", "-l", "netobserv-managed=true", "-o", "name",
-			).Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			if IsOCPVersionAtLeast("v4.15") {
-				o.Expect(podsAfterPause).Should(o.ContainSubstring("pod/netobserv-plugin-static-"), "netobserv-plugin-static pod should exist after pause")
-			}
-			o.Expect(podsAfterPause).ShouldNot(o.ContainSubstring("pod/flowlogs-pipeline-"), "flowlogs-pipeline pods should be deleted")
-			o.Expect(podsAfterPause).ShouldNot(o.ContainSubstring("pod/netobserv-ebpf-agent-"), "netobserv-ebpf-agent pods should be deleted")
-			// Verify regular netobserv-plugin pod is deleted (not the static one)
-			podLines := strings.Split(podsAfterPause, "\n")
-			for _, podLine := range podLines {
-				if strings.Contains(podLine, "pod/netobserv-plugin-") && !strings.Contains(podLine, "pod/netobserv-plugin-static-") {
-					e2e.Failf("Found non-static netobserv-plugin pod that should be deleted: %s", podLine)
-				}
-			}
-
-			// Build list of components that should be deleted = originalComponentsList - componentsShouldRemain
-			originalComponentsList := strings.Split(strings.TrimSpace(componentsBeforePause), "\n")
-			var componentsShouldDelete []string
-			for _, component := range originalComponentsList {
-				component = strings.TrimSpace(component)
-				if component == "" {
-					continue
-				}
-				// Check if this component should remain
-				shouldRemain := false
-				for _, remainComponent := range componentsShouldRemain {
-					if component == remainComponent {
-						shouldRemain = true
-						break
-					}
-				}
-				// If it shouldn't remain, add to delete list
-				if !shouldRemain {
-					componentsShouldDelete = append(componentsShouldDelete, component)
-				}
-			}
-			// Verify all components in the delete list are actually deleted
-			verifyComponentsDeleted(componentsAfterPause, componentsShouldDelete)
-
-			g.By("Resume the FlowCollector")
-			resumeTime := time.Now()
-			err = oc.AsAdmin().WithoutNamespace().Run("patch").Args(
-				"flowcollector", "cluster",
-				"--type=merge",
-				"-p", `{"spec":{"execution":{"mode":"Running"}}}`,
-			).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			g.By("Wait for FlowCollector to be ready")
-			flow.WaitForFlowcollectorReady(oc)
-
-			g.By("Verify no 'on hold' message in FlowCollector status")
-			onHoldConditionsAfterResume, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+		g.By("Wait for FlowCollector status to show 'on hold' message")
+		err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 150*time.Second, false, func(context.Context) (done bool, err error) {
+			onHoldConditions, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
 				"flowcollector", "cluster",
 				"-o", `jsonpath={.status.conditions[?(@.message=="FlowCollector is on hold")]}`,
 			).Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(onHoldConditionsAfterResume).Should(o.BeEmpty())
-
-			g.By("Wait for a min before logs gets collected and written to loki after resume")
-			time.Sleep(60 * time.Second)
-
-			g.By("Verify flows are being created in Loki after resume")
-			err = verifyLokilogsTime(kubeadminToken, ls.Route, resumeTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
-		})
-
-		g.It("Author:aramesha-NonPreRelease-High-88455-Verify TLS Tracking feature [Serial]", func() {
-			SkipIfOCPBelow("v4.14")
-			g.By("Deploy TLS test server and client pods")
-			servertemplate := filePath.Join(baseDir, "test-tls-server_template.yaml")
-			testServerTemplate := TestServerTemplate{
-				ServerNS: "test-server-88455",
-				Template: servertemplate,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
-			err := testServerTemplate.createServer(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
-
-			clientTemplate := filePath.Join(baseDir, "test-tls-client_template.yaml")
-			testClientTemplate := TestClientTemplate{
-				ServerNS: testServerTemplate.ServerNS,
-				ClientNS: "test-client-88455",
-				Template: clientTemplate,
-			}
-			defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
-			err = testClientTemplate.createClient(oc)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
-
-			g.By("Deploy FlowCollector with TLS Tracking feature enabled")
-			flow := Flowcollector{
-				Namespace:     namespace,
-				EBPFeatures:   []string{"\"TLSTracking\""},
-				LokiNamespace: lokiStackNS,
-				Template:      flowFixturePath,
-			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			g.By("Wait for a min before logs gets collected and written to loki")
-			startTime := time.Now()
-			time.Sleep(60 * time.Second)
-
-			lokilabels := Lokilabels{
-				App:             "netobserv-flowcollector",
-				SrcK8SNamespace: testClientTemplate.ServerNS,
-				DstK8SNamespace: testClientTemplate.ClientNS,
-				DstK8SOwnerName: "tls-client",
-				SrcK8SOwnerName: "tls-server-service",
-			}
-
-			g.By("Verify HTTP flows")
-			lokiParams := []string{"Proto=\"6\"", "SrcPort=\"80\""}
-			flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of HTTP flows > 0")
-			// Verify TLS fields are not populated
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.TLSVersion).Should(o.BeEmpty(), "expected TLS version to be empty for HTTP")
-			}
-
-			g.By("Verify HTTPS flows with TLSVersion 1.3")
-			lokiParams = []string{"Proto=\"6\"", "SrcPort=\"443\"", "TLSVersion=\"TLS 1.3\""}
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of HTTPS flows with TLSv1.3 > 0")
-			// Verify TLS 1.3 fields
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.TLSTypes).Should(o.ContainElement("ServerHello"), "expected TLS Types to contain ServerHello")
-				o.Expect(r.Flowlog.TLSGroup).NotTo(o.BeEmpty())
-				o.Expect(r.Flowlog.TLSCipherSuite).NotTo(o.BeEmpty())
-			}
-
-			g.By("Verify HTTPS flows with TLSVersion 1.2")
-			lokiParams = []string{"Proto=\"6\"", "SrcPort=\"443\"", "TLSVersion=\"TLS 1.2\""}
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of HTTPS flows with TLSv1.2 > 0")
-			// Verify TLS 1.2 fields
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.TLSTypes).Should(o.ContainElement("ServerHello"), "expected TLS Types to contain ServerHello")
-				o.Expect(r.Flowlog.TLSGroup).Should(o.BeEmpty(), "expected TLS Group to be empty for TLS 1.2")
-				o.Expect(r.Flowlog.TLSCipherSuite).NotTo(o.BeEmpty())
-			}
-
-			g.By("Verify HTTPS flows with TLSVersion 1.1")
-			lokiParams = []string{"Proto=\"6\"", "SrcPort=\"443\"", "TLSVersion=\"TLS 1.1\""}
-			flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, lokiParams...)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of HTTPS flows with TLSv1.1 > 0")
-			// Verify TLS 1.1 fields
-			for _, r := range flowRecords {
-				o.Expect(r.Flowlog.TLSTypes).Should(o.ContainElement("ServerHello"), "expected TLS Types to contain ServerHello")
-				o.Expect(r.Flowlog.TLSGroup).Should(o.BeEmpty(), "expected TLS Group to be empty for TLS 1.1")
-				o.Expect(r.Flowlog.TLSCipherSuite).Should(o.BeEmpty(), "expected TLS CipherSuite to be empty for TLS 1.1")
-			}
-
-			g.By("Verify TLS metrics")
-			verifyTLSMetrics(oc, "TLSVersion")
-			verifyTLSMetrics(oc, "TLSCipherSuite")
-			verifyTLSMetrics(oc, "TLSGroup")
-
-			g.By("Wait for TLSInsecureVersion alert to be active")
-			waitForAlertToBeActive(oc, "TLSInsecureVersion_PerSrcNamespaceWarning")
-
-			g.By("Verify TLS alert has expected labels and annotations")
-			alertStatus, err := getAlertStatus(oc, "TLSInsecureVersion_PerSrcNamespaceWarning")
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(alertStatus["labels"]).To(o.HaveKey("severity"))
-			o.Expect(alertStatus["labels"].(map[string]any)["severity"]).To(o.Equal("warning"))
-			o.Expect(alertStatus["labels"].(map[string]any)["netobserv"]).To(o.Equal("true"))
-		})
-
-		g.It("Author:kapjain-Medium-88683-Secure communications between Agent and FLP [Serial]", func() {
-			SkipIfOCPBelow("v4.14")
-			var (
-				certManagerPackageName = "openshift-cert-manager-operator"
-				certManagerNS          = "cert-manager-operator"
-				certManagerSource      CatalogSourceObjects
-				certManagerCatalog     = "redhat-operators"
-				certTemplatePath       = filePath.Join(baseDir, "cert_manager_certificates_template.yaml")
-			)
-
-			certManager := SubscriptionObjects{
-				OperatorName:  "cert-manager-operator-controller-manager",
-				Namespace:     certManagerNS,
-				PackageName:   certManagerPackageName,
-				Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
-				OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
-				CatalogSource: &certManagerSource,
-			}
-
-			g.By("Deploy cert-manager Operator")
-			// check if cert-manager Operator exists
-			certManagerExisting, err := CheckOperatorStatus(oc, certManager.Namespace, certManager.PackageName)
-			o.Expect(err).NotTo(o.HaveOccurred())
-
-			certManagerChannel, err := getOperatorChannel(oc, certManagerCatalog, certManagerPackageName)
-			if err != nil || certManagerChannel == "" {
-				g.Skip("cert-manager channel not found, skipping test")
-			}
-			certManagerSource = CatalogSourceObjects{certManagerChannel, certManagerCatalog, "openshift-marketplace"}
-
-			if !certManagerExisting {
-				// Create namespace for cert-manager operator
-				certManagerNSObj := OperatorNamespace{
-					Name:              certManagerNS,
-					NamespaceTemplate: filePath.Join(subscriptionDir, "namespace.yaml"),
-				}
-				certManagerNSObj.DeployOperatorNamespace(oc)
-
-				ensureOperatorDeployed(oc, certManager, certManagerSource, "name=cert-manager-operator")
-			}
-
-			defer func() {
-				if !certManagerExisting {
-					certManager.uninstallOperator(oc)
-					oc.DeleteSpecifiedNamespaceAsAdmin(certManagerNS)
-				}
-			}()
-
-			g.By("Wait for cert-manager CRDs to be available")
-			err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 180*time.Second, false, func(context.Context) (done bool, err error) {
-				issuerCRD, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("crd", "issuers.cert-manager.io").Output()
-				certCRD, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("crd", "certificates.cert-manager.io").Output()
-				if strings.Contains(issuerCRD, "issuers.cert-manager.io") && strings.Contains(certCRD, "certificates.cert-manager.io") {
-					e2e.Logf("cert-manager CRDs are available")
-					return true, nil
-				}
-				e2e.Logf("Waiting for cert-manager CRDs to be available...")
+			if err != nil {
+				e2e.Logf("Error getting FlowCollector status: %v", err)
 				return false, nil
-			})
-			compat_otp.AssertWaitPollNoErr(err, "cert-manager CRDs did not become available")
-
-			g.By("Create certificates using cert-manager")
-			certFile := compat_otp.ProcessTemplate(oc, "--ignore-unknown-parameters=true", "-f", certTemplatePath, "-p", "Namespace="+namespace)
-			err = oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", certFile, "-n", namespace).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			defer func() {
-				_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("-f", certFile, "-n", namespace).Execute()
-			}()
-
-			g.By("Wait for certificate secrets to be created")
-			err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 300*time.Second, false, func(context.Context) (done bool, err error) {
-				_, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("secret", "prov-netobserv-ca-secret", "-n", namespace).Output()
-				if err != nil {
-					return false, nil
-				}
-				_, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("secret", "prov-flowlogs-pipeline-cert", "-n", namespace).Output()
-				if err != nil {
-					return false, nil
-				}
-				_, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("secret", "prov-ebpf-agent-cert", "-n", namespace).Output()
-				if err != nil {
-					return false, nil
-				}
-				return true, nil
-			})
-			compat_otp.AssertWaitPollNoErr(err, "certificate secrets did not become available")
-
-			g.By("Deploy FlowCollector in Service mode with Provided TLS certificates")
-			flow := Flowcollector{
-				Namespace:                   namespace,
-				Template:                    flowFixturePath,
-				DeploymentModel:             "Service",
-				ServiceTLSType:              "Provided",
-				ServiceCASecretName:         "prov-netobserv-ca-secret",
-				ServiceServerCertSecretName: "prov-flowlogs-pipeline-cert",
-				ServiceClientCertSecretName: "prov-ebpf-agent-cert",
-				LokiNamespace:               lokiStackNS,
 			}
-
-			defer func() { _ = flow.DeleteFlowcollector(oc) }()
-			flow.CreateFlowcollector(oc)
-
-			g.By("Verify eBPF agent is using mTLS")
-			ebpfPods, err := compat_otp.GetAllPods(oc, namespace+"-privileged")
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(len(ebpfPods)).Should(o.BeNumerically(">", 0), "No eBPF agent pods found")
-
-			ebpfLogs, err := oc.AsAdmin().WithoutNamespace().Run("logs").Args("-n", namespace+"-privileged", ebpfPods[0]).Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(ebpfLogs).To(o.ContainSubstring("Starting GRPC client with mTLS"), "eBPF agent logs should show mTLS is enabled")
-
-			g.By("Wait for flow logs to be collected and written to Loki")
-			startTime := time.Now()
-			time.Sleep(60 * time.Second)
-
-			g.By("Verify flow logs are being stored in Loki using verifyLokilogsTime")
-			err = verifyLokilogsTime(kubeadminToken, ls.Route, startTime)
-			o.Expect(err).NotTo(o.HaveOccurred())
+			if onHoldConditions != "" {
+				e2e.Logf("FlowCollector status shows 'on hold'")
+				return true, nil
+			}
+			e2e.Logf("Waiting for FlowCollector to show 'on hold' status...")
+			return false, nil
 		})
-		//Add future NetObserv + Loki test-cases here
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.Context("with Kafka", func() {
-			var (
-				kafkaDir, kafkaTopicPath, kafkaNodePoolPath string
-				AMQexisting                                 = false
-				amq                                         SubscriptionObjects
-				kafkaMetrics                                KafkaMetrics
-				kafka                                       Kafka
-				kafkaTopic                                  KafkaTopic
-				kafkaNodePool                               KafkaNodePool
-				kafkaUser                                   KafkaUser
-				kafkaNs                                     = "netobserv-kafka"
-				kafkaClusterName                            = "kafka-cluster"
-				kafkaAddress                                = fmt.Sprintf("%s-kafka-bootstrap.%s:9093", kafkaClusterName, kafkaNs)
-				additionalNamespaces                        = fmt.Sprintf("\"%s\"", kafkaNs)
+		g.By("Verify except for netobserv-plugin-static and network policies and persistent configmaps, all components are deleted")
+		componentsAfterPause, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"service,deployment,daemonset,serviceaccount,networkpolicy,configmap,secret",
+			"-A", "-l", "netobserv-managed=true", "-o", "name",
+		).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		e2e.Logf("Components after pause: %s", componentsAfterPause)
+
+		// Components with stable names that should remain when paused
+		// Common components across all OCP versions
+		componentsShouldRemain := []string{
+			"configmap/grafana-dashboard-netobserv-health",
+			"configmap/netobserv-main",
+			"configmap/loki-config",
+			"deployment.apps/loki",
+			"service/loki",
+		}
+		// Static plugin and network policy are only available on OCP 4.15+
+		if IsOCPVersionAtLeast("v4.15") {
+			componentsShouldRemain = append(componentsShouldRemain,
+				"deployment.apps/netobserv-plugin-static",
+				"service/netobserv-plugin-static",
+				"networkpolicy.networking.k8s.io/netobserv",
 			)
+		}
+		verifyComponentsExist(componentsAfterPause, componentsShouldRemain)
 
-			g.BeforeEach(func() {
-				kafkaDir, _ = filePath.Abs("testdata/kafka")
-				// Kafka NodePool path
-				kafkaNodePoolPath = filePath.Join(kafkaDir, "kafka-node-pool.yaml")
-				// Kafka Topic path
-				kafkaTopicPath = filePath.Join(kafkaDir, "kafka-topic.yaml")
-				// Kafka TLS Template path
-				kafkaTLSPath := filePath.Join(kafkaDir, "kafka-tls.yaml")
-				// Kafka metrics config Template path
-				kafkaMetricsPath := filePath.Join(kafkaDir, "kafka-metrics-config.yaml")
-				// Kafka User path
-				kafkaUserPath := filePath.Join(kafkaDir, "kafka-user.yaml")
+		// Verify netobserv-plugin-static pod exists and other pods are deleted (using pattern since pod names have dynamic IDs)
+		podsAfterPause, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"pod", "-A", "-l", "netobserv-managed=true", "-o", "name",
+		).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if IsOCPVersionAtLeast("v4.15") {
+			o.Expect(podsAfterPause).Should(o.ContainSubstring("pod/netobserv-plugin-static-"), "netobserv-plugin-static pod should exist after pause")
+		}
+		o.Expect(podsAfterPause).ShouldNot(o.ContainSubstring("pod/flowlogs-pipeline-"), "flowlogs-pipeline pods should be deleted")
+		o.Expect(podsAfterPause).ShouldNot(o.ContainSubstring("pod/netobserv-ebpf-agent-"), "netobserv-ebpf-agent pods should be deleted")
+		// Verify regular netobserv-plugin pod is deleted (not the static one)
+		podLines := strings.Split(podsAfterPause, "\n")
+		for _, podLine := range podLines {
+			if strings.Contains(podLine, "pod/netobserv-plugin-") && !strings.Contains(podLine, "pod/netobserv-plugin-static-") {
+				e2e.Failf("Found non-static netobserv-plugin pod that should be deleted: %s", podLine)
+			}
+		}
 
-				g.By("Subscribe to AMQ operator")
-				kafkaSource := CatalogSourceObjects{"stable", "redhat-operators", "openshift-marketplace"}
-				amq = SubscriptionObjects{
-					OperatorName:  "amq-streams-cluster-operator",
-					Namespace:     "openshift-operators",
-					PackageName:   "amq-streams",
-					Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
-					CatalogSource: &kafkaSource,
+		// Build list of components that should be deleted = originalComponentsList - componentsShouldRemain
+		originalComponentsList := strings.Split(strings.TrimSpace(componentsBeforePause), "\n")
+		var componentsShouldDelete []string
+		for _, component := range originalComponentsList {
+			component = strings.TrimSpace(component)
+			if component == "" {
+				continue
+			}
+			// Check if this component should remain
+			shouldRemain := false
+			for _, remainComponent := range componentsShouldRemain {
+				if component == remainComponent {
+					shouldRemain = true
+					break
 				}
-
-				kafkaChannel, err := getOperatorChannel(oc, kafkaSource.SourceName, amq.PackageName)
-				if err != nil || kafkaChannel == "" {
-					g.Skip("Kafka channel not found, skip this case")
-				}
-
-				// check if amq Streams Operator is already present
-				AMQexisting, err = CheckOperatorStatus(oc, amq.Namespace, amq.PackageName)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				if !AMQexisting {
-					g.DeferCleanup(amq.uninstallOperator, oc)
-					ensureOperatorDeployed(oc, amq, kafkaSource, "name="+amq.OperatorName)
-					// before creating kafka, check the existence of crd kafkas.kafka.strimzi.io
-					checkResource(oc, true, true, "kafka.strimzi.io", []string{"crd", "kafkas.kafka.strimzi.io", "-ojsonpath={.spec.group}"})
-				}
-
-				kafkaMetrics = KafkaMetrics{
-					Namespace: kafkaNs,
-					Template:  kafkaMetricsPath,
-				}
-
-				kafka = Kafka{
-					Name:      kafkaClusterName,
-					Namespace: kafkaNs,
-					Template:  kafkaTLSPath,
-				}
-
-				kafkaNodePool = KafkaNodePool{
-					NodePoolName: "kafka-pool",
-					Namespace:    kafkaNs,
-					Name:         kafka.Name,
-					Template:     kafkaNodePoolPath,
-				}
-
-				kafkaTopic = KafkaTopic{
-					TopicName: "network-flows",
-					Name:      kafka.Name,
-					Namespace: kafkaNs,
-					Template:  kafkaTopicPath,
-				}
-
-				kafkaUser = KafkaUser{
-					UserName:  "flp-kafka",
-					Name:      kafka.Name,
-					Namespace: kafkaNs,
-					Template:  kafkaUserPath,
-				}
-
-				g.By("Deploy Kafka with TLS")
-				g.DeferCleanup(oc.DeleteSpecifiedNamespaceAsAdmin, kafkaNs)
-				oc.CreateSpecifiedNamespaceAsAdmin(kafkaNs)
-				kafkaMetrics.deployKafkaMetrics(oc)
-				g.DeferCleanup(kafkaNodePool.deleteKafkaNodePool, oc)
-				kafkaNodePool.deployKafkaNodePool(oc)
-				g.DeferCleanup(kafka.deleteKafka, oc)
-				kafka.deployKafka(oc)
-				g.DeferCleanup(kafkaTopic.deleteKafkaTopic, oc)
-				kafkaTopic.deployKafkaTopic(oc)
-				g.DeferCleanup(kafkaUser.deleteKafkaUser, oc)
-				kafkaUser.deployKafkaUser(oc)
-
-				g.By("Check if Kafka and Kafka topic are ready")
-				// wait for KafkaNodePool, Kafka and KafkaTopic to be ready
-				WaitForPodsReadyWithLabel(oc, kafka.Namespace, "strimzi.io/pool-name=kafka-pool")
-				waitForKafkaReady(oc, kafka.Name, kafka.Namespace)
-				waitForKafkaTopicReady(oc, kafkaTopic.TopicName, kafkaTopic.Namespace)
-			})
-
-			g.It("Author:aramesha-NonPreRelease-Longduration-Critical-56362-High-53597-High-56326-High-64880-High-75340-Verify network flows are captured with Kafka with TLS [Serial][Slow]", func() {
-				SkipIfOCPBelow("v4.14")
-
-				g.By("Deploy FlowCollector with Kafka TLS")
-				flow := Flowcollector{
-					Namespace:                         namespace,
-					DeploymentModel:                   "Kafka",
-					Template:                          flowFixturePath,
-					LokiNamespace:                     lokiStackNS,
-					KafkaAddress:                      kafkaAddress,
-					KafkaTLSEnable:                    "true",
-					KafkaNamespace:                    kafkaNs,
-					NetworkPolicyAdditionalNamespaces: []string{additionalNamespaces},
-				}
-
-				defer func() { _ = flow.DeleteFlowcollector(oc) }()
-				flow.CreateFlowcollector(oc)
-
-				g.By("Ensure secrets are synced")
-				// ensure certs are synced to privileged NS
-				secrets, err := getSecrets(oc, namespace+"-privileged")
-				o.Expect(err).ToNot(o.HaveOccurred())
-				o.Expect(secrets).To(o.And(o.ContainSubstring(kafkaUser.UserName), o.ContainSubstring(kafka.Name+"-cluster-ca-cert")))
-
-				g.By("Verify prometheus is able to scrape metrics for FLP-Kafka")
-				flpPrpmSM := "flowlogs-pipeline-transformer-monitor"
-				tlsScheme, err := getMetricsScheme(oc, flpPrpmSM, flow.Namespace)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				tlsScheme = strings.Trim(tlsScheme, "'")
-				o.Expect(tlsScheme).To(o.Equal("https"))
-
-				serverName, err := getMetricsServerName(oc, flpPrpmSM, flow.Namespace)
-				serverName = strings.Trim(serverName, "'")
-				o.Expect(err).NotTo(o.HaveOccurred())
-				flpPromSA := "flowlogs-pipeline-transformer-prom"
-				expectedServerName := fmt.Sprintf("%s.%s.svc", flpPromSA, namespace)
-				o.Expect(serverName).To(o.Equal(expectedServerName))
-
-				// verify FLP metrics are being populated with Kafka
-				// Sleep before making any metrics request
-				g.By("Verify prometheus is able to scrape FLP metrics")
-				time.Sleep(30 * time.Second)
-				verifyFLPMetrics(oc)
-
-				// verify logs
-				g.By("Wait for a min before logs gets collected and written to loki")
-				startTime := time.Now()
-				time.Sleep(60 * time.Second)
-
-				g.By("Get flowlogs from loki")
-				err = verifyLokilogsTime(kubeadminToken, ls.Route, startTime)
-				o.Expect(err).NotTo(o.HaveOccurred())
-			})
-
-			g.It("Author:aramesha-NonPreRelease-Longduration-High-57397-High-65116-Low-89197-Verify network-flows export with Kafka and netobserv installation without Loki[Serial]", func() {
-				SkipIfOCPBelow("v4.10")
-				g.By("Deploy kafka Topic for export")
-				// deploy kafka topic for export
-				kafkaTopic2 := KafkaTopic{
-					TopicName: "network-flows-export",
-					Name:      kafka.Name,
-					Namespace: kafkaNs,
-					Template:  kafkaTopicPath,
-				}
-
-				defer kafkaTopic2.deleteKafkaTopic(oc)
-				kafkaTopic2.deployKafkaTopic(oc)
-				waitForKafkaTopicReady(oc, kafkaTopic2.TopicName, kafkaTopic2.Namespace)
-
-				kafkaExporterConfig := map[string]interface{}{
-					"kafka": map[string]interface{}{
-						"address": kafkaAddress,
-						"tls": map[string]interface{}{
-							"caCert": map[string]interface{}{
-								"certFile":  "ca.crt",
-								"name":      "kafka-cluster-cluster-ca-cert",
-								"namespace": kafkaNs,
-								"type":      "secret"},
-							"enable":             true,
-							"insecureSkipVerify": false,
-							"userCert": map[string]interface{}{
-								"certFile":  "user.crt",
-								"certKey":   "user.key",
-								"name":      kafkaUser.UserName,
-								"namespace": kafkaNs,
-								"type":      "secret"},
-						},
-						"topic": kafkaTopic2.TopicName},
-					"type": "Kafka",
-				}
-
-				config, err := json.Marshal(kafkaExporterConfig)
-				o.Expect(err).ToNot(o.HaveOccurred())
-				kafkaConfig := string(config)
-
-				// Use random compression to test different options across periodic runs
-				validCompressions := []string{"gzip", "snappy", "lz4", "zstd"}
-				randomCompression := validCompressions[g.GinkgoRandomSeed()%int64(len(validCompressions))]
-				e2e.Logf("Using Kafka compression: %s (seed: %d)", randomCompression, g.GinkgoRandomSeed())
-
-				g.By("Deploy FlowCollector with Kafka TLS")
-				flow := Flowcollector{
-					Namespace:                         namespace,
-					DeploymentModel:                   "Kafka",
-					Template:                          flowFixturePath,
-					LokiNamespace:                     lokiStackNS,
-					KafkaAddress:                      kafkaAddress,
-					KafkaTLSEnable:                    "true",
-					KafkaNamespace:                    kafkaNs,
-					KafkaCompression:                  randomCompression,
-					Exporters:                         []string{kafkaConfig},
-					NetworkPolicyAdditionalNamespaces: []string{additionalNamespaces},
-				}
-
-				defer func() { _ = flow.DeleteFlowcollector(oc) }()
-				flow.CreateFlowcollector(oc)
-
-				// Scenario1: Verify flows are exported with Kafka DeploymentModel and with Loki enabled
-				g.By("Verify flowcollector is deployed with KAFKA exporter")
-				exporterType, err := oc.AsAdmin().Run("get").Args("flowcollector", "cluster", "-o", "jsonpath='{.spec.exporters[0].type}'").Output()
-				o.Expect(err).ToNot(o.HaveOccurred())
-				o.Expect(exporterType).To(o.Equal(`'Kafka'`))
-
-				g.By("Ensure flows are observed, all pods are running and secrets are synced and plugin pod is deployed")
-				// ensure certs are synced to privileged NS
-				secrets, err := getSecrets(oc, namespace+"-privileged")
-				o.Expect(err).ToNot(o.HaveOccurred())
-				o.Expect(secrets).To(o.And(o.ContainSubstring(kafkaUser.UserName), o.ContainSubstring(kafka.Name+"-cluster-ca-cert")))
-
-				// verify logs
-				g.By("Wait for a min before logs gets collected and written to loki")
-				startTime := time.Now()
-				time.Sleep(60 * time.Second)
-
-				g.By("Get flowlogs from loki")
-				err = verifyLokilogsTime(kubeadminToken, ls.Route, startTime)
-				o.Expect(err).NotTo(o.HaveOccurred())
-
-				g.By("Deploy Kafka consumer pod")
-				// using amq-streams/kafka-34-rhel8:2.5.2 version. Update if imagePull issues are observed
-				consumerTemplate := filePath.Join(kafkaDir, "topic-consumer-tls.yaml")
-				consumer := Resource{"job", kafkaTopic2.TopicName + "-consumer", kafkaNs}
-				defer func() { _ = consumer.clear(oc) }()
-				err = consumer.applyFromTemplate(oc, "-n", consumer.Namespace, "-f", consumerTemplate, "-p", "NAME="+consumer.Name, "NAMESPACE="+consumer.Namespace, "KAFKA_TOPIC="+kafkaTopic2.TopicName, "CLUSTER_NAME="+kafka.Name, "KAFKA_USER="+kafkaUser.UserName)
-				o.Expect(err).NotTo(o.HaveOccurred())
-
-				WaitForPodsReadyWithLabel(oc, consumer.Namespace, "job-name="+consumer.Name)
-
-				consumerPodName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-n", consumer.Namespace, "-l", "job-name="+consumer.Name, "-o=jsonpath={.items[0].metadata.name}").Output()
-				o.Expect(err).NotTo(o.HaveOccurred())
-
-				g.By("Verify Kafka consumer pod logs")
-				podLogs, err := compat_otp.WaitAndGetSpecificPodLogs(oc, consumer.Namespace, "", consumerPodName, `'{"AgentIP":'`)
-				compat_otp.AssertWaitPollNoErr(err, "Did not get log for the pod with job-name=network-flows-export-consumer label")
-				verifyFlowRecordFromLogs(podLogs)
-
-				g.By("Verify NetObserv can be installed without Loki")
-				_ = flow.DeleteFlowcollector(oc)
-				// Ensure FLP and eBPF pods are deleted
-				checkPodDeleted(oc, namespace, "app=flowlogs-pipeline", "flowlogs-pipeline")
-				checkPodDeleted(oc, namespace+"-privileged", "app=netobserv-ebpf-agent", "netobserv-ebpf-agent")
-
-				flow.DeploymentModel = "Direct"
-				flow.LokiEnable = "false"
-				flow.CreateFlowcollector(oc)
-
-				g.By("Verify Kafka consumer pod logs")
-				podLogs, err = compat_otp.WaitAndGetSpecificPodLogs(oc, consumer.Namespace, "", consumerPodName, `'{"AgentIP":'`)
-				compat_otp.AssertWaitPollNoErr(err, "Did not get log for the pod with job-name=network-flows-export-consumer label")
-				verifyFlowRecordFromLogs(podLogs)
-
-				g.By("Verify console plugin pod is not deployed when its disabled in flowcollector")
-				_ = flow.DeleteFlowcollector(oc)
-				// Ensure FLP and eBPF pods are deleted
-				checkPodDeleted(oc, namespace, "app=flowlogs-pipeline", "flowlogs-pipeline")
-				checkPodDeleted(oc, namespace+"-privileged", "app=netobserv-ebpf-agent", "netobserv-ebpf-agent")
-
-				flow.PluginEnable = "false"
-				flow.CreateFlowcollector(oc)
-
-				// Scenario3: Verify all pods except plugin pod are present with only Plugin disabled in flowcollector
-				g.By("Ensure all pods except consolePlugin pod are deployed")
-				consolePod, err := compat_otp.GetAllPodsWithLabel(oc, namespace, "app=netobserv-plugin")
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(len(consolePod)).To(o.Equal(0))
-			})
-
-			//Add future NetObserv + Loki + Kafka test-cases here
-		})
-
-		g.Context("with VMs", func() {
-			var (
-				// virt operator vars
-				VOexisting                 = false
-				virtOperatorNS             = "openshift-cnv"
-				virtualizationDir, _       = filePath.Abs("testdata/virtualization")
-				kubevirtHyperconvergedPath = filePath.Join(virtualizationDir, "kubevirt-hyperconverged.yaml")
-				virtCatsrc                 = Resource{"catsrc", "redhat-operators", "openshift-marketplace"}
-				virtPackageName            = "kubevirt-hyperconverged"
-				virtSource                 = CatalogSourceObjects{"stable", virtCatsrc.Name, virtCatsrc.Namespace}
-				VO                         = SubscriptionObjects{
-					OperatorName:  "kubevirt-hyperconverged",
-					Namespace:     virtOperatorNS,
-					PackageName:   virtPackageName,
-					Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
-					OperatorGroup: filePath.Join(subscriptionDir, "singlenamespace-og.yaml"),
-					CatalogSource: &virtSource,
-				}
-			)
-
-			g.BeforeEach(func() {
-				clusterArch, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-o=jsonpath={.items[0].status.nodeInfo.architecture}").Output()
-				o.Expect(err).NotTo(o.HaveOccurred())
-				if strings.Contains(clusterArch, "ppc64le") {
-					g.Skip("Virtualization operator is not supported on ppc64le architecture. Skip this test!")
-				}
-
-				isMetal, err := isClusterBareMetal(oc)
-				o.Expect(err).ToNot(o.HaveOccurred())
-				if !isMetal && !hasMetalWorkerNodes(oc) {
-					g.Skip("Cluster does not have baremetal workers. Skip this test!")
-				}
-
-				g.By("Deploy Openshift Virtualization operator")
-				VOexisting, err = CheckOperatorStatus(oc, VO.Namespace, VO.PackageName)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				if !VOexisting {
-					g.DeferCleanup(VO.uninstallOperator, oc)
-					ensureOperatorDeployed(oc, VO, virtSource, "name=virt-operator")
-				}
-
-				g.By("Deploy OpenShift Virtualization Deployment CR")
-				g.DeferCleanup(deleteResource, oc, "hyperconverged", "kubevirt-hyperconverged", virtOperatorNS)
-				_, err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", kubevirtHyperconvergedPath).Output()
-				o.Expect(err).ToNot(o.HaveOccurred())
-				waitUntilHyperConvergedReady(oc, "kubevirt-hyperconverged", virtOperatorNS)
-				WaitForPodsReadyWithLabel(oc, virtOperatorNS, "app.kubernetes.io/managed-by=virt-operator")
-				// Wait for kubemacpool service endpoints to be ready to avoid race condition when creating VMs
-				waitForServiceEndpoints(oc, virtOperatorNS, "kubemacpool-service")
-			})
-
-			g.It("Author:aramesha-NonPreRelease-Longduration-High-76537-Verify flow enrichment for VM's secondary interfaces [Disruptive][Slow]", func() {
-				SkipIfOCPBelow("v4.13")
-				var (
-					testNS = "test-76537"
-					// NAD vars
-					networkName   = "l2-network"
-					layer2NadPath = filePath.Join(virtualizationDir, "layer2-nad.yaml")
-					// VM vars
-					testVMStaticIPTemplatePath = filePath.Join(virtualizationDir, "test-vm-static-IP_template.yaml")
-				)
-
-				g.By("Deploy Network Attachment Definition in test-76537 namespace")
-				defer deleteNamespace(oc, testNS)
-				defer deleteResource(oc, "net-attach-def", networkName, testNS)
-				_, err := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", layer2NadPath).Output()
-				o.Expect(err).ToNot(o.HaveOccurred())
-				// Wait a min for NAD to come up
-				time.Sleep(60 * time.Second)
-				checkNAD(oc, networkName, testNS)
-
-				g.By("Deploy test VM1")
-				testVM1 := TestVMStaticIPTemplate{
-					Name:        "test-vm1",
-					Namespace:   testNS,
-					NetworkName: networkName,
-					Mac:         "02:00:00:00:00:01",
-					StaticIP:    "10.10.10.15/24",
-					Template:    testVMStaticIPTemplatePath,
-				}
-				defer deleteResource(oc, "vm", testVM1.Name, testNS)
-				err = testVM1.createVMStaticIP(oc)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				waitUntilVMReady(oc, testVM1.Name, testVM1.Namespace)
-
-				g.By("Wait for VM1 to get IP assigned")
-				vm1Ip, err := waitForVMIPAssignment(oc, testVM1.Name, testVM1.Namespace, 1)
-				o.Expect(err).ToNot(o.HaveOccurred())
-				o.Expect(vm1Ip).To(o.Equal("10.10.10.15"))
-
-				startTime := time.Now()
-
-				g.By("Deploy test VM2")
-				testVM2 := TestVMStaticIPTemplate{
-					Name:        "test-vm2",
-					Namespace:   testNS,
-					NetworkName: networkName,
-					Mac:         "02:00:00:00:00:02",
-					StaticIP:    "10.10.10.14/24",
-					RunCmd:      fmt.Sprintf("[[ping, %s]]", vm1Ip),
-					Template:    testVMStaticIPTemplatePath,
-				}
-				defer deleteResource(oc, "vm", testVM2.Name, testNS)
-				err = testVM2.createVMStaticIP(oc)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				waitUntilVMReady(oc, testVM2.Name, testVM2.Namespace)
-
-				g.By("Wait for VM2 to get IP assigned")
-				vm2Ip, err := waitForVMIPAssignment(oc, testVM2.Name, testVM2.Namespace, 1)
-				o.Expect(err).ToNot(o.HaveOccurred())
-				o.Expect(vm2Ip).To(o.Equal("10.10.10.14"))
-
-				g.By("Deploy FlowCollector")
-				flow := Flowcollector{
-					Namespace:      namespace,
-					Template:       flowFixturePath,
-					LokiNamespace:  lokiStackNS,
-					EBPFPrivileged: "true",
-				}
-
-				defer func() { _ = flow.DeleteFlowcollector(oc) }()
-				flow.CreateFlowcollector(oc)
-
-				g.By("Wait for a min before logs gets collected and written to loki")
-				time.Sleep(60 * time.Second)
-
-				lokilabels := Lokilabels{
-					App:             "netobserv-flowcollector",
-					SrcK8SNamespace: testNS,
-					SrcK8SOwnerName: testVM2.Name,
-					DstK8SNamespace: testNS,
-					DstK8SOwnerName: testVM1.Name,
-				}
-				parameters := []string{"DstAddr=\"10.10.10.15\"", "SrcAddr=\"10.10.10.14\""}
-
-				g.By("Verify flows are written to loki")
-				flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows written to loki > 0")
-
-				g.By("Verify flow logs are enriched")
-				// Get VM1 pod name and node
-				vm1PodName, err := compat_otp.GetAllPodsWithLabel(oc, testNS, "vm.kubevirt.io/name="+testVM1.Name)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(vm1PodName).NotTo(o.BeEmpty())
-				vm1node, err := compat_otp.GetPodNodeName(oc, testNS, vm1PodName[0])
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(vm1node).NotTo(o.BeEmpty())
-
-				// Get vm2 pod name and node
-				vm2PodName, err := compat_otp.GetAllPodsWithLabel(oc, testNS, "vm.kubevirt.io/name="+testVM2.Name)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(vm2PodName).NotTo(o.BeEmpty())
-				vm2node, err := compat_otp.GetPodNodeName(oc, testNS, vm2PodName[0])
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(vm2node).NotTo(o.BeEmpty())
-
-				for _, r := range flowRecords {
-					o.Expect(r.Flowlog.DstK8SName).Should(o.ContainSubstring(vm1PodName[0]))
-					o.Expect(r.Flowlog.SrcK8SName).Should(o.ContainSubstring(vm2PodName[0]))
-					o.Expect(r.Flowlog.DstK8SOwnerType).Should(o.ContainSubstring("VirtualMachineInstance"))
-					o.Expect(r.Flowlog.SrcK8SOwnerType).Should(o.ContainSubstring("VirtualMachineInstance"))
-					o.Expect(r.Flowlog.DstK8SNetworkName).Should(o.ContainSubstring("test-76537/l2-network"))
-					o.Expect(r.Flowlog.SrcK8SNetworkName).Should(o.ContainSubstring("test-76537/l2-network"))
-				}
-			})
-
-			g.It("Author:aramesha-NonPreRelease-Longduration-Medium-85887-Verify UDN with VMs [Disruptive][Slow]", func() {
-				SkipIfOCPBelow("v4.18")
-				var (
-					// UDN vars
-					udnNS   = "netobserv-udn-85887"
-					udnName = "udn-network-85887"
-					// VM vars
-					testVMUDNTemplatePath = filePath.Join(virtualizationDir, "test-vm-UDN_template.yaml")
-				)
-
-				g.By("Deploy UDN in UDN ns")
-				var cidr, ipv4cidr, ipv6cidr string
-				defer deleteNamespace(oc, udnNS)
-				oc.CreateSpecificNamespaceUDN(udnNS)
-
-				if ipStackType == "ipv4single" {
-					cidr = "10.151.0.0/16"
-				} else {
-					if ipStackType == "ipv6single" {
-						cidr = "2011:100:200::0/48"
-					} else {
-						ipv4cidr = "10.151.0.0/16"
-						ipv6cidr = "2011:100:200::0/48"
-					}
-				}
-				createGeneralUDNCRD(oc, udnNS, udnName, ipv4cidr, ipv6cidr, cidr, "layer2")
-
-				g.By("Deploy test VM3")
-				testVM3 := TestVMUDNTemplate{
-					Name:        "test-vm3",
-					Namespace:   udnNS,
-					NetworkName: udnName,
-					Template:    testVMUDNTemplatePath,
-				}
-				defer deleteResource(oc, "vm", testVM3.Name, testVM3.Namespace)
-				err := testVM3.createVMUDN(oc)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				waitUntilVMReady(oc, testVM3.Name, testVM3.Namespace)
-
-				g.By("Wait for VM3 to get IP assigned")
-				vm3Ip, err := waitForVMIPAssignment(oc, testVM3.Name, testVM3.Namespace, 0)
-				o.Expect(err).ToNot(o.HaveOccurred())
-				o.Expect(vm3Ip).NotTo(o.BeEmpty())
-
-				startTime := time.Now()
-
-				g.By("Deploy test VM4")
-				testVM4 := TestVMUDNTemplate{
-					Name:        "test-vm4",
-					Namespace:   udnNS,
-					NetworkName: udnName,
-					RunCmd:      fmt.Sprintf("[[ping, %s]]", vm3Ip),
-					Template:    testVMUDNTemplatePath,
-				}
-				defer deleteResource(oc, "vm", testVM4.Name, testVM4.Namespace)
-				err = testVM4.createVMUDN(oc)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				waitUntilVMReady(oc, testVM4.Name, testVM4.Namespace)
-
-				g.By("Wait for VM4 to get IP assigned")
-				vm4Ip, err := waitForVMIPAssignment(oc, testVM4.Name, testVM4.Namespace, 0)
-				o.Expect(err).ToNot(o.HaveOccurred())
-				o.Expect(vm4Ip).NotTo(o.BeEmpty())
-
-				g.By("Deploy FlowCollector with UDNMapping feature enabled with eBPF in privileged mode")
-				flow := Flowcollector{
-					Namespace:      namespace,
-					EBPFPrivileged: "true",
-					EBPFeatures:    []string{"\"UDNMapping\""},
-					LokiNamespace:  lokiStackNS,
-					Template:       flowFixturePath,
-				}
-
-				defer func() { _ = flow.DeleteFlowcollector(oc) }()
-				flow.CreateFlowcollector(oc)
-
-				g.By("Wait for a min before logs gets collected and written to loki")
-				time.Sleep(60 * time.Second)
-
-				lokilabels := Lokilabels{
-					App:             "netobserv-flowcollector",
-					SrcK8SNamespace: udnNS,
-					SrcK8SOwnerName: testVM4.Name,
-					DstK8SNamespace: udnNS,
-					DstK8SOwnerName: testVM3.Name,
-				}
-
-				g.By("Verify flows are written to loki")
-				flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows written to loki > 0")
-
-				g.By("Verify flow logs are enriched")
-				// Get VM3 launcher pod name
-				vm3podname, err := compat_otp.GetAllPodsWithLabel(oc, udnNS, "vm.kubevirt.io/name="+testVM3.Name)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(vm3podname).NotTo(o.BeEmpty())
-				// Get VM4 launcher pod name
-				vm4podname, err := compat_otp.GetAllPodsWithLabel(oc, udnNS, "vm.kubevirt.io/name="+testVM4.Name)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(vm4podname).NotTo(o.BeEmpty())
-
-				for _, r := range flowRecords {
-					o.Expect(r.Flowlog.DstK8SName).Should(o.ContainSubstring(vm3podname[0]))
-					o.Expect(r.Flowlog.SrcK8SName).Should(o.ContainSubstring(vm4podname[0]))
-					o.Expect(r.Flowlog.DstK8SOwnerType).Should(o.ContainSubstring("VirtualMachineInstance"))
-					o.Expect(r.Flowlog.SrcK8SOwnerType).Should(o.ContainSubstring("VirtualMachineInstance"))
-					o.Expect(r.Flowlog.Udns).Should(o.ContainElement(fmt.Sprintf("%s/%s", udnNS, udnName)))
-					o.Expect(r.Flowlog.DstK8SNetworkName).Should(o.ContainSubstring(fmt.Sprintf("%s/%s", udnNS, udnName)))
-					o.Expect(r.Flowlog.SrcK8SNetworkName).Should(o.ContainSubstring(fmt.Sprintf("%s/%s", udnNS, udnName)))
-				}
-			})
-
-			g.It("Author:aramesha-High-85935-Validate CUDN with Localnet and VM's[Serial]", func() {
-				SkipIfOCPBelow("v4.19")
-				var (
-					// NMstate operator vars
-					opNamespace       = "openshift-nmstate"
-					nmStateDir, _     = filePath.Abs("testdata/networking/nmstate")
-					nmstateCRTemplate = filePath.Join(nmStateDir, "nmstate-cr-template.yaml")
-					nmstateCR         = nmstateCRResource{
-						name:     "nmstate",
-						template: nmstateCRTemplate,
-					}
-					nodeSelectLabel          = "node-role.kubernetes.io/worker"
-					ovnMappingPolicyTemplate = filePath.Join(nmStateDir, "ovn-mapping-policy-template.yaml")
-					ovnMappingPolicy         = ovnMappingPolicyResource{
-						name:       "bridge-mapping-85935",
-						nodelabel:  nodeSelectLabel,
-						labelvalue: "",
-						localnet1:  "mylocalnet",
-						bridge1:    "br-ex",
-						template:   ovnMappingPolicyTemplate,
-					}
-					// CUDN vars
-					matchLabelKey              = "test.io"
-					matchValue                 = "cudn-network-" + getRandomString()
-					secondaryCUDNName          = "secondary-localnet-85935"
-					cudnNS                     = []string{"netobserv-cudn1-85935", "netobserv-cudn2-85935"}
-					testVMLocalnetTemplatePath = filePath.Join(virtualizationDir, "test-vm-localnet_template.yaml")
-				)
-
-				g.By("Check the platform and network plugin type if it is suitable for running the test")
-				networkType := checkNetworkType(oc)
-				if !(isPlatformSuitableForNMState(oc)) || !strings.Contains(networkType, "ovn") {
-					g.Skip("Skipping for unsupported platform or non-OVN network plugin type!")
-				}
-				installNMstateOperator(oc)
-
-				workerNode, getNodeErr := compat_otp.GetFirstWorkerNode(oc)
-				o.Expect(getNodeErr).NotTo(o.HaveOccurred())
-				o.Expect(workerNode).NotTo(o.BeEmpty())
-
-				compat_otp.By("Create NMState CR")
-				defer deleteNMStateCR(oc, nmstateCR)
-				result, crErr := createNMStateCR(oc, nmstateCR, opNamespace)
-				compat_otp.AssertWaitPollNoErr(crErr, "create nmstate cr failed")
-				o.Expect(result).To(o.BeTrue())
-				e2e.Logf("SUCCESS - NMState CR Created")
-
-				compat_otp.By("Configure NNCP for creating OvnMapping NMstate Feature")
-				defer deleteNNCP(oc, ovnMappingPolicy.name)
-				defer func() {
-					ovnmapping, deferErr := compat_otp.DebugNodeWithChroot(oc, workerNode, "ovs-vsctl", "get", "Open_vSwitch", ".", "external_ids:ovn-bridge-mappings")
-					o.Expect(deferErr).NotTo(o.HaveOccurred())
-					if strings.Contains(ovnmapping, ovnMappingPolicy.localnet1) {
-						// ovs-vsctl can only use "set" to reserve some fields
-						_, err := compat_otp.DebugNodeWithChroot(oc, workerNode, "ovs-vsctl", "set", "Open_vSwitch", ".", "external_ids:ovn-bridge-mappings=\"physnet:br-ex\"")
-						o.Expect(err).NotTo(o.HaveOccurred())
-					}
-				}()
-				configErr3 := ovnMappingPolicy.configNNCP(oc)
-				o.Expect(configErr3).NotTo(o.HaveOccurred())
-				nncpErr3 := checkNNCPStatus(oc, ovnMappingPolicy.name, "Available")
-				compat_otp.AssertWaitPollNoErr(nncpErr3, fmt.Sprintf("%s policy applied failed", ovnMappingPolicy.name))
-
-				compat_otp.By("Create two namespaces and label them")
-				for _, ns := range cudnNS {
-					defer oc.DeleteSpecifiedNamespaceAsAdmin(ns)
-					oc.CreateSpecifiedNamespaceAsAdmin(ns)
-					err := oc.AsAdmin().WithoutNamespace().Run("label").Args("ns", ns, fmt.Sprintf("%s=%s", matchLabelKey, matchValue)).Execute()
-					o.Expect(err).NotTo(o.HaveOccurred())
-				}
-
-				compat_otp.By("Create secondary localnet CUDN")
-				defer removeResource(oc, true, true, "clusteruserdefinednetwork", secondaryCUDNName)
-				_, err := applyLocalnetCUDNtoMatchLabelNS(oc, matchLabelKey, matchValue, secondaryCUDNName, "mylocalnet", "192.168.200.0/24", "192.168.200.1/32", false)
-				o.Expect(err).NotTo(o.HaveOccurred())
-
-				g.By("Deploy test VM5")
-				testVM5 := TestVMUDNTemplate{
-					Name:        "test-vm5",
-					Namespace:   cudnNS[0],
-					NetworkName: secondaryCUDNName,
-					Template:    testVMLocalnetTemplatePath,
-				}
-				defer deleteResource(oc, "vm", testVM5.Name, testVM5.Namespace)
-				err = testVM5.createVMUDN(oc)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				waitUntilVMReady(oc, testVM5.Name, testVM5.Namespace)
-
-				// Even though VM comes up as Ready, the IP assignment takes some time
-				g.By("Wait for VM5 to get IP assigned")
-				vm5Ip, err := waitForVMIPAssignment(oc, testVM5.Name, testVM5.Namespace, 1)
-				o.Expect(err).ToNot(o.HaveOccurred())
-				o.Expect(vm5Ip).NotTo(o.BeEmpty())
-
-				startTime := time.Now()
-
-				g.By("Deploy test VM6")
-				testVM6 := TestVMUDNTemplate{
-					Name:        "test-vm6",
-					Namespace:   cudnNS[1],
-					NetworkName: secondaryCUDNName,
-					RunCmd:      fmt.Sprintf("[[ping, %s]]", vm5Ip),
-					Template:    testVMLocalnetTemplatePath,
-				}
-				defer deleteResource(oc, "vm", testVM6.Name, testVM6.Namespace)
-				err = testVM6.createVMUDN(oc)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				waitUntilVMReady(oc, testVM6.Name, testVM6.Namespace)
-
-				g.By("Wait for VM6 to get IP assigned")
-				vm6Ip, err := waitForVMIPAssignment(oc, testVM6.Name, testVM6.Namespace, 1)
-				o.Expect(err).ToNot(o.HaveOccurred())
-				o.Expect(vm6Ip).NotTo(o.BeEmpty())
-
-				g.By("Deploy FlowCollector with UDNMapping feature enabled with eBPF in privileged mode")
-				flow := Flowcollector{
-					Namespace:      namespace,
-					EBPFPrivileged: "true",
-					EBPFeatures:    []string{"\"UDNMapping\""},
-					LokiNamespace:  lokiStackNS,
-					Template:       flowFixturePath,
-				}
-
-				defer func() { _ = flow.DeleteFlowcollector(oc) }()
-				flow.CreateFlowcollector(oc)
-
-				g.By("Wait for a min before logs gets collected and written to loki")
-				time.Sleep(60 * time.Second)
-
-				g.By("Verify CUDN Localnet flows")
-				lokilabels := Lokilabels{
-					App:             "netobserv-flowcollector",
-					SrcK8SNamespace: cudnNS[1],
-					SrcK8SOwnerName: testVM6.Name,
-					DstK8SNamespace: cudnNS[0],
-					DstK8SOwnerName: testVM5.Name,
-				}
-
-				flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of CUDN Localnet flows > 0")
-				for _, r := range flowRecords {
-					o.Expect(r.Flowlog.Udns).Should(o.ContainElement(secondaryCUDNName))
-					o.Expect(r.Flowlog.DstK8SNetworkName).Should(o.ContainSubstring(secondaryCUDNName))
-					o.Expect(r.Flowlog.SrcK8SNetworkName).Should(o.ContainSubstring(secondaryCUDNName))
-				}
-			})
-			//Add future NetObserv + VM test-cases here
-		})
+			}
+			// If it shouldn't remain, add to delete list
+			if !shouldRemain {
+				componentsShouldDelete = append(componentsShouldDelete, component)
+			}
+		}
+		// Verify all components in the delete list are actually deleted
+		verifyComponentsDeleted(componentsAfterPause, componentsShouldDelete)
+
+		g.By("Resume the FlowCollector")
+		resumeTime := time.Now()
+		err = oc.AsAdmin().WithoutNamespace().Run("patch").Args(
+			"flowcollector", "cluster",
+			"--type=merge",
+			"-p", `{"spec":{"execution":{"mode":"Running"}}}`,
+		).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Wait for FlowCollector to be ready")
+		flow.WaitForFlowcollectorReady(oc)
+
+		g.By("Verify no 'on hold' message in FlowCollector status")
+		onHoldConditionsAfterResume, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"flowcollector", "cluster",
+			"-o", `jsonpath={.status.conditions[?(@.message=="FlowCollector is on hold")]}`,
+		).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(onHoldConditionsAfterResume).Should(o.BeEmpty())
+
+		g.By("Wait for a min before logs gets collected and written to loki after resume")
+		time.Sleep(60 * time.Second)
+
+		g.By("Verify flows are being created in Loki after resume")
+		err = verifyMonolithicLokilogsTime(oc, flow.Namespace, resumeTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
 	})
+
+	g.It("Author:aramesha-NonPreRelease-High-88455-Verify TLS Tracking feature [Serial]", func() {
+		g.By("Deploy TLS test server and client pods")
+		servertemplate := filePath.Join(baseDir, "test-tls-server_template.yaml")
+		testServerTemplate := TestServerTemplate{
+			ServerNS: "test-server-88455",
+			Template: servertemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplate.ServerNS)
+		err := testServerTemplate.createServer(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testServerTemplate.ServerNS)
+
+		clientTemplate := filePath.Join(baseDir, "test-tls-client_template.yaml")
+		testClientTemplate := TestClientTemplate{
+			ServerNS: testServerTemplate.ServerNS,
+			ClientNS: "test-client-88455",
+			Template: clientTemplate,
+		}
+		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplate.ClientNS)
+		err = testClientTemplate.createClient(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		compat_otp.AssertAllPodsToBeReady(oc, testClientTemplate.ClientNS)
+
+		g.By("Deploy FlowCollector with TLS Tracking feature enabled")
+		flow := Flowcollector{
+			Namespace:   namespace,
+			EBPFeatures: []string{"\"TLSTracking\""},
+			Template:    flowFixturePath,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Wait for a min before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(60 * time.Second)
+
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: testClientTemplate.ServerNS,
+			DstK8SNamespace: testClientTemplate.ClientNS,
+			DstK8SOwnerName: "tls-client",
+			SrcK8SOwnerName: "tls-server-service",
+		}
+
+		g.By("Verify HTTP flows")
+		lokiParams := []string{"Proto=\"6\"", "SrcPort=\"80\""}
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of HTTP flows > 0")
+		// Verify TLS fields are not populated
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.TLSVersion).Should(o.BeEmpty(), "expected TLS version to be empty for HTTP")
+		}
+
+		g.By("Verify HTTPS flows with TLSVersion 1.3")
+		lokiParams = []string{"Proto=\"6\"", "SrcPort=\"443\"", "TLSVersion=\"TLS 1.3\""}
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of HTTPS flows with TLSv1.3 > 0")
+		// Verify TLS 1.3 fields
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.TLSTypes).Should(o.ContainElement("ServerHello"), "expected TLS Types to contain ServerHello")
+			o.Expect(r.Flowlog.TLSGroup).NotTo(o.BeEmpty())
+			o.Expect(r.Flowlog.TLSCipherSuite).NotTo(o.BeEmpty())
+		}
+
+		g.By("Verify HTTPS flows with TLSVersion 1.2")
+		lokiParams = []string{"Proto=\"6\"", "SrcPort=\"443\"", "TLSVersion=\"TLS 1.2\""}
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of HTTPS flows with TLSv1.2 > 0")
+		// Verify TLS 1.2 fields
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.TLSTypes).Should(o.ContainElement("ServerHello"), "expected TLS Types to contain ServerHello")
+			o.Expect(r.Flowlog.TLSGroup).Should(o.BeEmpty(), "expected TLS Group to be empty for TLS 1.2")
+			o.Expect(r.Flowlog.TLSCipherSuite).NotTo(o.BeEmpty())
+		}
+
+		g.By("Verify HTTPS flows with TLSVersion 1.1")
+		lokiParams = []string{"Proto=\"6\"", "SrcPort=\"443\"", "TLSVersion=\"TLS 1.1\""}
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, lokiParams...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of HTTPS flows with TLSv1.1 > 0")
+		// Verify TLS 1.1 fields
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.TLSTypes).Should(o.ContainElement("ServerHello"), "expected TLS Types to contain ServerHello")
+			o.Expect(r.Flowlog.TLSGroup).Should(o.BeEmpty(), "expected TLS Group to be empty for TLS 1.1")
+			o.Expect(r.Flowlog.TLSCipherSuite).Should(o.BeEmpty(), "expected TLS CipherSuite to be empty for TLS 1.1")
+		}
+
+		g.By("Verify TLS metrics")
+		verifyTLSMetrics(oc, "TLSVersion")
+		verifyTLSMetrics(oc, "TLSCipherSuite")
+		verifyTLSMetrics(oc, "TLSGroup")
+
+		g.By("Wait for TLSInsecureVersion alert to be active")
+		waitForAlertToBePending(oc, "TLSInsecureVersion_PerSrcNamespaceWarning")
+
+		g.By("Verify TLS alert has expected labels")
+		alertLabels, err := getAlertLabels(oc, "TLSInsecureVersion_PerSrcNamespaceWarning")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(alertLabels).NotTo(o.BeNil())
+		o.Expect(alertLabels).To(o.HaveKeyWithValue("severity", "warning"))
+		o.Expect(alertLabels).To(o.HaveKeyWithValue("netobserv", "true"))
+	})
+
+	g.It("Author:kapjain-Medium-88683-Secure communications between Agent and FLP [Serial]", func() {
+		var (
+			certManagerPackageName = "openshift-cert-manager-operator"
+			certManagerNS          = "cert-manager-operator"
+			certManagerSource      CatalogSourceObjects
+			certManagerCatalog     = "redhat-operators"
+			certTemplatePath       = filePath.Join(baseDir, "cert_manager_certificates_template.yaml")
+		)
+
+		certManager := SubscriptionObjects{
+			OperatorName:  "cert-manager-operator-controller-manager",
+			Namespace:     certManagerNS,
+			PackageName:   certManagerPackageName,
+			Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
+			OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
+			CatalogSource: &certManagerSource,
+		}
+
+		g.By("Deploy cert-manager Operator")
+		// check if cert-manager Operator exists
+		certManagerExisting, err := CheckOperatorStatus(oc, certManager.Namespace, certManager.PackageName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		certManagerChannel, err := getOperatorChannel(oc, certManagerCatalog, certManagerPackageName)
+		if err != nil || certManagerChannel == "" {
+			g.Skip("cert-manager channel not found, skipping test")
+		}
+		certManagerSource = CatalogSourceObjects{certManagerChannel, certManagerCatalog, "openshift-marketplace"}
+
+		if !certManagerExisting {
+			// Create namespace for cert-manager operator
+			certManagerNSObj := OperatorNamespace{
+				Name:              certManagerNS,
+				NamespaceTemplate: filePath.Join(subscriptionDir, "namespace.yaml"),
+			}
+			certManagerNSObj.DeployOperatorNamespace(oc)
+
+			ensureOperatorDeployed(oc, certManager, certManagerSource, "name=cert-manager-operator")
+		}
+
+		defer func() {
+			if !certManagerExisting {
+				certManager.uninstallOperator(oc)
+				oc.DeleteSpecifiedNamespaceAsAdmin(certManagerNS)
+			}
+		}()
+
+		g.By("Wait for cert-manager CRDs to be available")
+		err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 180*time.Second, false, func(context.Context) (done bool, err error) {
+			issuerCRD, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("crd", "issuers.cert-manager.io").Output()
+			certCRD, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("crd", "certificates.cert-manager.io").Output()
+			if strings.Contains(issuerCRD, "issuers.cert-manager.io") && strings.Contains(certCRD, "certificates.cert-manager.io") {
+				e2e.Logf("cert-manager CRDs are available")
+				return true, nil
+			}
+			e2e.Logf("Waiting for cert-manager CRDs to be available...")
+			return false, nil
+		})
+		compat_otp.AssertWaitPollNoErr(err, "cert-manager CRDs did not become available")
+
+		g.By("Create certificates using cert-manager")
+		certFile := compat_otp.ProcessTemplate(oc, "--ignore-unknown-parameters=true", "-f", certTemplatePath, "-p", "Namespace="+namespace)
+		// Retry apply because cert-manager webhook may not be ready immediately after CRDs appear
+		err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 300*time.Second, true, func(context.Context) (done bool, err error) {
+			applyErr := oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", certFile, "-n", namespace).Execute()
+			if applyErr != nil {
+				e2e.Logf("Waiting for cert-manager webhook to be ready: %v", applyErr)
+				return false, nil
+			}
+			return true, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer func() {
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("-f", certFile, "-n", namespace).Execute()
+		}()
+
+		g.By("Wait for certificate secrets to be created")
+		err = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 300*time.Second, false, func(context.Context) (done bool, err error) {
+			_, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("secret", "prov-netobserv-ca-secret", "-n", namespace).Output()
+			if err != nil {
+				return false, nil
+			}
+			_, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("secret", "prov-flowlogs-pipeline-cert", "-n", namespace).Output()
+			if err != nil {
+				return false, nil
+			}
+			_, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("secret", "prov-ebpf-agent-cert", "-n", namespace).Output()
+			if err != nil {
+				return false, nil
+			}
+			return true, nil
+		})
+		compat_otp.AssertWaitPollNoErr(err, "certificate secrets did not become available")
+
+		g.By("Deploy FlowCollector in Service mode with Provided TLS certificates")
+		flow := Flowcollector{
+			Namespace:                   namespace,
+			Template:                    flowFixturePath,
+			DeploymentModel:             "Service",
+			ServiceTLSType:              "Provided",
+			ServiceCASecretName:         "prov-netobserv-ca-secret",
+			ServiceServerCertSecretName: "prov-flowlogs-pipeline-cert",
+			ServiceClientCertSecretName: "prov-ebpf-agent-cert",
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Verify eBPF agent is using mTLS")
+		ebpfPods, err := compat_otp.GetAllPods(oc, namespace+"-privileged")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(ebpfPods)).Should(o.BeNumerically(">", 0), "No eBPF agent pods found")
+
+		ebpfLogs, err := oc.AsAdmin().WithoutNamespace().Run("logs").Args("-n", namespace+"-privileged", ebpfPods[0]).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(ebpfLogs).To(o.ContainSubstring("Starting GRPC client with mTLS"), "eBPF agent logs should show mTLS is enabled")
+
+		g.By("Wait for flow logs to be collected and written to Loki")
+		startTime := time.Now()
+		time.Sleep(60 * time.Second)
+
+		g.By("Verify flow logs are being stored in Loki using verifyLokilogsTime")
+		err = verifyMonolithicLokilogsTime(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+	// Add future NetObserv + demoLoki test-cases here
 })

--- a/integration-tests/backend/test_flowcollector_kafka.go
+++ b/integration-tests/backend/test_flowcollector_kafka.go
@@ -1,0 +1,324 @@
+package e2etests
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	filePath "path/filepath"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[sig-netobserv] Network_Observability with Kafka", g.Ordered, g.ContinueOnFailure, func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc        = compat_otp.NewCLI("netobserv", compat_otp.KubeConfigPath())
+		namespace string
+
+		// Kafka-specific variables
+		kafkaDir, kafkaTopicPath, kafkaNodePoolPath string
+		AMQexisting                                 = false
+		amq                                         SubscriptionObjects
+		kafkaMetrics                                KafkaMetrics
+		kafka                                       Kafka
+		kafkaTopic                                  KafkaTopic
+		kafkaNodePool                               KafkaNodePool
+		kafkaUser                                   KafkaUser
+		kafkaNs                                     = "netobserv-kafka"
+		kafkaClusterName                            = "kafka-cluster"
+		kafkaAddress                                = fmt.Sprintf("%s-kafka-bootstrap.%s:9093", kafkaClusterName, kafkaNs)
+		additionalNamespaces                        = fmt.Sprintf("\"%s\"", kafkaNs)
+	)
+
+	g.BeforeAll(func() {
+		oc.SetNamespace(netobservNS)
+
+		// Set up Kafka paths
+		kafkaDir, _ = filePath.Abs("testdata/kafka")
+		kafkaNodePoolPath = filePath.Join(kafkaDir, "kafka-node-pool.yaml")
+		kafkaTopicPath = filePath.Join(kafkaDir, "kafka-topic.yaml")
+		kafkaTLSPath := filePath.Join(kafkaDir, "kafka-tls.yaml")
+		kafkaMetricsPath := filePath.Join(kafkaDir, "kafka-metrics-config.yaml")
+		kafkaUserPath := filePath.Join(kafkaDir, "kafka-user.yaml")
+
+		g.By("Subscribe to AMQ operator")
+		kafkaSource := CatalogSourceObjects{"stable", "redhat-operators", "openshift-marketplace"}
+		amq = SubscriptionObjects{
+			OperatorName:  "amq-streams-cluster-operator",
+			Namespace:     "openshift-operators",
+			PackageName:   "amq-streams",
+			Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
+			CatalogSource: &kafkaSource,
+		}
+
+		kafkaChannel, err := getOperatorChannel(oc, kafkaSource.SourceName, amq.PackageName)
+		if err != nil || kafkaChannel == "" {
+			g.Skip("Kafka channel not found, skip this case")
+		}
+
+		// check if AMQ Streams Operator is already present
+		AMQexisting, err = CheckOperatorStatus(oc, amq.Namespace, amq.PackageName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if !AMQexisting {
+			ensureOperatorDeployed(oc, amq, kafkaSource, "name="+amq.OperatorName)
+			// before creating kafka, check the existence of crd kafkas.kafka.strimzi.io
+			checkResource(oc, true, true, "kafka.strimzi.io", []string{"crd", "kafkas.kafka.strimzi.io", "-ojsonpath={.spec.group}"})
+		}
+
+		kafkaMetrics = KafkaMetrics{
+			Namespace: kafkaNs,
+			Template:  kafkaMetricsPath,
+		}
+
+		kafka = Kafka{
+			Name:      kafkaClusterName,
+			Namespace: kafkaNs,
+			Template:  kafkaTLSPath,
+		}
+
+		kafkaNodePool = KafkaNodePool{
+			NodePoolName: "kafka-pool",
+			Namespace:    kafkaNs,
+			Name:         kafka.Name,
+			Template:     kafkaNodePoolPath,
+		}
+
+		kafkaTopic = KafkaTopic{
+			TopicName: "network-flows",
+			Name:      kafka.Name,
+			Namespace: kafkaNs,
+			Template:  kafkaTopicPath,
+		}
+
+		kafkaUser = KafkaUser{
+			UserName:  "flp-kafka",
+			Name:      kafka.Name,
+			Namespace: kafkaNs,
+			Template:  kafkaUserPath,
+		}
+
+		g.By("Deploy Kafka with TLS")
+		oc.CreateSpecifiedNamespaceAsAdmin(kafkaNs)
+		kafkaMetrics.deployKafkaMetrics(oc)
+		kafkaNodePool.deployKafkaNodePool(oc)
+		kafka.deployKafka(oc)
+		kafkaTopic.deployKafkaTopic(oc)
+		kafkaUser.deployKafkaUser(oc)
+
+		g.By("Check if Kafka and Kafka topic are ready")
+		// wait for KafkaNodePool, Kafka and KafkaTopic to be ready
+		WaitForPodsReadyWithLabel(oc, kafka.Namespace, "strimzi.io/pool-name=kafka-pool")
+		waitForKafkaReady(oc, kafka.Name, kafka.Namespace)
+		waitForKafkaTopicReady(oc, kafkaTopic.TopicName, kafkaTopic.Namespace)
+	})
+
+	g.AfterAll(func() {
+		// Clean up Kafka resources in reverse order
+		kafkaUser.deleteKafkaUser(oc)
+		kafkaTopic.deleteKafkaTopic(oc)
+		kafka.deleteKafka(oc)
+		kafkaNodePool.deleteKafkaNodePool(oc)
+		oc.DeleteSpecifiedNamespaceAsAdmin(kafkaNs)
+
+		// Uninstall AMQ operator if it was not pre-existing
+		if !AMQexisting {
+			amq.uninstallOperator(oc)
+		}
+	})
+
+	g.BeforeEach(func() {
+		namespace = oc.Namespace()
+	})
+
+	g.It("Author:aramesha-NonPreRelease-Longduration-Critical-56362-High-53597-High-56326-High-64880-High-75340-Verify network flows are captured with Kafka with TLS [Serial][Slow]", func() {
+
+		g.By("Deploy FlowCollector with Kafka TLS")
+		flow := Flowcollector{
+			Namespace:                         namespace,
+			DeploymentModel:                   "Kafka",
+			Template:                          flowFixturePath,
+			KafkaAddress:                      kafkaAddress,
+			KafkaTLSEnable:                    "true",
+			KafkaNamespace:                    kafkaNs,
+			NetworkPolicyAdditionalNamespaces: []string{additionalNamespaces},
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Ensure secrets are synced")
+		// ensure certs are synced to privileged NS
+		secrets, err := getSecrets(oc, namespace+"-privileged")
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(secrets).To(o.And(o.ContainSubstring(kafkaUser.UserName), o.ContainSubstring(kafka.Name+"-cluster-ca-cert")))
+
+		g.By("Verify prometheus is able to scrape metrics for FLP-Kafka")
+		flpPrpmSM := "flowlogs-pipeline-transformer-monitor"
+		tlsScheme, err := getMetricsScheme(oc, flpPrpmSM, flow.Namespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		tlsScheme = strings.Trim(tlsScheme, "'")
+		o.Expect(tlsScheme).To(o.Equal("https"))
+
+		serverName, err := getMetricsServerName(oc, flpPrpmSM, flow.Namespace)
+		serverName = strings.Trim(serverName, "'")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		flpPromSA := "flowlogs-pipeline-transformer-prom"
+		expectedServerName := fmt.Sprintf("%s.%s.svc", flpPromSA, namespace)
+		o.Expect(serverName).To(o.Equal(expectedServerName))
+
+		// verify FLP metrics are being populated with Kafka
+		// Sleep before making any metrics request
+		g.By("Verify prometheus is able to scrape FLP metrics")
+		time.Sleep(30 * time.Second)
+		verifyFLPMetrics(oc)
+
+		// verify logs
+		g.By("Wait for a min before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(60 * time.Second)
+
+		g.By("Get flowlogs from loki")
+		err = verifyMonolithicLokilogsTime(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("Author:aramesha-NonPreRelease-Longduration-High-57397-High-65116-Low-89197-Verify network-flows export with Kafka and netobserv installation without Loki[Serial]", func() {
+		g.By("Deploy kafka Topic for export")
+		// deploy kafka topic for export
+		kafkaTopic2 := KafkaTopic{
+			TopicName: "network-flows-export",
+			Name:      kafka.Name,
+			Namespace: kafkaNs,
+			Template:  kafkaTopicPath,
+		}
+
+		defer kafkaTopic2.deleteKafkaTopic(oc)
+		kafkaTopic2.deployKafkaTopic(oc)
+		waitForKafkaTopicReady(oc, kafkaTopic2.TopicName, kafkaTopic2.Namespace)
+
+		kafkaExporterConfig := map[string]interface{}{
+			"kafka": map[string]interface{}{
+				"address": kafkaAddress,
+				"tls": map[string]interface{}{
+					"caCert": map[string]interface{}{
+						"certFile":  "ca.crt",
+						"name":      "kafka-cluster-cluster-ca-cert",
+						"namespace": kafkaNs,
+						"type":      "secret"},
+					"enable":             true,
+					"insecureSkipVerify": false,
+					"userCert": map[string]interface{}{
+						"certFile":  "user.crt",
+						"certKey":   "user.key",
+						"name":      kafkaUser.UserName,
+						"namespace": kafkaNs,
+						"type":      "secret"},
+				},
+				"topic": kafkaTopic2.TopicName},
+			"type": "Kafka",
+		}
+
+		config, err := json.Marshal(kafkaExporterConfig)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		kafkaConfig := string(config)
+
+		// Use random compression to test different options across periodic runs
+		validCompressions := []string{"gzip", "snappy", "lz4", "zstd"}
+		randomCompression := validCompressions[g.GinkgoRandomSeed()%int64(len(validCompressions))]
+		e2e.Logf("Using Kafka compression: %s (seed: %d)", randomCompression, g.GinkgoRandomSeed())
+
+		g.By("Deploy FlowCollector with Kafka TLS")
+		flow := Flowcollector{
+			Namespace:                         namespace,
+			DeploymentModel:                   "Kafka",
+			Template:                          flowFixturePath,
+			KafkaAddress:                      kafkaAddress,
+			KafkaTLSEnable:                    "true",
+			KafkaNamespace:                    kafkaNs,
+			KafkaCompression:                  randomCompression,
+			Exporters:                         []string{kafkaConfig},
+			NetworkPolicyAdditionalNamespaces: []string{additionalNamespaces},
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		// Scenario1: Verify flows are exported with Kafka DeploymentModel and with Loki enabled
+		g.By("Verify flowcollector is deployed with KAFKA exporter")
+		exporterType, err := oc.AsAdmin().Run("get").Args("flowcollector", "cluster", "-o", "jsonpath='{.spec.exporters[0].type}'").Output()
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(exporterType).To(o.Equal(`'Kafka'`))
+
+		g.By("Ensure flows are observed, all pods are running and secrets are synced and plugin pod is deployed")
+		// ensure certs are synced to privileged NS
+		secrets, err := getSecrets(oc, namespace+"-privileged")
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(secrets).To(o.And(o.ContainSubstring(kafkaUser.UserName), o.ContainSubstring(kafka.Name+"-cluster-ca-cert")))
+
+		// verify logs
+		g.By("Wait for a min before logs gets collected and written to loki")
+		startTime := time.Now()
+		time.Sleep(60 * time.Second)
+
+		g.By("Get flowlogs from loki")
+		err = verifyMonolithicLokilogsTime(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Deploy Kafka consumer pod")
+		// using amq-streams/kafka-34-rhel8:2.5.2 version. Update if imagePull issues are observed
+		consumerTemplate := filePath.Join(kafkaDir, "topic-consumer-tls.yaml")
+		consumer := Resource{"job", kafkaTopic2.TopicName + "-consumer", kafkaNs}
+		defer func() { _ = consumer.clear(oc) }()
+		err = consumer.applyFromTemplate(oc, "-n", consumer.Namespace, "-f", consumerTemplate, "-p", "NAME="+consumer.Name, "NAMESPACE="+consumer.Namespace, "KAFKA_TOPIC="+kafkaTopic2.TopicName, "CLUSTER_NAME="+kafka.Name, "KAFKA_USER="+kafkaUser.UserName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		WaitForPodsReadyWithLabel(oc, consumer.Namespace, "job-name="+consumer.Name)
+
+		consumerPodName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-n", consumer.Namespace, "-l", "job-name="+consumer.Name, "-o=jsonpath={.items[0].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Verify Kafka consumer pod logs")
+		podLogs, err := compat_otp.WaitAndGetSpecificPodLogs(oc, consumer.Namespace, "", consumerPodName, `'{"AgentIP":'`)
+		compat_otp.AssertWaitPollNoErr(err, "Did not get log for the pod with job-name=network-flows-export-consumer label")
+		verifyFlowRecordFromLogs(podLogs)
+
+		g.By("Verify NetObserv can be installed without Loki")
+		_ = flow.DeleteFlowcollector(oc)
+		// Ensure FLP and eBPF pods are deleted
+		checkPodDeleted(oc, namespace, "app=flowlogs-pipeline", "flowlogs-pipeline")
+		checkPodDeleted(oc, namespace+"-privileged", "app=netobserv-ebpf-agent", "netobserv-ebpf-agent")
+
+		flow.DeploymentModel = "Service"
+		flow.LokiEnable = "false"
+		flow.InstallDemoLoki = "false"
+		flow.CreateFlowcollector(oc)
+
+		g.By("Verify new Kafka consumer records after FlowCollector recreation")
+		podLogs, err = waitForNewPodLogs(oc, consumer.Namespace, consumerPodName, `{"AgentIP":`)
+		compat_otp.AssertWaitPollNoErr(err, "No new records appeared in Kafka consumer after FlowCollector recreation")
+		verifyFlowRecordFromLogs(podLogs)
+
+		g.By("Verify console plugin pod is not deployed when its disabled in flowcollector")
+		_ = flow.DeleteFlowcollector(oc)
+		// Ensure FLP and eBPF pods are deleted
+		checkPodDeleted(oc, namespace, "app=flowlogs-pipeline", "flowlogs-pipeline")
+		checkPodDeleted(oc, namespace+"-privileged", "app=netobserv-ebpf-agent", "netobserv-ebpf-agent")
+
+		flow.PluginEnable = "false"
+		flow.CreateFlowcollector(oc)
+
+		// Scenario3: Verify all pods except plugin pod are present with only Plugin disabled in flowcollector
+		g.By("Ensure all pods except consolePlugin pod are deployed")
+		consolePod, err := compat_otp.GetAllPodsWithLabel(oc, namespace, "app=netobserv-plugin")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(consolePod)).To(o.Equal(0))
+	})
+
+	// Add future NetObserv + demoLoki + Kafka test-cases here
+})

--- a/integration-tests/backend/test_flowcollector_virt.go
+++ b/integration-tests/backend/test_flowcollector_virt.go
@@ -1,0 +1,466 @@
+package e2etests
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	filePath "path/filepath"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[sig-netobserv] Network_Observability with VMs", g.Ordered, g.ContinueOnFailure, func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc        = compat_otp.NewCLI("netobserv", compat_otp.KubeConfigPath())
+		namespace string
+
+		// virt operator vars
+		VOexisting                 = false
+		virtOperatorNS             = "openshift-cnv"
+		virtualizationDir, _       = filePath.Abs("testdata/virtualization")
+		kubevirtHyperconvergedPath = filePath.Join(virtualizationDir, "kubevirt-hyperconverged.yaml")
+		virtCatsrc                 = Resource{"catsrc", "redhat-operators", "openshift-marketplace"}
+		virtPackageName            = "kubevirt-hyperconverged"
+		virtSource                 = CatalogSourceObjects{"stable", virtCatsrc.Name, virtCatsrc.Namespace}
+		VO                         = SubscriptionObjects{
+			OperatorName:  "kubevirt-hyperconverged",
+			Namespace:     virtOperatorNS,
+			PackageName:   virtPackageName,
+			Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
+			OperatorGroup: filePath.Join(subscriptionDir, "singlenamespace-og.yaml"),
+			CatalogSource: &virtSource,
+		}
+		networkingDir = filePath.Join(baseDir, "networking")
+		ipStackType   string
+	)
+
+	g.BeforeAll(func() {
+		oc.SetNamespace(netobservNS)
+		ipStackType = checkIPStackType(oc)
+
+		// Architecture check
+		clusterArch, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-o=jsonpath={.items[0].status.nodeInfo.architecture}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if strings.Contains(clusterArch, "ppc64le") {
+			g.Skip("Virtualization operator is not supported on ppc64le architecture.")
+		}
+		isMetal, err := isClusterBareMetal(oc)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		if !isMetal && !hasMetalWorkerNodes(oc) {
+			g.Skip("Cluster does not have baremetal workers.")
+		}
+
+		// Deploy virt operator + HyperConverged
+		VOexisting, err = CheckOperatorStatus(oc, VO.Namespace, VO.PackageName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if !VOexisting {
+			ensureOperatorDeployed(oc, VO, virtSource, "name=virt-operator")
+		}
+		_, err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", kubevirtHyperconvergedPath).Output()
+		o.Expect(err).ToNot(o.HaveOccurred())
+		waitUntilHyperConvergedReady(oc, "kubevirt-hyperconverged", virtOperatorNS)
+		WaitForPodsReadyWithLabel(oc, virtOperatorNS, "app.kubernetes.io/managed-by=virt-operator")
+		// Wait for kubemacpool service endpoints to be ready to avoid race condition when creating VMs
+		waitForServiceEndpoints(oc, virtOperatorNS, "kubemacpool-service")
+	})
+
+	g.AfterAll(func() {
+		deleteResource(oc, "hyperconverged", "kubevirt-hyperconverged", virtOperatorNS)
+		if !VOexisting {
+			VO.uninstallOperator(oc)
+		}
+	})
+
+	g.BeforeEach(func() {
+		namespace = oc.Namespace()
+	})
+
+	g.It("Author:aramesha-NonPreRelease-Longduration-High-76537-Verify flow enrichment for VM's secondary interfaces [Disruptive][Slow]", func() {
+		var (
+			testNS = "test-76537"
+			// NAD vars
+			networkName   = "l2-network"
+			layer2NadPath = filePath.Join(virtualizationDir, "layer2-nad.yaml")
+			// VM vars
+			testVMStaticIPTemplatePath = filePath.Join(virtualizationDir, "test-vm-static-IP_template.yaml")
+		)
+
+		g.By("Deploy Network Attachment Definition in test-76537 namespace")
+		defer deleteNamespace(oc, testNS)
+		defer deleteResource(oc, "net-attach-def", networkName, testNS)
+		_, err := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", layer2NadPath).Output()
+		o.Expect(err).ToNot(o.HaveOccurred())
+		// Wait a min for NAD to come up
+		time.Sleep(60 * time.Second)
+		checkNAD(oc, networkName, testNS)
+
+		g.By("Deploy test VM1")
+		testVM1 := TestVMStaticIPTemplate{
+			Name:        "test-vm1",
+			Namespace:   testNS,
+			NetworkName: networkName,
+			Mac:         "02:00:00:00:00:01",
+			StaticIP:    "10.10.10.15/24",
+			Template:    testVMStaticIPTemplatePath,
+		}
+		defer deleteResource(oc, "vm", testVM1.Name, testNS)
+		err = testVM1.createVMStaticIP(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitUntilVMReady(oc, testVM1.Name, testVM1.Namespace)
+
+		g.By("Wait for VM1 to get IP assigned")
+		vm1Ip, err := waitForVMIPAssignment(oc, testVM1.Name, testVM1.Namespace, 1)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(vm1Ip).To(o.Equal("10.10.10.15"))
+
+		startTime := time.Now()
+
+		g.By("Deploy test VM2")
+		testVM2 := TestVMStaticIPTemplate{
+			Name:        "test-vm2",
+			Namespace:   testNS,
+			NetworkName: networkName,
+			Mac:         "02:00:00:00:00:02",
+			StaticIP:    "10.10.10.14/24",
+			RunCmd:      fmt.Sprintf("[[ping, %s]]", vm1Ip),
+			Template:    testVMStaticIPTemplatePath,
+		}
+		defer deleteResource(oc, "vm", testVM2.Name, testNS)
+		err = testVM2.createVMStaticIP(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitUntilVMReady(oc, testVM2.Name, testVM2.Namespace)
+
+		g.By("Wait for VM2 to get IP assigned")
+		vm2Ip, err := waitForVMIPAssignment(oc, testVM2.Name, testVM2.Namespace, 1)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(vm2Ip).To(o.Equal("10.10.10.14"))
+
+		g.By("Deploy FlowCollector")
+		flow := Flowcollector{
+			Namespace:      namespace,
+			Template:       flowFixturePath,
+			EBPFPrivileged: "true",
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Wait for a min before logs gets collected and written to loki")
+		time.Sleep(60 * time.Second)
+
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: testNS,
+			SrcK8SOwnerName: testVM2.Name,
+			DstK8SNamespace: testNS,
+			DstK8SOwnerName: testVM1.Name,
+		}
+		parameters := []string{"DstAddr=\"10.10.10.15\"", "SrcAddr=\"10.10.10.14\""}
+
+		g.By("Verify flows are written to loki")
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows written to loki > 0")
+
+		g.By("Verify flow logs are enriched")
+		// Get VM1 pod name and node
+		vm1PodName, err := compat_otp.GetAllPodsWithLabel(oc, testNS, "vm.kubevirt.io/name="+testVM1.Name)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(vm1PodName).NotTo(o.BeEmpty())
+		vm1node, err := compat_otp.GetPodNodeName(oc, testNS, vm1PodName[0])
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(vm1node).NotTo(o.BeEmpty())
+
+		// Get vm2 pod name and node
+		vm2PodName, err := compat_otp.GetAllPodsWithLabel(oc, testNS, "vm.kubevirt.io/name="+testVM2.Name)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(vm2PodName).NotTo(o.BeEmpty())
+		vm2node, err := compat_otp.GetPodNodeName(oc, testNS, vm2PodName[0])
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(vm2node).NotTo(o.BeEmpty())
+
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.DstK8SName).Should(o.ContainSubstring(vm1PodName[0]))
+			o.Expect(r.Flowlog.SrcK8SName).Should(o.ContainSubstring(vm2PodName[0]))
+			o.Expect(r.Flowlog.DstK8SOwnerType).Should(o.ContainSubstring("VirtualMachineInstance"))
+			o.Expect(r.Flowlog.SrcK8SOwnerType).Should(o.ContainSubstring("VirtualMachineInstance"))
+			o.Expect(r.Flowlog.DstK8SNetworkName).Should(o.ContainSubstring("test-76537/l2-network"))
+			o.Expect(r.Flowlog.SrcK8SNetworkName).Should(o.ContainSubstring("test-76537/l2-network"))
+		}
+	})
+
+	g.It("Author:aramesha-NonPreRelease-Longduration-Medium-85887-Verify UDN with VMs [Disruptive][Slow]", func() {
+		SkipIfOCPBelow("v4.18")
+		var (
+			// UDN vars
+			udnNS   = "netobserv-udn-85887"
+			udnName = "udn-network-85887"
+			// VM vars
+			testVMUDNTemplatePath = filePath.Join(virtualizationDir, "test-vm-UDN_template.yaml")
+		)
+
+		g.By("Deploy UDN in UDN ns")
+		var cidr, ipv4cidr, ipv6cidr string
+		defer deleteNamespace(oc, udnNS)
+		oc.CreateSpecificNamespaceUDN(udnNS)
+
+		if ipStackType == "ipv4single" {
+			cidr = "10.151.0.0/16"
+		} else {
+			if ipStackType == "ipv6single" {
+				cidr = "2011:100:200::0/48"
+			} else {
+				ipv4cidr = "10.151.0.0/16"
+				ipv6cidr = "2011:100:200::0/48"
+			}
+		}
+		createGeneralUDNCRD(oc, udnNS, udnName, ipv4cidr, ipv6cidr, cidr, "layer2")
+
+		g.By("Deploy test VM3")
+		testVM3 := TestVMUDNTemplate{
+			Name:        "test-vm3",
+			Namespace:   udnNS,
+			NetworkName: udnName,
+			Template:    testVMUDNTemplatePath,
+		}
+		defer deleteResource(oc, "vm", testVM3.Name, testVM3.Namespace)
+		err := testVM3.createVMUDN(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitUntilVMReady(oc, testVM3.Name, testVM3.Namespace)
+
+		g.By("Wait for VM3 to get IP assigned")
+		vm3Ip, err := waitForVMIPAssignment(oc, testVM3.Name, testVM3.Namespace, 0)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(vm3Ip).NotTo(o.BeEmpty())
+
+		startTime := time.Now()
+
+		g.By("Deploy test VM4")
+		testVM4 := TestVMUDNTemplate{
+			Name:        "test-vm4",
+			Namespace:   udnNS,
+			NetworkName: udnName,
+			RunCmd:      fmt.Sprintf("[[ping, %s]]", vm3Ip),
+			Template:    testVMUDNTemplatePath,
+		}
+		defer deleteResource(oc, "vm", testVM4.Name, testVM4.Namespace)
+		err = testVM4.createVMUDN(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitUntilVMReady(oc, testVM4.Name, testVM4.Namespace)
+
+		g.By("Wait for VM4 to get IP assigned")
+		vm4Ip, err := waitForVMIPAssignment(oc, testVM4.Name, testVM4.Namespace, 0)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(vm4Ip).NotTo(o.BeEmpty())
+
+		g.By("Deploy FlowCollector with UDNMapping feature enabled with eBPF in privileged mode")
+		flow := Flowcollector{
+			Namespace:      namespace,
+			EBPFPrivileged: "true",
+			EBPFeatures:    []string{"\"UDNMapping\""},
+			Template:       flowFixturePath,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Wait for a min before logs gets collected and written to loki")
+		time.Sleep(60 * time.Second)
+
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: udnNS,
+			SrcK8SOwnerName: testVM4.Name,
+			DstK8SNamespace: udnNS,
+			DstK8SOwnerName: testVM3.Name,
+		}
+
+		g.By("Verify flows are written to loki")
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows written to loki > 0")
+
+		g.By("Verify flow logs are enriched")
+		// Get VM3 launcher pod name
+		vm3podname, err := compat_otp.GetAllPodsWithLabel(oc, udnNS, "vm.kubevirt.io/name="+testVM3.Name)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(vm3podname).NotTo(o.BeEmpty())
+		// Get VM4 launcher pod name
+		vm4podname, err := compat_otp.GetAllPodsWithLabel(oc, udnNS, "vm.kubevirt.io/name="+testVM4.Name)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(vm4podname).NotTo(o.BeEmpty())
+
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.DstK8SName).Should(o.ContainSubstring(vm3podname[0]))
+			o.Expect(r.Flowlog.SrcK8SName).Should(o.ContainSubstring(vm4podname[0]))
+			o.Expect(r.Flowlog.DstK8SOwnerType).Should(o.ContainSubstring("VirtualMachineInstance"))
+			o.Expect(r.Flowlog.SrcK8SOwnerType).Should(o.ContainSubstring("VirtualMachineInstance"))
+			o.Expect(r.Flowlog.Udns).Should(o.ContainElement(fmt.Sprintf("%s/%s", udnNS, udnName)))
+			o.Expect(r.Flowlog.DstK8SNetworkName).Should(o.ContainSubstring(fmt.Sprintf("%s/%s", udnNS, udnName)))
+			o.Expect(r.Flowlog.SrcK8SNetworkName).Should(o.ContainSubstring(fmt.Sprintf("%s/%s", udnNS, udnName)))
+		}
+	})
+
+	g.It("Author:aramesha-High-85935-Validate CUDN with Localnet and VM's[Serial]", func() {
+		SkipIfOCPBelow("v4.19")
+		var (
+			// NMstate operator vars
+			opNamespace       = "openshift-nmstate"
+			nmStateDir        = filePath.Join(networkingDir, "nmstate")
+			nmstateCRTemplate = filePath.Join(nmStateDir, "nmstate-cr-template.yaml")
+			nmstateCR         = nmstateCRResource{
+				name:     "nmstate",
+				template: nmstateCRTemplate,
+			}
+			nodeSelectLabel          = "node-role.kubernetes.io/worker"
+			ovnMappingPolicyTemplate = filePath.Join(nmStateDir, "ovn-mapping-policy-template.yaml")
+			ovnMappingPolicy         = ovnMappingPolicyResource{
+				name:       "bridge-mapping-85935",
+				nodelabel:  nodeSelectLabel,
+				labelvalue: "",
+				localnet1:  "mylocalnet",
+				bridge1:    "br-ex",
+				template:   ovnMappingPolicyTemplate,
+			}
+			// CUDN vars
+			matchLabelKey              = "test.io"
+			matchValue                 = "cudn-network-" + getRandomString()
+			secondaryCUDNName          = "secondary-localnet-85935"
+			cudnNS                     = []string{"netobserv-cudn1-85935", "netobserv-cudn2-85935"}
+			testVMLocalnetTemplatePath = filePath.Join(virtualizationDir, "test-vm-localnet_template.yaml")
+		)
+
+		g.By("Check the platform and network plugin type if it is suitable for running the test")
+		networkType := checkNetworkType(oc)
+		if !(isPlatformSuitableForNMState(oc)) || !strings.Contains(networkType, "ovn") {
+			g.Skip("Skipping for unsupported platform or non-OVN network plugin type!")
+		}
+		nmstateCatsrc := Resource{"catalogsource", "redhat-operators", "openshift-marketplace"}
+		nmstateSource := CatalogSourceObjects{"stable", nmstateCatsrc.Name, nmstateCatsrc.Namespace}
+		NMS := SubscriptionObjects{
+			OperatorName:  "kubernetes-nmstate-operator",
+			Namespace:     opNamespace,
+			PackageName:   "kubernetes-nmstate-operator",
+			Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
+			OperatorGroup: filePath.Join(subscriptionDir, "singlenamespace-og.yaml"),
+			CatalogSource: &nmstateSource,
+		}
+		ensureOperatorDeployed(oc, NMS, nmstateSource, "name="+NMS.OperatorName)
+
+		workerNode, getNodeErr := compat_otp.GetFirstWorkerNode(oc)
+		o.Expect(getNodeErr).NotTo(o.HaveOccurred())
+		o.Expect(workerNode).NotTo(o.BeEmpty())
+
+		compat_otp.By("Create NMState CR")
+		defer deleteNMStateCR(oc, nmstateCR)
+		result, crErr := createNMStateCR(oc, nmstateCR, opNamespace)
+		compat_otp.AssertWaitPollNoErr(crErr, "create nmstate cr failed")
+		o.Expect(result).To(o.BeTrue())
+		e2e.Logf("SUCCESS - NMState CR Created")
+
+		compat_otp.By("Configure NNCP for creating OvnMapping NMstate Feature")
+		defer deleteNNCP(oc, ovnMappingPolicy.name)
+		defer func() {
+			ovnmapping, deferErr := compat_otp.DebugNodeWithChroot(oc, workerNode, "ovs-vsctl", "get", "Open_vSwitch", ".", "external_ids:ovn-bridge-mappings")
+			o.Expect(deferErr).NotTo(o.HaveOccurred())
+			if strings.Contains(ovnmapping, ovnMappingPolicy.localnet1) {
+				// ovs-vsctl can only use "set" to reserve some fields
+				_, err := compat_otp.DebugNodeWithChroot(oc, workerNode, "ovs-vsctl", "set", "Open_vSwitch", ".", "external_ids:ovn-bridge-mappings=\"physnet:br-ex\"")
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+		}()
+		configErr3 := ovnMappingPolicy.configNNCP(oc)
+		o.Expect(configErr3).NotTo(o.HaveOccurred())
+		nncpErr3 := checkNNCPStatus(oc, ovnMappingPolicy.name, "Available")
+		compat_otp.AssertWaitPollNoErr(nncpErr3, fmt.Sprintf("%s policy applied failed", ovnMappingPolicy.name))
+
+		compat_otp.By("Create two namespaces and label them")
+		for _, ns := range cudnNS {
+			defer oc.DeleteSpecifiedNamespaceAsAdmin(ns)
+			oc.CreateSpecifiedNamespaceAsAdmin(ns)
+			err := oc.AsAdmin().WithoutNamespace().Run("label").Args("ns", ns, fmt.Sprintf("%s=%s", matchLabelKey, matchValue)).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+
+		compat_otp.By("Create secondary localnet CUDN")
+		defer removeResource(oc, true, true, "clusteruserdefinednetwork", secondaryCUDNName)
+		_, err := applyLocalnetCUDNtoMatchLabelNS(oc, matchLabelKey, matchValue, secondaryCUDNName, "mylocalnet", "192.168.200.0/24", "192.168.200.1/32", false)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Deploy test VM5")
+		testVM5 := TestVMUDNTemplate{
+			Name:        "test-vm5",
+			Namespace:   cudnNS[0],
+			NetworkName: secondaryCUDNName,
+			Template:    testVMLocalnetTemplatePath,
+		}
+		defer deleteResource(oc, "vm", testVM5.Name, testVM5.Namespace)
+		err = testVM5.createVMUDN(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitUntilVMReady(oc, testVM5.Name, testVM5.Namespace)
+
+		// Even though VM comes up as Ready, the IP assignment takes some time
+		g.By("Wait for VM5 to get IP assigned")
+		vm5Ip, err := waitForVMIPAssignment(oc, testVM5.Name, testVM5.Namespace, 1)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(vm5Ip).NotTo(o.BeEmpty())
+
+		startTime := time.Now()
+
+		g.By("Deploy test VM6")
+		testVM6 := TestVMUDNTemplate{
+			Name:        "test-vm6",
+			Namespace:   cudnNS[1],
+			NetworkName: secondaryCUDNName,
+			RunCmd:      fmt.Sprintf("[[ping, %s]]", vm5Ip),
+			Template:    testVMLocalnetTemplatePath,
+		}
+		defer deleteResource(oc, "vm", testVM6.Name, testVM6.Namespace)
+		err = testVM6.createVMUDN(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		waitUntilVMReady(oc, testVM6.Name, testVM6.Namespace)
+
+		g.By("Wait for VM6 to get IP assigned")
+		vm6Ip, err := waitForVMIPAssignment(oc, testVM6.Name, testVM6.Namespace, 1)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(vm6Ip).NotTo(o.BeEmpty())
+
+		g.By("Deploy FlowCollector with UDNMapping feature enabled with eBPF in privileged mode")
+		flow := Flowcollector{
+			Namespace:      namespace,
+			EBPFPrivileged: "true",
+			EBPFeatures:    []string{"\"UDNMapping\""},
+			Template:       flowFixturePath,
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector(oc) }()
+		flow.CreateFlowcollector(oc)
+
+		g.By("Wait for a min before logs gets collected and written to loki")
+		time.Sleep(60 * time.Second)
+
+		g.By("Verify CUDN Localnet flows")
+		lokilabels := Lokilabels{
+			App:             "netobserv-flowcollector",
+			SrcK8SNamespace: cudnNS[1],
+			SrcK8SOwnerName: testVM6.Name,
+			DstK8SNamespace: cudnNS[0],
+			DstK8SOwnerName: testVM5.Name,
+		}
+
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of CUDN Localnet flows > 0")
+		for _, r := range flowRecords {
+			o.Expect(r.Flowlog.Udns).Should(o.ContainElement(secondaryCUDNName))
+			o.Expect(r.Flowlog.DstK8SNetworkName).Should(o.ContainSubstring(secondaryCUDNName))
+			o.Expect(r.Flowlog.SrcK8SNetworkName).Should(o.ContainSubstring(secondaryCUDNName))
+		}
+	})
+})

--- a/integration-tests/backend/test_flowcollectorslice.go
+++ b/integration-tests/backend/test_flowcollectorslice.go
@@ -2,16 +2,13 @@ package e2etests
 
 import (
 	"encoding/json"
-	"os"
 	"time"
 
 	filePath "path/filepath"
-	"strings"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
-	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 )
 
@@ -19,187 +16,18 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 
 	defer g.GinkgoRecover()
 	var (
-		oc = compat_otp.NewCLI("netobserv", compat_otp.KubeConfigPath())
-		// NetObserv Operator variables
-		NOcatSrc = Resource{"catsrc", "netobserv-konflux-fbc", netobservNS}
-		NOSource = CatalogSourceObjects{"stable", NOcatSrc.Name, NOcatSrc.Namespace}
-
-		// Template directories
-		baseDir, _           = filePath.Abs("testdata")
-		subscriptionDir      = filePath.Join(baseDir, "subscription")
-		flowFixturePath      = filePath.Join(baseDir, "flowcollector_v1beta2_template.yaml")
+		oc                   = compat_otp.NewCLI("netobserv", compat_otp.KubeConfigPath())
 		flowSliceFixturePath = filePath.Join(baseDir, "flowcollectorSlice_v1alpha1_template.yaml")
-
-		// Operator namespace object
-		OperatorNS = OperatorNamespace{
-			Name:              netobservNS,
-			NamespaceTemplate: filePath.Join(subscriptionDir, "namespace.yaml"),
-		}
-		NO = SubscriptionObjects{
-			OperatorName:  "netobserv-operator",
-			Namespace:     netobservNS,
-			PackageName:   NOPackageName,
-			Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
-			OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
-			CatalogSource: &NOSource,
-		}
-		imageDigest    = filePath.Join(subscriptionDir, "image-digest-mirror-set.yaml")
-		catSrcTemplate = filePath.Join(subscriptionDir, "catalog-source.yaml")
-		catalogSource  = os.Getenv("MULTISTAGE_PARAM_OVERRIDE_NETOBSERV_CS_IMAGE")
-
-		kubeadminToken  string
-		kubeAdminPasswd = os.Getenv("QE_KUBEADMIN_PASSWORD")
-		namespace       string
-
-		// Loki Operator variables
-		lokiDir         = filePath.Join(baseDir, "loki")
-		lokiPackageName = "loki-operator"
-		lokiSource      CatalogSourceObjects
-		ls              *lokiStack
-		Lokiexisting    = false
-		lokiStackNS     = "netobserv-loki"
-		LO              = SubscriptionObjects{
-			OperatorName:  "loki-operator-controller-manager",
-			Namespace:     loNS,
-			PackageName:   lokiPackageName,
-			Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
-			OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
-			CatalogSource: &lokiSource,
-		}
-
-		// LokiStack variables
-		ipStackType       string
-		lokiStackTemplate = filePath.Join(lokiDir, "lokistack-simple.yaml")
-		lokiTenant        = "openshift-network"
+		namespace            string
+		ipStackType          string
 	)
 
 	g.BeforeEach(func() {
-		if strings.Contains(os.Getenv("E2E_RUN_TAGS"), "disconnected") {
-			g.Skip("Skipping tests for disconnected profiles")
-		}
 		namespace = oc.Namespace()
-
-		g.By("Get kubeadmin token")
-		if kubeAdminPasswd == "" {
-			g.Skip("no kubeAdminPasswd is provided in this profile, set QE_KUBEADMIN_PASSWORD env var")
-		}
-		serverURL, serverURLErr := oc.AsAdmin().WithoutNamespace().Run("whoami").Args("--show-server").Output()
-		o.Expect(serverURLErr).NotTo(o.HaveOccurred())
-		currentContext, currentContextErr := oc.WithoutNamespace().Run("config").Args("current-context").Output()
-		o.Expect(currentContextErr).NotTo(o.HaveOccurred())
-		defer func() {
-			rollbackCtxErr := oc.WithoutNamespace().Run("config").Args("set", "current-context", currentContext).Execute()
-			o.Expect(rollbackCtxErr).NotTo(o.HaveOccurred())
-		}()
-
-		kubeadminToken = getKubeAdminToken(oc, kubeAdminPasswd, serverURL, currentContext)
-		o.Expect(kubeadminToken).NotTo(o.BeEmpty())
-
-		isHypershift := compat_otp.IsHypershiftHostedCluster(oc)
-
-		// Deploy NetObserv operator
-		OperatorNS.DeployOperatorNamespace(oc)
-		deployedUpstreamCatalogSource, catSrcErr := setupCatalogSource(oc, NOcatSrc, catSrcTemplate, imageDigest, catalogSource, isHypershift, &NOSource, &NO)
-		o.Expect(catSrcErr).NotTo(o.HaveOccurred())
-		ensureNetObservOperatorDeployed(oc, NO, NOSource, deployedUpstreamCatalogSource)
-
 		ipStackType = checkIPStackType(oc)
-
-		g.By("Deploy loki operator")
-		if !validateInfraAndResourcesForLoki(oc, "10Gi", "6") {
-			g.Skip("Current platform does not have enough resources available for this test!")
-		}
-
-		// check if Loki Operator exists
-		var err error
-		Lokiexisting, err = CheckOperatorStatus(oc, LO.Namespace, LO.PackageName)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		lokiChannel, err := getOperatorChannel(oc, "redhat-operators", "loki-operator")
-		if err != nil || lokiChannel == "" {
-			g.Skip("Loki channel not found, skip this case")
-		}
-		lokiSource = CatalogSourceObjects{lokiChannel, "redhat-operators", "openshift-marketplace"}
-
-		// Don't delete if Loki Operator existed already before NetObserv
-		//  unless it is not using the 'stable' operator
-		// If Loki Operator was installed by NetObserv tests,
-		//  it will install and uninstall after each spec/test.
-		if !Lokiexisting {
-			g.DeferCleanup(LO.uninstallOperator, oc)
-			ensureOperatorDeployed(oc, LO, lokiSource, "name="+LO.OperatorName)
-		} else {
-			channelName, err := checkOperatorChannel(oc, LO.Namespace, LO.PackageName)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			if channelName != lokiChannel {
-				e2e.Logf("found %s channel for loki operator, removing and reinstalling with %s channel instead", channelName, lokiSource.Channel)
-				LO.uninstallOperator(oc)
-				g.DeferCleanup(LO.uninstallOperator, oc)
-				ensureOperatorDeployed(oc, LO, lokiSource, "name="+LO.OperatorName)
-				Lokiexisting = false
-			}
-		}
-
-		g.By("Deploy lokiStack")
-		// get storageClass Name
-		sc, err := getStorageClassName(oc)
-		if err != nil || len(sc) == 0 {
-			g.Skip("StorageClass not found in cluster, skip this case")
-		}
-
-		objectStorageType := getStorageType(oc)
-		if len(objectStorageType) == 0 && ipStackType != "ipv6single" {
-			g.Skip("Current cluster doesn't have a proper object storage for this test!")
-		}
-
-		g.DeferCleanup(oc.DeleteSpecifiedNamespaceAsAdmin, lokiStackNS)
-		oc.CreateSpecifiedNamespaceAsAdmin(lokiStackNS)
-
-		ls = &lokiStack{
-			Name:          "lokistack",
-			Namespace:     lokiStackNS,
-			TSize:         "1x.demo",
-			StorageType:   objectStorageType,
-			StorageSecret: "objectstore-secret",
-			StorageClass:  sc,
-			BucketName:    "netobserv-loki-" + getInfrastructureName(oc),
-			Tenant:        lokiTenant,
-			Template:      lokiStackTemplate,
-		}
-
-		if ipStackType == "ipv6single" {
-			e2e.Logf("running IPv6 test")
-			ls.EnableIPV6 = "true"
-		}
-
-		g.DeferCleanup(ls.removeObjectStorage, oc)
-		err = ls.prepareResourcesForLokiStack(oc)
-		if err != nil {
-			g.Skip("Skipping test since LokiStack resources were not deployed")
-		}
-
-		g.DeferCleanup(ls.removeLokiStack, oc)
-		err = ls.deployLokiStack(oc)
-		if err != nil {
-			g.Skip("Skipping test since LokiStack was not deployed")
-		}
-
-		lokiStackResource := Resource{"lokistack", ls.Name, ls.Namespace}
-		err = lokiStackResource.WaitForResourceToAppear(oc)
-		if err != nil {
-			g.Skip("Skipping test since LokiStack did not become ready")
-		}
-
-		err = ls.waitForLokiStackToBeReady(oc)
-		if err != nil {
-			g.Skip("Skipping test since LokiStack is not ready")
-		}
-		ls.Route = "https://" + getRouteAddress(oc, ls.Namespace, ls.Name)
 	})
 
 	g.It("Author:aramesha-Critical-86388-Verify flowCollectorSlice collectionMode: AlwaysCollect [Serial]", func() {
-		SkipIfOCPBelow("v4.14")
-		// Test ping pods template variables
 		pingPodsTemplate := filePath.Join(baseDir, "test-ping-pods_template.yaml")
 		testPingPodsTemplate := TestPingPodsTemplate{
 			ServerNS:    "test-ping-server-86388-always",
@@ -245,7 +73,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		g.By("Deploy FlowCollector with SlicesEnabled in AlwaysCollect mode")
 		flow := Flowcollector{
 			Namespace:      namespace,
-			LokiNamespace:  lokiStackNS,
 			CollectionMode: "AlwaysCollect",
 			SlicesEnable:   "true",
 			Template:       flowFixturePath,
@@ -273,7 +100,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		}
 		parameters := []string{"DstAddr=\"192.168.1.0\""}
 
-		flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows from client NS to internal-service > 0")
 		for _, r := range flowRecords {
@@ -284,7 +111,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		g.By("Verify flows with external-api subnetLabel")
 		parameters = []string{"DstAddr=\"8.8.8.8\""}
 
-		flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows from client NS to external-api > 0")
 		for _, r := range flowRecords {
@@ -298,7 +125,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			SrcK8SNamespace: testPingPodsTemplate.ServerNS,
 		}
 
-		flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows from server NS > 0")
 		for _, r := range flowRecords {
@@ -307,9 +134,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 	})
 
 	g.It("Author:aramesha-Critical-86388-Verify flowCollectorSlice collectionMode: AllowList [Serial]", func() {
-		SkipIfOCPBelow("v4.14")
 
-		// Test ping pods template variables
 		pingPodsTemplate := filePath.Join(baseDir, "test-ping-pods_template.yaml")
 		testPingPodsTemplate := TestPingPodsTemplate{
 			ServerNS:    "test-ping-server-86388-allowlist",
@@ -335,7 +160,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		g.By("Deploy FlowCollector with Slices enabled in AllowList mode")
 		flow := Flowcollector{
 			Namespace:       namespace,
-			LokiNamespace:   lokiStackNS,
 			CollectionMode:  "AllowList",
 			SlicesEnable:    "true",
 			NamespacesAllow: []string{"\"/openshift-.*/\""},
@@ -364,7 +188,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		}
 		parameters := []string{"DstAddr=\"8.8.8.8\""}
 
-		flowRecords, err := lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
+		flowRecords, err := lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows from client NS > 0")
 		for _, r := range flowRecords {
@@ -376,9 +200,10 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		lokilabels = Lokilabels{
 			App:             "netobserv-flowcollector",
 			SrcK8SNamespace: testPingPodsTemplate.ServerNS,
+			AllowEmpty:      true,
 		}
 
-		flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime, parameters...)
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime, parameters...)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(len(flowRecords)).Should(o.BeNumerically("==", 0), "expected number of flows from server NS = 0")
 
@@ -389,17 +214,15 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			SrcK8SNamespace: "openshift-dns",
 		}
 
-		flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows from openshift-dns NS > 0")
 
 		// Scenario4: Flows between namespaces with one in allowedNamespaces section should still be collected
 		g.By("Verify flows between namespaces")
 		startTime = time.Now()
-		// Get server pod IP
 		serverPodIP, _ := getPodIP(oc, testPingPodsTemplate.ServerNS, "ping-server", ipStackType)
 
-		// Continuously ping server for 300 seconds to generate sustained traffic
 		_, err = e2eoutput.RunHostCmd(testPingPodsTemplate.ClientNS, "ping-client", "ping -w 300 "+serverPodIP)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		time.Sleep(60 * time.Second)
@@ -410,236 +233,8 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			DstK8SNamespace: testPingPodsTemplate.ServerNS,
 		}
 
-		flowRecords, err = lokilabels.getLokiFlowLogs(kubeadminToken, ls.Route, startTime)
+		flowRecords, err = lokilabels.GetMonolithicLokiFlowLogs(oc, flow.Namespace, startTime)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected number of flows between test namespaces > 0")
-	})
-
-	g.It("Author:aramesha-NonPreRelease-Longduration-High-87145-Verify FlowCollectorSlices multi-tenancy [Disruptive][Slow]", func() {
-		SkipIfOCPBelow("v4.14")
-		g.By("Creating test users")
-		users, usersHTpassFile, htPassSecret := getNewUser(oc, 1)
-		defer userCleanup(oc, users, usersHTpassFile, htPassSecret)
-
-		g.By("Deploy FlowCollector with Slices enabled")
-		flow := Flowcollector{
-			Namespace:       namespace,
-			LokiNamespace:   lokiStackNS,
-			CollectionMode:  "AllowList",
-			SlicesEnable:    "true",
-			NamespacesAllow: []string{"\"/openshift-.*/\""},
-			Template:        flowFixturePath,
-		}
-
-		defer func() { _ = flow.DeleteFlowcollector(oc) }()
-		flow.CreateFlowcollector(oc)
-
-		g.By("Verify FlowCollectorSlices ClusterRoles exist")
-		clusterRoleOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterrole", "-o=jsonpath={.items[*].metadata.name}").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(clusterRoleOutput).Should(o.ContainSubstring("flowcollectorslices.flows.netobserv.io-v1alpha1-admin"))
-		o.Expect(clusterRoleOutput).Should(o.ContainSubstring("flowcollectorslices.flows.netobserv.io-v1alpha1-edit"))
-		o.Expect(clusterRoleOutput).Should(o.ContainSubstring("flowcollectorslices.flows.netobserv.io-v1alpha1-view"))
-
-		g.By("Deploy test server and client pods for test-a namespace")
-		serverTemplate := filePath.Join(baseDir, "test-nginx-server_template.yaml")
-		testServerTemplateA := TestServerTemplate{
-			ServerNS: "test-a-server-87145",
-			Template: serverTemplate,
-		}
-		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplateA.ServerNS)
-		err = testServerTemplateA.createServer(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		compat_otp.AssertAllPodsToBeReady(oc, testServerTemplateA.ServerNS)
-
-		clientTemplate := filePath.Join(baseDir, "test-nginx-client_template.yaml")
-		testClientTemplateA := TestClientTemplate{
-			ServerNS: testServerTemplateA.ServerNS,
-			ClientNS: "test-a-client-87145",
-			Template: clientTemplate,
-		}
-		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplateA.ClientNS)
-		err = testClientTemplateA.createClient(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		compat_otp.AssertAllPodsToBeReady(oc, testClientTemplateA.ClientNS)
-
-		// Save original context
-		origContxt, contxtErr := oc.AsAdmin().WithoutNamespace().Run("config").Args("current-context").Output()
-		o.Expect(contxtErr).NotTo(o.HaveOccurred())
-		e2e.Logf("original context is %v", origContxt)
-		defer func() { _ = oc.AsAdmin().WithoutNamespace().Run("config").Args("use-context", origContxt).Execute() }()
-
-		origUser := oc.Username()
-		e2e.Logf("original user is %s", origUser)
-		defer oc.ChangeUser(origUser)
-
-		testUserName := users[0].Username
-		oc.ChangeUser(testUserName)
-		e2e.Logf("switched to user: %s", testUserName)
-
-		g.By("Create namespace test-a and grant testuser-0 admin permissions")
-		testNSA := testClientTemplateA.ClientNS
-		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("rolebinding", "testuser-0-admin",
-			"--clusterrole=flowcollectorslices.flows.netobserv.io-v1alpha1-admin",
-			"--user="+testUserName, "-n", testNSA).Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// Grant testuser admin access to the server namespace as well for flow visibility
-		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("rolebinding", "testuser-0-admin-server",
-			"--clusterrole=admin",
-			"--user="+testUserName, "-n", testServerTemplateA.ServerNS).Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// Grant testuser admin access to client namespace
-		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("rolebinding", "testuser-0-admin-client",
-			"--clusterrole=admin",
-			"--user="+testUserName, "-n", testNSA).Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// Grant loki reader access for multi-tenancy
-		defer removeUserAsReader(oc, testUserName)
-		addUserAsReader(oc, testUserName)
-
-		g.By("Verify testuser-0 can create flowcollectorslices in test-a")
-		canCreate, err := oc.WithoutNamespace().Run("auth").Args("can-i", "create", "flowcollectorslices", "-n", testNSA).Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(canCreate).Should(o.ContainSubstring("yes"))
-
-		g.By("Create a FlowCollectorSlice in test-a namespace")
-		flowSliceA := FlowcollectorSlice{
-			Name:      "test-a-slice",
-			Namespace: testNSA,
-			Sampling:  "100",
-			Template:  flowSliceFixturePath,
-		}
-		defer func() { _ = flowSliceA.DeleteFlowcollectorSlice(oc) }()
-		flowSliceA.CreateFlowcollectorSlice(oc)
-		flowSliceA.WaitForFlowcollectorSliceReady(oc)
-
-		g.By("Verify testuser-0 can view the FlowCollectorSlice in test-a")
-		sliceOutput, err := oc.WithoutNamespace().Run("get").Args("flowcollectorslice", "-n", testNSA, "-o=jsonpath={.items[*].metadata.name}").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sliceOutput).Should(o.ContainSubstring("test-a-slice"))
-
-		// Verify sampling value
-		samplingValue, err := oc.WithoutNamespace().Run("get").Args("flowcollectorslice", "test-a-slice", "-n", testNSA, "-o=jsonpath={.spec.sampling}").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(samplingValue).Should(o.Equal("100"))
-
-		g.By("Verify testuser-0 can update the FlowCollectorSlice in test-a")
-		err = oc.WithoutNamespace().Run("patch").Args("flowcollectorslice", "test-a-slice", "-n", testNSA,
-			"--type=merge", "-p={\"spec\":{\"sampling\":2}}").Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// Verify sampling was updated
-		samplingValue, err = oc.WithoutNamespace().Run("get").Args("flowcollectorslice", "test-a-slice", "-n", testNSA, "-o=jsonpath={.spec.sampling}").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(samplingValue).Should(o.Equal("2"))
-
-		g.By("Get testuser token for loki query")
-		user0token, err := oc.WithoutNamespace().Run("whoami").Args("-t").Output()
-		e2e.Logf("testuser token: %s", user0token)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		g.By("Wait for flows to be collected and written to loki")
-		startTime := time.Now()
-		time.Sleep(60 * time.Second)
-
-		g.By("Verify testuser-0 can access flows from test-a namespace")
-		lokilabels := Lokilabels{
-			App:             "netobserv-flowcollector",
-			SrcK8SNamespace: testServerTemplateA.ServerNS,
-			DstK8SNamespace: testNSA,
-			SrcK8SOwnerName: "nginx-service",
-			FlowDirection:   "0",
-		}
-		flowRecords, err := lokilabels.getLokiFlowLogs(user0token, ls.Route, startTime)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(len(flowRecords)).Should(o.BeNumerically(">", 0), "expected testuser to see flows from test-a namespace")
-
-		g.By("Create namespace test-b and create a FlowCollectorSlice as kubeadmin")
-		testServerTemplateB := TestServerTemplate{
-			ServerNS: "test-b-server-87145",
-			Template: serverTemplate,
-		}
-		defer oc.DeleteSpecifiedNamespaceAsAdmin(testServerTemplateB.ServerNS)
-
-		testClientTemplateB := TestClientTemplate{
-			ServerNS: testServerTemplateB.ServerNS,
-			ClientNS: "test-b-client-87145",
-			Template: clientTemplate,
-		}
-		defer oc.DeleteSpecifiedNamespaceAsAdmin(testClientTemplateB.ClientNS)
-
-		// Switch to admin to create test-b resources
-		oc.ChangeUser(origUser)
-		err = testServerTemplateB.createServer(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		compat_otp.AssertAllPodsToBeReady(oc, testServerTemplateB.ServerNS)
-
-		err = testClientTemplateB.createClient(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		compat_otp.AssertAllPodsToBeReady(oc, testClientTemplateB.ClientNS)
-
-		testNSB := testClientTemplateB.ClientNS
-		flowSliceB := FlowcollectorSlice{
-			Name:      "test-b-slice",
-			Namespace: testNSB,
-			Sampling:  "3",
-			Template:  flowSliceFixturePath,
-		}
-		defer func() { _ = flowSliceB.DeleteFlowcollectorSlice(oc) }()
-		flowSliceB.CreateFlowcollectorSlice(oc)
-		flowSliceB.WaitForFlowcollectorSliceReady(oc)
-
-		// Switch back to testuser
-		oc.ChangeUser(testUserName)
-
-		g.By("Verify testuser-0 cannot see test-b slice")
-		sliceOutputB, err := oc.WithoutNamespace().Run("get").Args("flowcollectorslice", "-n", testNSB).Output()
-		o.Expect(err).Should(o.HaveOccurred())
-		o.Expect(sliceOutputB).Should(o.MatchRegexp(`User ".*" cannot list resource "flowcollectorslices"`))
-
-		g.By("Verify testuser-0 cannot access flows from test-b namespace")
-		lokilabels = Lokilabels{
-			App:             "netobserv-flowcollector",
-			SrcK8SNamespace: testServerTemplateB.ServerNS,
-			DstK8SNamespace: testNSB,
-			SrcK8SOwnerName: "nginx-service",
-			FlowDirection:   "0",
-		}
-		flowRecords, err = lokilabels.getLokiFlowLogs(user0token, ls.Route, startTime)
-		// Multi-tenancy verification: Loki Gateway returns permission errors for unauthorized namespace access
-		if err != nil {
-			o.Expect(err.Error()).Should(o.ContainSubstring("permission"), "expected permission error for unauthorized namespace access, got: %v", err)
-		} else {
-			o.Expect(len(flowRecords)).Should(o.BeNumerically("==", 0), "expected testuser to NOT see flows from test-b namespace")
-		}
-
-		g.By("Add testuser-0 as viewer for test-b namespace")
-		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("rolebinding", "testuser-0-view",
-			"--clusterrole=flowcollectorslices.flows.netobserv.io-v1alpha1-view",
-			"--user="+testUserName, "-n", testNSB).Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		g.By("Verify testuser-0 can view FlowCollectorSlice in test-b")
-		sliceOutput, err = oc.WithoutNamespace().Run("get").Args("flowcollectorslice", "-n", testNSB, "-o=jsonpath={.items[*].metadata.name}").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(sliceOutput).Should(o.ContainSubstring("test-b-slice"))
-
-		g.By("Verify testuser-0 cannot update FlowCollectorSlice in test-b (view-only)")
-		patchOutput, err := oc.WithoutNamespace().Run("patch").Args("flowcollectorslice", "test-b-slice", "-n", testNSB,
-			"--type=merge", "-p={\"spec\":{\"sampling\":25}}").Output()
-		o.Expect(err).Should(o.HaveOccurred())
-		o.Expect(patchOutput).Should(o.MatchRegexp(`User ".*" cannot patch resource "flowcollectorslices"`))
-
-		g.By("Remove testuser-0's view access from test-b")
-		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("rolebinding", "testuser-0-view", "-n", testNSB).Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		g.By("Verify access to test-b FlowCollectorSlices is revoked")
-		sliceOutputRevoked, err := oc.WithoutNamespace().Run("get").Args("flowcollectorslice", "-n", testNSB).Output()
-		o.Expect(err).Should(o.HaveOccurred())
-		o.Expect(sliceOutputRevoked).Should(o.MatchRegexp(`User ".*" cannot list resource "flowcollectorslices"`))
 	})
 })

--- a/integration-tests/backend/test_flowmetrics.go
+++ b/integration-tests/backend/test_flowmetrics.go
@@ -1,7 +1,6 @@
 package e2etests
 
 import (
-	"os"
 	filePath "path/filepath"
 	"regexp"
 	"strings"
@@ -16,53 +15,18 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 
 	defer g.GinkgoRecover()
 	var (
-		oc = compat_otp.NewCLI("netobserv", compat_otp.KubeConfigPath())
-		// NetObserv Operator variables
-		NOcatSrc = Resource{"catsrc", "netobserv-konflux-fbc", netobservNS}
-		NOSource = CatalogSourceObjects{"stable", NOcatSrc.Name, NOcatSrc.Namespace}
-
-		// Template directories
-		baseDir, _      = filePath.Abs("testdata")
-		subscriptionDir = filePath.Join(baseDir, "subscription")
-		flowFixturePath = filePath.Join(baseDir, "flowcollector_v1beta2_template.yaml")
+		oc              = compat_otp.NewCLI("netobserv", compat_otp.KubeConfigPath())
 		flowmetricsPath = filePath.Join(baseDir, "flowmetrics_v1alpha1_template.yaml")
-
-		// Operator namespace object
-		OperatorNS = OperatorNamespace{
-			Name:              netobservNS,
-			NamespaceTemplate: filePath.Join(subscriptionDir, "namespace.yaml"),
-		}
-		NO = SubscriptionObjects{
-			OperatorName:  "netobserv-operator",
-			Namespace:     netobservNS,
-			PackageName:   NOPackageName,
-			Subscription:  filePath.Join(subscriptionDir, "sub-template.yaml"),
-			OperatorGroup: filePath.Join(subscriptionDir, "allnamespace-og.yaml"),
-			CatalogSource: &NOSource,
-		}
-		imageDigest    = filePath.Join(subscriptionDir, "image-digest-mirror-set.yaml")
-		catSrcTemplate = filePath.Join(subscriptionDir, "catalog-source.yaml")
-		catalogSource  = os.Getenv("MULTISTAGE_PARAM_OVERRIDE_NETOBSERV_CS_IMAGE")
-
-		flow Flowcollector
+		flow            Flowcollector
 	)
 
 	g.BeforeEach(func() {
-		if strings.Contains(os.Getenv("E2E_RUN_TAGS"), "disconnected") {
-			g.Skip("Skipping tests for disconnected profiles")
-		}
-
-		OperatorNS.DeployOperatorNamespace(oc)
-		deployedUpstreamCatalogSource, catSrcErr := setupCatalogSource(oc, NOcatSrc, catSrcTemplate, imageDigest, catalogSource, false, &NOSource, &NO)
-		o.Expect(catSrcErr).NotTo(o.HaveOccurred())
-		ensureNetObservOperatorDeployed(oc, NO, NOSource, deployedUpstreamCatalogSource)
-
-		// Create flowcollector in beforeEach
 		flow = Flowcollector{
-			Namespace:   oc.Namespace(),
-			EBPFeatures: []string{"\"FlowRTT\""},
-			LokiEnable:  "false",
-			Template:    flowFixturePath,
+			Namespace:       oc.Namespace(),
+			EBPFeatures:     []string{"\"FlowRTT\""},
+			LokiEnable:      "false",
+			InstallDemoLoki: "false",
+			Template:        flowFixturePath,
 		}
 		flow.CreateFlowcollector(oc)
 	})
@@ -71,7 +35,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 	})
 
 	g.It("Author:memodi-High-73539-Create custom metrics and charts [Serial]", func() {
-		SkipIfOCPBelow("v4.12")
 		namespace := oc.Namespace()
 		customMetrics := CustomMetrics{
 			Namespace: namespace,

--- a/integration-tests/backend/testdata/flowcollector_v1beta2_template.yaml
+++ b/integration-tests/backend/testdata/flowcollector_v1beta2_template.yaml
@@ -94,36 +94,9 @@ objects:
         lokiStack:
           name: ${LokistackName}
           namespace: ${LokiNamespace}
-        manual:
-          authToken: Forward
-          querierUrl: "${LokiURL}"
-          ingesterUrl: "${LokiURL}"
-          statusUrl: "${LokiStatusURL}"
-          tls:
-            enable: true
-            caCert:
-              type: configmap
-              name: "${LokiTLSCertName}"
-              certFile: service-ca.crt
-              namespace: "${LokiNamespace}"
-            insecureSkipVerify: false
-          tenantID: network
-          statusTls:
-            enable: "${{LokiStatusTLSEnable}}"
-            caCert:
-              certFile: service-ca.crt
-              name: "${LokiStatusTLSCertName}"
-              type: configmap
-              namespace: "${LokiNamespace}"
-            insecureSkipVerify: false
-            userCert:
-              certFile: tls.crt
-              certKey: tls.key
-              name: "${LokiStatusTLSUserCertName}"
-              type: secret
-              namespace: "${LokiNamespace}"
         monolithic:
           url: ${MonolithicLokiURL}
+          installDemoLoki: "${{InstallDemoLoki}}"
       networkPolicy:
         additionalNamespaces: "${{NetworkPolicyAdditionalNamespaces}}"
         enable: "${{NetworkPolicyEnable}}"
@@ -139,7 +112,7 @@ parameters:
     description: "namespace where you want flowlogsPipeline and consoleplugin pods to be deployed"
     value: "netobserv"
   - name: DeploymentModel
-    value: "Direct"
+    value: "Service"
   - name: EBPFCacheActiveTimeout
     value: 15s
   - name: Sampling
@@ -175,25 +148,15 @@ parameters:
   - name: NamespacesAllow
     value: '["`/netobserv.*/`"]'
   - name: LokiMode
-    value: "LokiStack"
+    value: "Monolithic"
   - name: LokiEnable
     value: "true"
   - name: LokistackName
     value: lokistack
-  - name: LokiURL
-    value: "https://lokistack-gateway-http.netobserv.svc.cluster.local:8080/api/logs/v1/network/"
-  - name: LokiTLSCertName
-    value: "lokistack-gateway-ca-bundle"
-  - name: LokiStatusURL
-    value: ""
-  - name: LokiStatusTLSEnable
-    value: "false"
-  - name: LokiStatusTLSCertName
-    value: "lokistack-ca-bundle"
-  - name: LokiStatusTLSUserCertName
-    value: "lokistack-query-frontend-http"
   - name: MonolithicLokiURL
     value: "http://loki.netobserv.svc:3100/"
+  - name: InstallDemoLoki
+    value: "true"
   - name: LokiNamespace
     value: "netobserv"
   - name: KafkaAddress

--- a/integration-tests/backend/util.go
+++ b/integration-tests/backend/util.go
@@ -911,22 +911,6 @@ func isPlatformSuitableForNMState(oc *exutil.CLI) bool {
 	return true
 }
 
-// Check if BaselineCapabilities have been set
-func isBaselineCapsSet(oc *exutil.CLI) bool {
-	baselineCapabilitySet, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterversion", "version", "-o=jsonpath={.spec.capabilities.baselineCapabilitySet}").Output()
-	o.Expect(err).NotTo(o.HaveOccurred())
-	e2e.Logf("baselineCapabilitySet parameters: %v\n", baselineCapabilitySet)
-	return len(baselineCapabilitySet) != 0
-}
-
-// Check if component is listed in clusterversion.status.capabilities.enabledCapabilities
-func isEnabledCapability(oc *exutil.CLI, component string) bool {
-	enabledCapabilities, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterversion", "-o=jsonpath={.items[*].status.capabilities.enabledCapabilities}").Output()
-	o.Expect(err).NotTo(o.HaveOccurred())
-	e2e.Logf("Cluster enabled capability parameters: %v\n", enabledCapabilities)
-	return strings.Contains(enabledCapabilities, component)
-}
-
 // verifyComponentsDeleted verifies that specified components are NOT present in the output (exact line match)
 func verifyComponentsDeleted(componentsOutput string, componentsList []string) {
 	outputLines := strings.Split(strings.TrimSpace(componentsOutput), "\n")


### PR DESCRIPTION
## Summary
- Split `test_flowcollector.go` into separate files: `test_flowcollector_kafka.go`, `test_flowcollector_virt.go`, `test_flow_multitenancy.go`
- Switch most tests from LokiStack to demoLoki (`installDemoLoki: true`) — operator auto-deploys lightweight Loki
- Keep LokiStack only for multitenancy tests (63839, 87145) that require multi-tenant auth
- Centralize shared variables in `suite_vars.go` and operator deployment in `BeforeSuite`
- Remove outdated `SkipIfOCPBelow` checks for versions below 4.18
- Simplify `GetMonolithicLokiFlowLogs` / `verifyMonolithicLokilogsTime` to take namespace directly instead of parsing URL
- Extract `lokiStream` as named type for stream label merging in flow records
- Promote `openshift/api` and `k8s.io/api` to direct dependencies in go.mod (fixes CI lint timeout)
- Replace unreleased FBC catalog deployment of NMState operator with standard `redhat-operators` catalog
- Remove `deployedUpstreamCatalogSource` flag and DOWNSTREAM env var CSV patching (no longer needed)
- Remove unused helper functions

## Test Results
- Virt:
[sig-netobserv] Network_Observability with VMs Author:aramesha-NonPreRelease-Longduration-High-76537-Verify flow enrichment for VM's secondary interfaces
[Disruptive][Slow] [612.171 seconds]
[sig-netobserv] Network_Observability with VMs Author:aramesha-NonPreRelease-Longduration-Medium-85887-Verify UDN with VMs [Disruptive][Slow] [362.798 seconds]
[sig-netobserv] Network_Observability with VMs Author:aramesha-High-85935-Validate CUDN with Localnet and VM's[Serial] [562.716 seconds]
[sig-netobserv] Network_Observability Author:aramesha-High-83022-Validate CUDN with Localnet [Serial] [357.972 seconds]
  SUCCESS! 32m20.259843994s --- PASS: TestBackend (1940.54s)
  PASS
  ok    e2etests        1945.631s

- IPSec
[sig-netobserv] Network_Observability Author:memodi-NonPreRelease-High-82637-Verify IPSec feature [Disruptive] [281.370 seconds]

   SUCCESS! 5m32.679440641s --- PASS: TestBackend (332.93s)
  PASS
  ok    e2etests        338.195s

- Locally passing tests:
[sig-netobserv] Network_Observability Author:kapjain-Medium-88683-Secure communications between Agent and FLP [Serial] [293.974 seconds]
  
   SUCCESS! 5m37.393209611s --- PASS: TestBackend (337.63s)
  PASS
  ok    e2etests        342.676s
[sig-netobserv] Network_Observability Author:aramesha-NonPreRelease-High-69218-High-71291-Verify cluster ID and zone in multiCluster deployment [Serial] [217.719
  seconds]
  
   SUCCESS! 4m22.610910545s --- PASS: TestBackend (262.91s)
  PASS
  ok    e2etests        268.096s
[sig-netobserv] Network_Observability with Kafka Author:aramesha-NonPreRelease-Longduration-High-57397-High-65116-Low-89197-Verify network-flows export with Kafka and
  netobserv installation without Loki[Serial] [556.588 seconds]
  
   SUCCESS! 10m2.859452495s --- PASS: TestBackend (603.17s)
  PASS
  ok    e2etests        608.899s
[sig-netobserv] Network_Observability Exporters Author:aramesha-High-64156-Verify IPFIX-exporter [Serial] [139.483 seconds]
  
   SUCCESS! 3m3.153324054s --- PASS: TestBackend (183.39s)
  PASS
  ok    e2etests        188.447s
1. [sig-netobserv] Network_Observability Multitenancy Author:memodi-NonPreRelease-Longduration-High-63839-Verify-multi-tenancy [Disruptive][Slow] [675.515 seconds]
 2. [sig-netobserv] Network_Observability Multitenancy Author:aramesha-NonPreRelease-Longduration-High-87145-Verify FlowCollectorSlices multi-tenancy [Disruptive][Slow]
  [544.477 seconds]
   SUCCESS! 21m2.147359287s --- PASS: TestBackend (1262.52s)
  PASS
  ok    e2etests        1267.718s

- Jenkins run: [noo-backend-tests#122](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/netobserv/job/noo-backend-tests/122/console) Failing tests fixed and passed on rerun [noo-backend-tests#124](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/netobserv/job/noo-backend-tests/124/console)

## Test plan
- [x] Run full backend test suite on flexy cluster to verify demoLoki flow collection works end-to-end
- [x] Verify multitenancy tests (63839, 87145) still work with LokiStack
- [x] Verify Kafka tests deploy AMQ + collect flows via demoLoki
- [x] Verify VM tests work on baremetal cluster with demoLoki

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Expanded end-to-end coverage for multitenancy, Kafka TLS export, KubeVirt VM scenarios, UDN/CUDN networking, and FlowCollector slices.

* **Bug Fixes**
  * Improved FlowCollector readiness detection across deployment models.
  * Enhanced Loki flow-log retrieval to enrich records from stream labels and to wait more accurately for expected readiness/results.
  * Switched alert validation to Prometheus-based polling (now checking for pending alerts).

* **Tests**
  * Updated test suite setup and configurations to align with current templates and hosted-cluster/disconnected execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->