### PR TITLE
NETOBSERV-2767: Do not fail on Console CR update failure

### DIFF
--- a/bundles/k8s/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundles/k8s/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -951,7 +951,7 @@ spec:
           verbs:
           - get
           - list
-          - update
+          - patch
           - watch
         - apiGroups:
           - operator.openshift.io

--- a/bundles/openshift/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundles/openshift/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -947,7 +947,7 @@ spec:
           verbs:
           - get
           - list
-          - update
+          - patch
           - watch
         - apiGroups:
           - operator.openshift.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -246,7 +246,7 @@ rules:
   verbs:
   - get
   - list
-  - update
+  - patch
   - watch
 - apiGroups:
   - operator.openshift.io

--- a/helm/templates/clusterrole.yaml
+++ b/helm/templates/clusterrole.yaml
@@ -246,7 +246,7 @@ rules:
     verbs:
       - get
       - list
-      - update
+      - patch
       - watch
   - apiGroups:
       - operator.openshift.io

--- a/internal/controller/consoleplugin/consoleplugin_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_reconciler.go
@@ -169,7 +169,7 @@ func (r *CPReconciler) checkAutoPatch(ctx context.Context, desired *flowslatest.
 	if reg && !registered {
 		// Note, envtest does not support any kind of patch strategy.
 		// Using MergeFrom (ie. full inspection) is not the most efficient, but it's what makes envtest happy.
-		patch := client.MergeFrom(console.DeepCopy())
+		patch := client.MergeFromWithOptions(console.DeepCopy(), client.MergeFromWithOptimisticLock{})
 		console.Spec.Plugins = append(console.Spec.Plugins, name)
 		if err := r.Client.Patch(ctx, &console, patch); err != nil {
 			log.FromContext(ctx).Error(err, "Could not update the Console Operator resource for plugin registration. Please register manually.")

--- a/internal/controller/consoleplugin/consoleplugin_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_reconciler.go
@@ -86,9 +86,7 @@ func (r *CPReconciler) reconcile(ctx context.Context, desired *flowslatest.FlowC
 
 	hasPluginAPI := r.ClusterInfo.HasConsolePlugin()
 	if hasPluginAPI {
-		if err = r.checkAutoPatch(ctx, desired, constants.PluginName); err != nil {
-			return err
-		}
+		r.checkAutoPatch(ctx, desired, constants.PluginName)
 	}
 
 	if desired.Spec.NeedsConsolePluginDeployment(hasPluginAPI) {
@@ -156,7 +154,7 @@ func (r *CPReconciler) reconcile(ctx context.Context, desired *flowslatest.FlowC
 	return nil
 }
 
-func (r *CPReconciler) checkAutoPatch(ctx context.Context, desired *flowslatest.FlowCollector, name string) error {
+func (r *CPReconciler) checkAutoPatch(ctx context.Context, desired *flowslatest.FlowCollector, name string) {
 	console := operatorsv1.Console{}
 	advancedConfig := helper.GetAdvancedPluginConfig(desired.Spec.ConsolePlugin.Advanced)
 	reg := desired.Spec.UseWebConsole() && *advancedConfig.Register
@@ -165,14 +163,16 @@ func (r *CPReconciler) checkAutoPatch(ctx context.Context, desired *flowslatest.
 			log.FromContext(ctx).Error(err, "Could not get the Console Operator resource for plugin registration. Please register manually.")
 			r.Status.SetDegraded("PluginRegistrationFailed", "Could not auto-register console plugin; manual registration needed")
 		}
-		return nil
+		return
 	}
 	registered := helper.ContainsString(console.Spec.Plugins, name)
 	if reg && !registered {
 		console.Spec.Plugins = append(console.Spec.Plugins, name)
-		return r.Client.Update(ctx, &console)
+		if err := r.Client.Update(ctx, &console); err != nil {
+			log.FromContext(ctx).Error(err, "Could not update the Console Operator resource for plugin registration. Please register manually.")
+			r.Status.SetDegraded("PluginRegistrationFailed", "Could not auto-register console plugin; manual registration needed")
+		}
 	}
-	return nil
 }
 
 func (r *CPReconciler) reconcilePermissions(ctx context.Context, builder *builder, name string) error {

--- a/internal/controller/consoleplugin/consoleplugin_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_reconciler.go
@@ -3,7 +3,6 @@ package consoleplugin
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 
 	osv1 "github.com/openshift/api/console/v1"
@@ -168,8 +167,11 @@ func (r *CPReconciler) checkAutoPatch(ctx context.Context, desired *flowslatest.
 	}
 	registered := helper.ContainsString(console.Spec.Plugins, name)
 	if reg && !registered {
-		patch := fmt.Appendf(nil, `[{"op": "add", "path": "/spec/plugins/-", "value": "%s"}]`, name)
-		if err := r.Client.Patch(ctx, &console, client.RawPatch(types.JSONPatchType, patch)); err != nil {
+		// Note, envtest does not support any kind of patch strategy.
+		// Using MergeFrom (ie. full inspection) is not the most efficient, but it's what makes envtest happy.
+		patch := client.MergeFrom(console.DeepCopy())
+		console.Spec.Plugins = append(console.Spec.Plugins, name)
+		if err := r.Client.Patch(ctx, &console, patch); err != nil {
 			log.FromContext(ctx).Error(err, "Could not update the Console Operator resource for plugin registration. Please register manually.")
 			r.Status.SetDegraded("PluginRegistrationFailed", "Could not auto-register console plugin; manual registration needed")
 		}

--- a/internal/controller/consoleplugin/consoleplugin_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_reconciler.go
@@ -3,6 +3,7 @@ package consoleplugin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 
 	osv1 "github.com/openshift/api/console/v1"
@@ -167,8 +168,8 @@ func (r *CPReconciler) checkAutoPatch(ctx context.Context, desired *flowslatest.
 	}
 	registered := helper.ContainsString(console.Spec.Plugins, name)
 	if reg && !registered {
-		console.Spec.Plugins = append(console.Spec.Plugins, name)
-		if err := r.Client.Update(ctx, &console); err != nil {
+		patch := fmt.Appendf(nil, `[{"op": "add", "path": "/spec/plugins/-", "value": "%s"}]`, name)
+		if err := r.Client.Patch(ctx, &console, client.RawPatch(types.JSONPatchType, patch)); err != nil {
 			log.FromContext(ctx).Error(err, "Could not update the Console Operator resource for plugin registration. Please register manually.")
 			r.Status.SetDegraded("PluginRegistrationFailed", "Could not auto-register console plugin; manual registration needed")
 		}

--- a/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
@@ -58,9 +58,7 @@ func (r *StaticReconciler) reconcileStatic(ctx context.Context, desired *flowsla
 	}
 
 	if r.ClusterInfo.HasConsolePlugin() {
-		if err = r.checkAutoPatch(ctx, desired, constants.StaticPluginName); err != nil {
-			return err
-		}
+		r.checkAutoPatch(ctx, desired, constants.StaticPluginName)
 	}
 
 	if r.ClusterInfo.HasConsolePlugin() {

--- a/internal/controller/envtest/flowcollector_controller_console_envtest.go
+++ b/internal/controller/envtest/flowcollector_controller_console_envtest.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	configv1 "github.com/openshift/api/config/v1"
 	operatorsv1 "github.com/openshift/api/operator/v1"
 	olm "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -63,32 +62,6 @@ func FlowCollectorConsolePluginSpecs(env test.Environment, ctxGetter test.Contex
 	rbKeyPlugin := types.NamespacedName{Name: "netobserv-token-review-plugin"}
 
 	if env == test.EnvOpenShift {
-		Context("Console plugin test init", func() {
-			It("Should create Console CR", func() {
-				created := &operatorsv1.Console{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: consoleCRKey.Name,
-					},
-					Spec: operatorsv1.ConsoleSpec{
-						OperatorSpec: operatorsv1.OperatorSpec{
-							ManagementState: operatorsv1.Unmanaged,
-							LogLevel:        operatorsv1.Normal,
-						},
-						Providers: operatorsv1.ConsoleProviders{},
-						Route: operatorsv1.ConsoleConfigRoute{
-							Hostname: "",
-							Secret: configv1.SecretNameReference{
-								Name: "",
-							},
-						},
-					},
-				}
-
-				// Create
-				Expect(k8sClient.Create(ctx, created)).Should(Succeed())
-			})
-		})
-
 		Context("Deploying the static console plugin", func() {
 			It("Should create successfully", func() {
 				By("Expecting to create the static console plugin Deployment")
@@ -468,18 +441,6 @@ func FlowCollectorConsolePluginSpecs(env test.Environment, ctxGetter test.Contex
 		It("Should delete CR", func() {
 			test.CleanupCR(ctx, k8sClient, crKey)
 		})
-
-		if env == test.EnvOpenShift {
-			It("Should delete Console CR", func() {
-				Eventually(func() error {
-					return k8sClient.Delete(ctx, &operatorsv1.Console{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: consoleCRKey.Name,
-						},
-					})
-				}, timeout, interval).Should(Succeed())
-			})
-		}
 
 		It("Should delete fake controller", func() {
 			dp := appsv1.Deployment{}

--- a/internal/pkg/manager/manager.go
+++ b/internal/pkg/manager/manager.go
@@ -21,36 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-//+kubebuilder:rbac:groups=core,resources=namespaces;services;serviceaccounts;configmaps;persistentvolumeclaims;secrets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=pods;nodes;endpoints,verbs=get;list;watch
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups=apps,resources=deployments;daemonsets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;rolebindings,verbs=get;list;create;delete;update;watch
-//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update
-//+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;create;delete;update;patch;list;watch
-//+kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;list;update;watch
-//+kubebuilder:rbac:groups=operator.openshift.io,resources=networks,verbs=get;list;watch
-//+kubebuilder:rbac:groups=flows.netobserv.io,resources=flowcollectors;flowmetrics;flowcollectorslices,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=flows.netobserv.io,resources=flowcollectors/status;flowmetrics/status;flowcollectorslices/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=flows.netobserv.io,resources=flowcollectors/finalizers,verbs=update
-//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=hostnetwork,verbs=use
-//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=list;create;update;watch
-//+kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=list;get;watch
-//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;create;delete;update;patch;list;watch
-//+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions;networks,verbs=get;list;watch
-//+kubebuilder:rbac:groups=loki.grafana.com,resources=network,resourceNames=logs,verbs=create
-//+kubebuilder:rbac:groups=loki.grafana.com,resources=lokistacks,verbs=get;list;watch
-//+kubebuilder:rbac:groups=metrics.k8s.io,resources=pods,verbs=create
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=bpfman.io,resources=clusterbpfapplications,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=bpfman.io,resources=clusterbpfapplications/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions/status,verbs=update;patch
-//+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=create;delete;patch;update;get;watch;list
-//+kubebuilder:rbac:groups=k8s.ovn.org,resources=userdefinednetworks;clusteruserdefinednetworks,verbs=get;list;watch
-//+kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
-
 type Registerer func(context.Context, *Manager) (PostCreateHook, error)
 type PostCreateHook = func(ctx context.Context) error
 

--- a/internal/pkg/manager/roles.go
+++ b/internal/pkg/manager/roles.go
@@ -34,8 +34,8 @@ package manager
 // Operator needs to create roles and cluster roles for granting transitive rights to its workloads
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;rolebindings,verbs=get;list;create;delete;update;watch
 
-// To be removed
-//+kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;list;update;watch
+// Operator needs to patch Console CR (cluster scope)
+//+kubebuilder:rbac:groups=operator.openshift.io,resources=consoles,verbs=get;list;patch;watch
 
 // Operator needs to create ConsolePlugin (cluster scope)
 //+kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;create;delete;update;patch;list;watch
@@ -79,3 +79,5 @@ package manager
 
 // Transitive: operator needs to grant UDN read permission to FLP at the cluster scope
 //+kubebuilder:rbac:groups=k8s.ovn.org,resources=userdefinednetworks;clusteruserdefinednetworks,verbs=get;list;watch
+
+//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update

--- a/internal/pkg/test/envtest.go
+++ b/internal/pkg/test/envtest.go
@@ -247,6 +247,18 @@ func setupOpenShiftClusterResources(ctx context.Context, k8sClient client.Client
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	err = k8sClient.Create(ctx, &operatorsv1.Console{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: operatorsv1.ConsoleSpec{
+			OperatorSpec: operatorsv1.OperatorSpec{
+				ManagementState: operatorsv1.Unmanaged,
+				LogLevel:        operatorsv1.Normal,
+			},
+			Plugins: []string{},
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
 	err = k8sClient.Create(ctx, &olm.Subscription{
 		ObjectMeta: metav1.ObjectMeta{Name: "netobserv-operator", Namespace: opNamespace},
 		Spec:       &olm.SubscriptionSpec{},
@@ -271,6 +283,9 @@ func writeKubeConfig(testEnv *envtest.Environment) (string, error) {
 }
 
 func TeardownEnvTest(suiteContext *SuiteContext) {
+	if suiteContext == nil {
+		return
+	}
 	if suiteContext.kubeConfig != "" {
 		defer os.Remove(suiteContext.kubeConfig)
 	}


### PR DESCRIPTION
## Description

When the Console CR cannot be updated, do not fail the whole reconcile loop; just log the error and surface to status instead (same as already done for Get failure)

Also, use Patch instead of Update

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of console-plugin reconciliation: auto-registration and Console Operator plugin updates are now best-effort, so reconciliation continues even when those steps fail.
  * Enhanced degraded-status handling when the Console Operator can’t be fetched or plugin list updates fail.
  * Static console plugin reconciliation no longer blocks on auto-patching issues.
* **Permissions / RBAC**
  * Updated OpenShift/RBAC permissions for `operator.openshift.io` `consoles` to use `patch` instead of `update`.
* **Tests**
  * Increased envtest timeout and refined OpenShift console envtest setup/cleanup for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->