### PR TITLE
NETOBSERV-2875: fix direct mode and informers mode

### DIFF
--- a/internal/controller/flp/envtest/flp_controller_envtest.go
+++ b/internal/controller/flp/envtest/flp_controller_envtest.go
@@ -196,6 +196,18 @@ func ControllerSpecs(env test.Environment, ctxGetter test.ContextGetter) {
 					Namespace: operatorNamespace,
 				}, &cm)
 			}, timeout, interval).Should(Succeed())
+
+			By("Expecting to create the flowlogs-pipeline Service, even in Direct mode, because informers are enabled")
+			svc := v1.Service{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, flpKey1, &svc)
+			}, timeout, interval).Should(Succeed())
+			Expect(svc.Spec.Ports).To(HaveLen(1))
+			Expect(svc.Spec.Ports[0].Name).To(Equal("k8scache"))
+			if env == test.EnvOpenShift {
+				By("Expecting the Service to request a serving certificate for the k8scache TLS server")
+				Expect(svc.Annotations[constants.OpenShiftCertificateAnnotation]).To(Equal("flowlogs-pipeline-cert"))
+			}
 		})
 
 		It("Should update successfully", func() {
@@ -269,6 +281,11 @@ func ControllerSpecs(env test.Environment, ctxGetter test.ContextGetter) {
 				g.Expect(ds.Spec.Template.Spec.Tolerations).
 					To(ContainElement(v1.Toleration{Operator: v1.TolerationOpExists}))
 			}, timeout, interval).Should(Succeed())
+
+			By("Deleting the flowlogs-pipeline Service, since informers got disabled and we're still in Direct mode")
+			Eventually(func() error {
+				return k8sClient.Get(ctx, flpKey1, &v1.Service{})
+			}, timeout, interval).Should(MatchError(`services "flowlogs-pipeline" not found`))
 		})
 
 		It("Should redeploy if the spec doesn't change but the external flowlogs-pipeline-config does", func() {

--- a/internal/controller/flp/flp_monolith_objects.go
+++ b/internal/controller/flp/flp_monolith_objects.go
@@ -170,15 +170,17 @@ func (b *monolithBuilder) service() *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{"app": monoName},
-			Ports: []corev1.ServicePort{
-				{
-					Name:       constants.FLPPortName,
-					Port:       port,
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt32(port),
-				},
-			},
 		},
+	}
+	// In Direct mode (hostNetwork/hostPort), the main flow-ingest port is reached directly
+	// by the agents, not through this Service; only expose it otherwise.
+	if !b.desired.UseHostNetwork() {
+		svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
+			Name:       constants.FLPPortName,
+			Port:       port,
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt32(port),
+		})
 	}
 	// Only expose k8scache port when centralized informers are enabled
 	if b.desired.Processor.IsInformerCacheProxyEnabled() {

--- a/internal/controller/flp/flp_monolith_reconciler.go
+++ b/internal/controller/flp/flp_monolith_reconciler.go
@@ -119,15 +119,8 @@ func (r *monolithReconciler) reconcile(ctx context.Context, desired *flowslatest
 		return err
 	}
 
-	if desired.Spec.UseHostNetwork() && !desired.Spec.Processor.IsInformerCacheProxyEnabled() {
-		// In Direct mode, agents reach FLP directly (hostNetwork/hostPort), so no Service
-		// is needed... unless centralized informers are enabled, in which case we still
-		// need a Service to expose the k8scache port and trigger serving-cert generation.
-		r.Managed.TryDelete(ctx, r.service)
-	} else {
-		if err := r.reconcileService(ctx, &builder); err != nil {
-			return err
-		}
+	if err := r.reconcileOrDeleteService(ctx, &desired.Spec, &builder); err != nil {
+		return err
 	}
 
 	err = r.reconcilePrometheusService(ctx, &builder)
@@ -175,6 +168,18 @@ func (r *monolithReconciler) reconcileDynamicConfigMap(ctx context.Context, newD
 		}
 	}
 	return nil
+}
+
+// reconcileOrDeleteService reconciles the FLP Service, or deletes it when it's not needed:
+// in Direct mode, agents reach FLP directly (hostNetwork/hostPort), so no Service is needed...
+// unless centralized informers are enabled, in which case we still need a Service to expose
+// the k8scache port and trigger serving-cert generation.
+func (r *monolithReconciler) reconcileOrDeleteService(ctx context.Context, desired *flowslatest.FlowCollectorSpec, builder *monolithBuilder) error {
+	if desired.UseHostNetwork() && !desired.Processor.IsInformerCacheProxyEnabled() {
+		r.Managed.TryDelete(ctx, r.service)
+		return nil
+	}
+	return r.reconcileService(ctx, builder)
 }
 
 func (r *monolithReconciler) reconcileService(ctx context.Context, builder *monolithBuilder) error {

--- a/internal/controller/flp/flp_monolith_reconciler.go
+++ b/internal/controller/flp/flp_monolith_reconciler.go
@@ -119,7 +119,10 @@ func (r *monolithReconciler) reconcile(ctx context.Context, desired *flowslatest
 		return err
 	}
 
-	if desired.Spec.UseHostNetwork() {
+	if desired.Spec.UseHostNetwork() && !desired.Spec.Processor.IsInformerCacheProxyEnabled() {
+		// In Direct mode, agents reach FLP directly (hostNetwork/hostPort), so no Service
+		// is needed... unless centralized informers are enabled, in which case we still
+		// need a Service to expose the k8scache port and trigger serving-cert generation.
 		r.Managed.TryDelete(ctx, r.service)
 	} else {
 		if err := r.reconcileService(ctx, &builder); err != nil {

--- a/internal/controller/flp/flp_test.go
+++ b/internal/controller/flp/flp_test.go
@@ -511,6 +511,44 @@ func TestServiceChanged(t *testing.T) {
 	assert.Contains(report.String(), "Service annotations changed")
 }
 
+func TestServiceDirectModeWithInformersEnabled(t *testing.T) {
+	assert := assert.New(t)
+
+	ns := "namespace"
+	cfg := getConfig()
+	cfg.DeploymentModel = flowslatest.DeploymentModelDirect
+	cfg.Processor.InformerCacheProxy = &flowslatest.FlowCollectorInformerCacheProxy{
+		Enabled: ptr.To(true),
+	}
+	b := monoBuilder(ns, &cfg)
+	svc := b.service()
+
+	// The main flow-ingest port must not be exposed: in Direct mode agents reach FLP via hostPort/hostNetwork directly.
+	for _, p := range svc.Spec.Ports {
+		assert.NotEqual(constants.FLPPortName, p.Name, "main port should not be exposed on the Service in Direct mode")
+	}
+	// The k8scache port must still be exposed, so the informers can reach the processors,
+	// and so that the OpenShift serving-cert secret gets created (svc-certs volume relies on it).
+	assert.Contains(svc.Spec.Ports, corev1.ServicePort{
+		Name:       "k8scache",
+		Port:       flowslatest.DefaultK8sCachePort,
+		Protocol:   corev1.ProtocolTCP,
+		TargetPort: intstr.FromInt32(flowslatest.DefaultK8sCachePort),
+	})
+}
+
+func TestServiceDirectModeWithoutInformers(t *testing.T) {
+	assert := assert.New(t)
+
+	ns := "namespace"
+	cfg := getConfig()
+	cfg.DeploymentModel = flowslatest.DeploymentModelDirect
+	b := monoBuilder(ns, &cfg)
+	svc := b.service()
+
+	assert.Empty(svc.Spec.Ports, "no port should be exposed on the Service in Direct mode without informers")
+}
+
 func TestServiceMonitorNoChange(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
## Description

In Direct mode, the monolithic FLP reconciler was deleting the Service, because in that mode agents reach FLP directly via hostNetwork/hostPort. But that same Service was the only place where the OpenShift annotation that triggers creation of the flowlogs-pipeline-cert secret was added. When informers are enabled, the pod (DaemonSet) unconditionally mounts that secret for the k8scache port — hence the FailedMount.

Fix applied:
  - flp_monolith_reconciler.go: the Service is no longer deleted when UseHostNetwork() && IsInformerCacheProxyEnabled() — in that case it continues to be reconciled.
  - flp_monolith_objects.go: the main flow-ingest port is now omitted from the Service in Direct mode (agents don't need it, they go directly via hostPort), but the k8scache port and
  the cert annotation are still present when applicable.
  - Added TestServiceDirectModeWithInformersEnabled and TestServiceDirectModeWithoutInformers in flp_test.go to cover the exact bug scenario.

## Dependencies

n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [x] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Direct mode networking to avoid exposing the main FLP ingest port when it can be reached directly.
  * Kept the necessary cache-service port available when centralized informer support is enabled.
  * Adjusted FLP Service reconciliation behavior to retain the Service when required for cache access and certificate provisioning.

* **Tests**
  * Added coverage validating Direct mode service port exposure with centralized informers enabled and disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->