### PR TITLE
Fix STATIC_PLUGIN_INHERIT_TOLERATION_SUBSCRIPTION should not be set by default

### DIFF
--- a/bundles/openshift/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundles/openshift/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -1046,8 +1046,6 @@ spec:
                       fieldPath: metadata.namespace
                 - name: VENDOR
                   value: OpenShift_Downstream
-                - name: STATIC_PLUGIN_INHERIT_TOLERATION_SUBSCRIPTION
-                  value: netobserv-operator
                 image: quay.io/netobserv/network-observability-operator:1.12.0-community
                 imagePullPolicy: Always
                 livenessProbe:

--- a/config/openshift/common/manager-patch.yaml
+++ b/config/openshift/common/manager-patch.yaml
@@ -31,9 +31,3 @@
   value:
     name: VENDOR
     value: OpenShift_Downstream
-
-- op: add
-  path: "/spec/template/spec/containers/0/env/-"
-  value:
-    name: STATIC_PLUGIN_INHERIT_TOLERATION_SUBSCRIPTION
-    value: netobserv-operator


### PR DESCRIPTION
The default config was making an assumption that the subscription is named "netobserv-operator", and that ends up hardcoded in the bundle env (can still be reconfigured manually, but breaking the "out of the box" path)

It's safer to not make this assumption at all. Users who want propagating the toleration from Subscription need to configure manually the env STATIC_PLUGIN_INHERIT_TOLERATION_SUBSCRIPTION with the correct subscription name