### PR TITLE
check informers for only version >= 2.0

### DIFF
--- a/integration-tests/backend/flowcollector.go
+++ b/integration-tests/backend/flowcollector.go
@@ -9,6 +9,7 @@ import (
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
+	"golang.org/x/mod/semver"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
@@ -209,8 +210,15 @@ func (flow *Flowcollector) WaitForFlowcollectorReady(oc *exutil.CLI) {
 	default:
 		waitUntilDeploymentReady(oc, "flowlogs-pipeline", flow.Namespace)
 	}
-	// check informers deployment
-	waitUntilDeploymentReady(oc, "flowlogs-pipeline-informers", flow.Namespace)
+	// check informers deployment - only available in version >= 2.0
+	csvVersion, err := getCSVVersion(oc.AdminDynamicClient(), netobservNS)
+	if err != nil {
+		e2e.Logf("Could not get CSV version, skipping informers check: %v", err)
+	} else if semver.Compare(semver.Canonical("v"+csvVersion), "v2.0.0") >= 0 {
+		waitUntilDeploymentReady(oc, "flowlogs-pipeline-informers", flow.Namespace)
+	} else {
+		e2e.Logf("Skipping informers check, CSV version %s is below 2.0", csvVersion)
+	}
 
 	// check ebpf-agent status
 	waitUntilDaemonSetReady(oc, "netobserv-ebpf-agent", flow.Namespace+"-privileged")
@@ -222,7 +230,7 @@ func (flow *Flowcollector) WaitForFlowcollectorReady(oc *exutil.CLI) {
 
 	compat_otp.AssertAllPodsToBeReady(oc, flow.Namespace)
 	compat_otp.AssertAllPodsToBeReady(oc, flow.Namespace+"-privileged")
-	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 600*time.Second, false, func(context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 600*time.Second, false, func(context.Context) (done bool, err error) {
 		condStatus, err := oc.AsAdmin().Run("get").Args("flowcollector", "cluster", "-o", `jsonpath='{.status.conditions[?(@.type=="Ready")].status}'`).Output()
 		if err != nil {
 			return false, nil

--- a/integration-tests/backend/operator.go
+++ b/integration-tests/backend/operator.go
@@ -350,19 +350,36 @@ func getCSVVersion(dynamicClient dynamic.Interface, operatorNamespace string) (s
 		Resource: "clusterserviceversions",
 	}
 
-	csvList, err := dynamicClient.Resource(csvGVR).Namespace(operatorNamespace).List(context.Background(), metav1.ListOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	csvList, err := dynamicClient.Resource(csvGVR).Namespace(operatorNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to list CSVs in namespace %s: %v", operatorNamespace, err)
 	}
 
+	var matched []string
 	for _, csv := range csvList.Items {
-		if strings.HasPrefix(csv.GetName(), NOPackageName+".") {
-			version, found, err := unstructured.NestedString(csv.Object, "spec", "version")
-			if err != nil || !found {
-				return "", fmt.Errorf("version field not found in CSV %s", csv.GetName())
-			}
-			return version, nil
+		if !strings.HasPrefix(csv.GetName(), NOPackageName+".") {
+			continue
 		}
+		// Only consider the active CSV (phase "Succeeded"); during upgrades,
+		// replaced CSVs have phase "Replacing" or "Deleting".
+		phase, _, _ := unstructured.NestedString(csv.Object, "status", "phase")
+		if phase != "Succeeded" {
+			continue
+		}
+		version, found, err := unstructured.NestedString(csv.Object, "spec", "version")
+		if err != nil || !found {
+			return "", fmt.Errorf("version field not found in CSV %s", csv.GetName())
+		}
+		matched = append(matched, version)
 	}
-	return "", fmt.Errorf("no CSV found for %s in namespace %s", NOPackageName, operatorNamespace)
+	switch len(matched) {
+	case 0:
+		return "", fmt.Errorf("no active CSV found for %s in namespace %s", NOPackageName, operatorNamespace)
+	case 1:
+		return matched[0], nil
+	default:
+		return "", fmt.Errorf("multiple active CSVs found for %s in namespace %s: %v", NOPackageName, operatorNamespace, matched)
+	}
 }

--- a/integration-tests/backend/operator.go
+++ b/integration-tests/backend/operator.go
@@ -13,7 +13,10 @@ import (
 	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -336,4 +339,30 @@ func getOperatorChannel(oc *exutil.CLI, catalog string, packageName string) (ope
 	channels, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifests", "-l", "catalog="+catalog, "-n", "openshift-marketplace", "-o=jsonpath={.items[?(@.metadata.name==\""+packageName+"\")].status.channels[*].name}").Output()
 	channelArr := strings.Split(channels, " ")
 	return channelArr[len(channelArr)-1], err
+}
+
+// getCSVVersion returns the version of the installed NetObserv Operator CSV in the given namespace.
+// It uses the dynamic client to list CSVs and finds the one whose name starts with the operator name prefix.
+func getCSVVersion(dynamicClient dynamic.Interface, operatorNamespace string) (string, error) {
+	csvGVR := schema.GroupVersionResource{
+		Group:    "operators.coreos.com",
+		Version:  "v1alpha1",
+		Resource: "clusterserviceversions",
+	}
+
+	csvList, err := dynamicClient.Resource(csvGVR).Namespace(operatorNamespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list CSVs in namespace %s: %v", operatorNamespace, err)
+	}
+
+	for _, csv := range csvList.Items {
+		if strings.HasPrefix(csv.GetName(), NOPackageName+".") {
+			version, found, err := unstructured.NestedString(csv.Object, "spec", "version")
+			if err != nil || !found {
+				return "", fmt.Errorf("version field not found in CSV %s", csv.GetName())
+			}
+			return version, nil
+		}
+	}
+	return "", fmt.Errorf("no CSV found for %s in namespace %s", NOPackageName, operatorNamespace)
 }


### PR DESCRIPTION
## Description

check informers for only version >= 2.0

```
$ ginkgo run -v  --focus=59746 .
[1785779591] Backend Suite - 1/7491 specs Running Suite: Backend Suite - /Users/memodi/workspaces/repos/netobserv/netobserv-operator/integration-tests/backend
==========================================================================================================
Random Seed: 1785779591

Will run 1 specs
Detected OCP version: v5.0
[sig-netobserv] Network_Observability Author:aramesha-NonPreRelease-Critical-59746-NetObserv upgrade testing [Serial]
/Users/memodi/workspaces/repos/netobserv/netobserv-operator/integration-tests/backend/test_flowcollector.go:628
• PASSED [456.608 seconds]
•==========================================================================================================
Backend Suite - 1/1 specs • SUCCESS! [501.101 seconds]

Ran 1 tests
Passed: 1, Failed: 0, Skipped: 0
==========================================================================================================

PASSED TESTS (1):
----------------------------------------------------------------------------------------------------------
1. [sig-netobserv] Network_Observability Author:aramesha-NonPreRelease-Critical-59746-NetObserv upgrade testing [Serial] [456.608 seconds]

 SUCCESS! 8m21.101169049s PASS

Ginkgo ran 1 suite in 9m22.369018513s
Test Suite Passed
```

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [X] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment readiness checks for newer operator versions.
  * Older versions are now handled appropriately without unnecessary checks.
  * Missing or unavailable version information is logged and skipped gracefully.
  * Enhanced reliability when locating and validating operator version details.
  * Improved handling of multiple or invalid version matches during deployment verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->