### PR TITLE
NETOBSERV-2839: add nil-checks for OnHold mode

### DIFF
--- a/internal/controller/ebpf/agent_controller.go
+++ b/internal/controller/ebpf/agent_controller.go
@@ -179,14 +179,18 @@ func (c *AgentController) reconcile(ctx context.Context, target *flowslatest.Flo
 
 	if target.Spec.OnHold() {
 		c.Status.SetUnused("FlowCollector is on hold")
-		rlog.Info("action: delete agent")
-		err = c.DeleteIfOwned(ctx, current)
-		if err != nil {
-			return err
+		if current != nil {
+			rlog.Info("action: delete agent")
+			err = c.DeleteIfOwned(ctx, current)
+			if err != nil {
+				return err
+			}
 		}
-		err = c.DeleteIfOwned(ctx, c.promSvc)
-		if err != nil {
-			return err
+		if c.promSvc != nil {
+			err = c.DeleteIfOwned(ctx, c.promSvc)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	}

--- a/internal/controller/ebpf/internal/permissions/permissions.go
+++ b/internal/controller/ebpf/internal/permissions/permissions.go
@@ -118,7 +118,7 @@ func (c *Reconciler) reconcileServiceAccount(ctx context.Context, desired *flows
 		}
 	}
 
-	if desired.Spec.OnHold() {
+	if desired.Spec.OnHold() && actual != nil {
 		return c.DeleteIfOwned(ctx, actual)
 	}
 
@@ -126,7 +126,7 @@ func (c *Reconciler) reconcileServiceAccount(ctx context.Context, desired *flows
 		rlog.Info("creating service account")
 		return c.CreateOwned(ctx, sAcc)
 	}
-	rlog.Info("service account already reconciled. Doing nothing")
+	rlog.Info("service account already reconciled, doing nothing")
 	return nil
 }
 


### PR DESCRIPTION
## Description

agent controller had ineffective nil-checks in DeleteIfOwned (it checks for nil interface, not nil pointer!)

Adding nil-pointer checks in agent_controller.go and permissions.go

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of paused flow collection to avoid unnecessary deletion attempts when resources are not present.
  * Improved ServiceAccount reconciliation when paused, preventing actions on missing resources.
  * Updated reconciliation logging for existing ServiceAccounts that require no changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->